### PR TITLE
fix examples/capture.lua

### DIFF
--- a/examples/capture.lua
+++ b/examples/capture.lua
@@ -21,7 +21,7 @@ for i = 1, show do
     scene:append(rects[i])
 end
 
-win.scene = scene:bind{MV = mat4(1), P = mat4(1)}
+win.scene = am.bind{MV = mat4(1), P = mat4(1)} ^ scene
 scene:action(function()
     if win:key_pressed("escape") then
         win:close()


### PR DESCRIPTION
In the current version, I could not find a node:bind method. Maybe it was deprecated, or moved to its global am object ? (am.bind ?)