### PR TITLE
MurmurHash: Merge MurmurHash3.cpp to latest release

### DIFF
--- a/third_party/angle-chrome_m34/src/third_party/murmurhash/MurmurHash3.cpp
+++ b/third_party/angle-chrome_m34/src/third_party/murmurhash/MurmurHash3.cpp
@@ -29,7 +29,7 @@
 
 #else	// defined(_MSC_VER)
 
-#define	FORCE_INLINE __attribute__((always_inline))
+#define	FORCE_INLINE inline __attribute__((always_inline))
 
 inline uint32_t rotl32 ( uint32_t x, int8_t r )
 {
@@ -52,12 +52,12 @@ inline uint64_t rotl64 ( uint64_t x, int8_t r )
 // Block read - if your platform needs to do endian-swapping or can only
 // handle aligned reads, do the conversion here
 
-FORCE_INLINE uint32_t getblock ( const uint32_t * p, int i )
+FORCE_INLINE uint32_t getblock32 ( const uint32_t * p, int i )
 {
   return p[i];
 }
 
-FORCE_INLINE uint64_t getblock ( const uint64_t * p, int i )
+FORCE_INLINE uint64_t getblock64 ( const uint64_t * p, int i )
 {
   return p[i];
 }
@@ -65,7 +65,7 @@ FORCE_INLINE uint64_t getblock ( const uint64_t * p, int i )
 //-----------------------------------------------------------------------------
 // Finalization mix - force all bits of a hash block to avalanche
 
-FORCE_INLINE uint32_t fmix ( uint32_t h )
+FORCE_INLINE uint32_t fmix32 ( uint32_t h )
 {
   h ^= h >> 16;
   h *= 0x85ebca6b;
@@ -78,7 +78,7 @@ FORCE_INLINE uint32_t fmix ( uint32_t h )
 
 //----------
 
-FORCE_INLINE uint64_t fmix ( uint64_t k )
+FORCE_INLINE uint64_t fmix64 ( uint64_t k )
 {
   k ^= k >> 33;
   k *= BIG_CONSTANT(0xff51afd7ed558ccd);
@@ -109,7 +109,7 @@ void MurmurHash3_x86_32 ( const void * key, int len,
 
   for(int i = -nblocks; i; i++)
   {
-    uint32_t k1 = getblock(blocks,i);
+    uint32_t k1 = getblock32(blocks,i);
 
     k1 *= c1;
     k1 = ROTL32(k1,15);
@@ -140,7 +140,7 @@ void MurmurHash3_x86_32 ( const void * key, int len,
 
   h1 ^= len;
 
-  h1 = fmix(h1);
+  h1 = fmix32(h1);
 
   *(uint32_t*)out = h1;
 } 
@@ -170,10 +170,10 @@ void MurmurHash3_x86_128 ( const void * key, const int len,
 
   for(int i = -nblocks; i; i++)
   {
-    uint32_t k1 = getblock(blocks,i*4+0);
-    uint32_t k2 = getblock(blocks,i*4+1);
-    uint32_t k3 = getblock(blocks,i*4+2);
-    uint32_t k4 = getblock(blocks,i*4+3);
+    uint32_t k1 = getblock32(blocks,i*4+0);
+    uint32_t k2 = getblock32(blocks,i*4+1);
+    uint32_t k3 = getblock32(blocks,i*4+2);
+    uint32_t k4 = getblock32(blocks,i*4+3);
 
     k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
 
@@ -236,10 +236,10 @@ void MurmurHash3_x86_128 ( const void * key, const int len,
   h1 += h2; h1 += h3; h1 += h4;
   h2 += h1; h3 += h1; h4 += h1;
 
-  h1 = fmix(h1);
-  h2 = fmix(h2);
-  h3 = fmix(h3);
-  h4 = fmix(h4);
+  h1 = fmix32(h1);
+  h2 = fmix32(h2);
+  h3 = fmix32(h3);
+  h4 = fmix32(h4);
 
   h1 += h2; h1 += h3; h1 += h4;
   h2 += h1; h3 += h1; h4 += h1;
@@ -271,8 +271,8 @@ void MurmurHash3_x64_128 ( const void * key, const int len,
 
   for(int i = 0; i < nblocks; i++)
   {
-    uint64_t k1 = getblock(blocks,i*2+0);
-    uint64_t k2 = getblock(blocks,i*2+1);
+    uint64_t k1 = getblock64(blocks,i*2+0);
+    uint64_t k2 = getblock64(blocks,i*2+1);
 
     k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
 
@@ -293,23 +293,23 @@ void MurmurHash3_x64_128 ( const void * key, const int len,
 
   switch(len & 15)
   {
-  case 15: k2 ^= uint64_t(tail[14]) << 48;
-  case 14: k2 ^= uint64_t(tail[13]) << 40;
-  case 13: k2 ^= uint64_t(tail[12]) << 32;
-  case 12: k2 ^= uint64_t(tail[11]) << 24;
-  case 11: k2 ^= uint64_t(tail[10]) << 16;
-  case 10: k2 ^= uint64_t(tail[ 9]) << 8;
-  case  9: k2 ^= uint64_t(tail[ 8]) << 0;
+  case 15: k2 ^= ((uint64_t)tail[14]) << 48;
+  case 14: k2 ^= ((uint64_t)tail[13]) << 40;
+  case 13: k2 ^= ((uint64_t)tail[12]) << 32;
+  case 12: k2 ^= ((uint64_t)tail[11]) << 24;
+  case 11: k2 ^= ((uint64_t)tail[10]) << 16;
+  case 10: k2 ^= ((uint64_t)tail[ 9]) << 8;
+  case  9: k2 ^= ((uint64_t)tail[ 8]) << 0;
            k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
 
-  case  8: k1 ^= uint64_t(tail[ 7]) << 56;
-  case  7: k1 ^= uint64_t(tail[ 6]) << 48;
-  case  6: k1 ^= uint64_t(tail[ 5]) << 40;
-  case  5: k1 ^= uint64_t(tail[ 4]) << 32;
-  case  4: k1 ^= uint64_t(tail[ 3]) << 24;
-  case  3: k1 ^= uint64_t(tail[ 2]) << 16;
-  case  2: k1 ^= uint64_t(tail[ 1]) << 8;
-  case  1: k1 ^= uint64_t(tail[ 0]) << 0;
+  case  8: k1 ^= ((uint64_t)tail[ 7]) << 56;
+  case  7: k1 ^= ((uint64_t)tail[ 6]) << 48;
+  case  6: k1 ^= ((uint64_t)tail[ 5]) << 40;
+  case  5: k1 ^= ((uint64_t)tail[ 4]) << 32;
+  case  4: k1 ^= ((uint64_t)tail[ 3]) << 24;
+  case  3: k1 ^= ((uint64_t)tail[ 2]) << 16;
+  case  2: k1 ^= ((uint64_t)tail[ 1]) << 8;
+  case  1: k1 ^= ((uint64_t)tail[ 0]) << 0;
            k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
   };
 
@@ -321,8 +321,8 @@ void MurmurHash3_x64_128 ( const void * key, const int len,
   h1 += h2;
   h2 += h1;
 
-  h1 = fmix(h1);
-  h2 = fmix(h2);
+  h1 = fmix64(h1);
+  h2 = fmix64(h2);
 
   h1 += h2;
   h2 += h1;
@@ -332,3 +332,4 @@ void MurmurHash3_x64_128 ( const void * key, const int len,
 }
 
 //-----------------------------------------------------------------------------
+


### PR DESCRIPTION
OS	: Solus 1.2.1 shannon
Kernel	: x86_64 Linux 4.8.2
g++ 	: g++ (Solus) 6.2.0

The FORCE_INLINE preprocessor caused the following errors when compiling
with the g++ (Solus) 6.2.0 compiler :

```
src/third_party/murmurhash/MurmurHash3.cpp:81:23: warning: always_inline function might not be inlinable [-Wattributes]
 FORCE_INLINE uint64_t fmix ( uint64_t k )
                       ^~~~
src/third_party/murmurhash/MurmurHash3.cpp:68:23: warning: always_inline function might not be inlinable [-Wattributes]
 FORCE_INLINE uint32_t fmix ( uint32_t h )
                       ^~~~
src/third_party/murmurhash/MurmurHash3.cpp:60:23: warning: always_inline function might not be inlinable [-Wattributes]
 FORCE_INLINE uint64_t getblock ( const uint64_t * p, int i )
                       ^~~~~~~~
src/third_party/murmurhash/MurmurHash3.cpp:55:23: warning: always_inline function might not be inlinable [-Wattributes]
 FORCE_INLINE uint32_t getblock ( const uint32_t * p, int i )
                       ^~~~~~~~
src/third_party/murmurhash/MurmurHash3.cpp: In function ‘void MurmurHash3_x86_32(const void*, int, uint32_t, void*)’:
src/third_party/murmurhash/MurmurHash3.cpp:55:23: error: inlining failed in call to always_inline ‘uint32_t getblock(const uint32_t*, int)’: function body can be overwritten at link time
src/third_party/murmurhash/MurmurHash3.cpp:112:36: note: called from here
     uint32_t k1 = getblock(blocks,i);
                                    ^
src/third_party/murmurhash/MurmurHash3.cpp:68:23: error: inlining failed in call to always_inline ‘uint32_t fmix(uint32_t)’: function body can be overwritten at link time
 FORCE_INLINE uint32_t fmix ( uint32_t h )
                       ^~~~
src/third_party/murmurhash/MurmurHash3.cpp:143:16: note: called from here
   h1 = fmix(h1);
                ^
src/third_party/murmurhash/MurmurHash3.cpp:55:23: error: inlining failed in call to always_inline ‘uint32_t getblock(const uint32_t*, int)’: function body can be overwritten at link time
 FORCE_INLINE uint32_t getblock ( const uint32_t * p, int i )
                       ^~~~~~~~
src/third_party/murmurhash/MurmurHash3.cpp:112:36: note: called from here
     uint32_t k1 = getblock(blocks,i);
                                    ^
src/third_party/murmurhash/MurmurHash3.cpp:68:23: error: inlining failed in call to always_inline ‘uint32_t fmix(uint32_t)’: function body can be overwritten at link time
 FORCE_INLINE uint32_t fmix ( uint32_t h )
                       ^~~~
src/third_party/murmurhash/MurmurHash3.cpp:143:16: note: called from here
   h1 = fmix(h1);
```

I did run a successful compile on another machine of mine running Arch Linux with
g++ (GCC) 6.2.1, however the warnings mentioned were still present.

The reason seems to be in the FORCE_INLINE definition where a inline
specifier is missing before calling the \_\_attribute\_\_((always_inline))
preprocessor.

Merging to the latest MurmurHash3.cpp source has solved this issue.

As for now, I haven't really found any problems with the newer release.

Signed-off-by: CTXz <ctx.xda@gmail.com>