### PR TITLE
include glsl files on export

### DIFF
--- a/src/am_export.cpp
+++ b/src/am_export.cpp
@@ -148,7 +148,8 @@ static bool add_data_files_to_zip(const char *zipfile, const char *rootdir, cons
         add_files_to_pak(zipfile, rootdir, dir, "*.ogg", false, ZIP_PLATFORM_DOS) &&
         add_files_to_pak(zipfile, rootdir, dir, "*.obj", true, ZIP_PLATFORM_DOS) &&
         add_files_to_pak(zipfile, rootdir, dir, "*.json", true, ZIP_PLATFORM_DOS) &&
-        add_files_to_pak(zipfile, rootdir, dir, "*.glsl", true, ZIP_PLATFORM_DOS) &&
+        add_files_to_pak(zipfile, rootdir, dir, "*.frag", true, ZIP_PLATFORM_DOS) &&
+        add_files_to_pak(zipfile, rootdir, dir, "*.vert", true, ZIP_PLATFORM_DOS) &&
         true;
 }
 

--- a/src/am_export.cpp
+++ b/src/am_export.cpp
@@ -148,6 +148,7 @@ static bool add_data_files_to_zip(const char *zipfile, const char *rootdir, cons
         add_files_to_pak(zipfile, rootdir, dir, "*.ogg", false, ZIP_PLATFORM_DOS) &&
         add_files_to_pak(zipfile, rootdir, dir, "*.obj", true, ZIP_PLATFORM_DOS) &&
         add_files_to_pak(zipfile, rootdir, dir, "*.json", true, ZIP_PLATFORM_DOS) &&
+        add_files_to_pak(zipfile, rootdir, dir, "*.glsl", true, ZIP_PLATFORM_DOS) &&
         true;
 }
 


### PR DESCRIPTION
not sure if it's a valid demand but i feel more organized writing shaders in seperate glsl files (with syntax highlighting and indentation)