### PR TITLE
Fix mouse down position on iOS/emscripten

### DIFF
--- a/src/am_backend_emscripten.cpp
+++ b/src/am_backend_emscripten.cpp
@@ -341,6 +341,9 @@ static bool handle_events() {
                 if (event.button.which != SDL_TOUCH_MOUSEID) {
                     am_window *win = am_find_window((am_native_window*)sdl_window);
                     if (win) {
+                        // make sure we have the current mouse position
+                        mouse_x = event.motion.x;
+                        mouse_y = event.motion.y;
                         win->mouse_down(eng->L, convert_mouse_button(event.button.button));
                     }
                 }


### PR DESCRIPTION
When running via emscripten/html on iOS, mouse down events didn't have the correct position. This fixes the problem.

I verified the problem and the fix on iOS with Safari, Chrome and Firefox. When running on a desktop browser, there was no problem. I don't have an Android device to check on that, but the fix I made should be harmless on other platforms.

If you want to see the bug demonstrated, let me know and I can put an example online somewhere.

Also, I wasn't sure if the same thing should apply to mouse released, or if lock_pointer should be handled too - so this might not be a 100% complete fix.
