### PR TITLE
Emscripten touch events

### DIFF
--- a/src/am_backend_emscripten.cpp
+++ b/src/am_backend_emscripten.cpp
@@ -392,6 +392,7 @@ static bool handle_events() {
                 break;
             }
             case SDL_MOUSEWHEEL: {
+                mouse_wheel_x += event.wheel.x > 0 ? 1 : event.wheel.x < 0 ? -1 : 0;
                 mouse_wheel_y += event.wheel.y > 0 ? 1 : event.wheel.y < 0 ? -1 : 0;
                 break;
             }

--- a/src/am_backend_emscripten.cpp
+++ b/src/am_backend_emscripten.cpp
@@ -326,6 +326,39 @@ static bool handle_events() {
                 }
                 break;
             }
+            case SDL_FINGERDOWN: {
+                am_window *win = am_find_window((am_native_window*)sdl_window);
+                win->touch_begin(
+                    eng->L,
+                    (void*)event.tfinger.fingerId,
+                    event.tfinger.x * win->screen_width,
+                    event.tfinger.y * win->screen_height,
+                    event.tfinger.pressure
+                );
+                break;
+            }
+            case SDL_FINGERMOTION: {
+                am_window *win = am_find_window((am_native_window*)sdl_window);
+                win->touch_move(
+                    eng->L,
+                    (void*)event.tfinger.fingerId,
+                    event.tfinger.x * win->screen_width,
+                    event.tfinger.y * win->screen_height,
+                    event.tfinger.pressure
+                );
+                break;
+            }
+            case SDL_FINGERUP: {
+                am_window *win = am_find_window((am_native_window*)sdl_window);
+                win->touch_end(
+                    eng->L,
+                    (void*)event.tfinger.fingerId,
+                    event.tfinger.x * win->screen_width,
+                    event.tfinger.y * win->screen_height,
+                    event.tfinger.pressure
+                );
+                break;
+            }
             case SDL_MOUSEMOTION: {
                 int lock_pointer = EM_ASM_INT({ return window.amulet.have_pointer_lock() ? 1 : 0; }, 0);
                 if (lock_pointer) {


### PR DESCRIPTION
I've added support for touch events for html exports. I tested this on Safari & Chrome on macOS, and Safari and Firefox on iOS.

I also included an attempt at supporting horizontal mouse wheel events, but that is not working yet. I see support for it in emscripten and SDL, but the x axis values are always 0 for me. I suspect a problem upstream in emscripten. If you want, I can omit that from this PR.