### PR TITLE
Fix html key event support for semicolon, minus, equals, and left/right Mac command keys.

### DIFF
--- a/html/library_sdl.js
+++ b/html/library_sdl.js
@@ -185,6 +185,7 @@ var LibrarySDL = {
       220: 92, // back slash
       221: 93, // close square bracket
       222: 39, // quote
+      224: 227 | 1<<10, // meta/command key
     },
 
     scanCodes: { // SDL keycode ==> SDL scancode. See SDL_scancode.h

--- a/html/library_sdl.js
+++ b/html/library_sdl.js
@@ -89,6 +89,7 @@ var LibrarySDL = {
     
     keyCodes: { // DOM code ==> SDL code. See https://developer.mozilla.org/en/Document_Object_Model_%28DOM%29/KeyboardEvent and SDL_keycode.h
       // For keys that don't have unicode value, we map DOM codes with the corresponding scan codes + 1024 (using "| 1 << 10")
+      // See also: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
       16: 225 | 1<<10, // shift
       17: 224 | 1<<10, // control (right, or left)
       18: 226 | 1<<10, // alt
@@ -106,8 +107,8 @@ var LibrarySDL = {
       45: 73 | 1<<10, // insert
       46: 127, // SDLK_DEL == '\177'
       
-      91: 227 | 1<<10, // windows key or super key on linux (doesn't work on Mac)
-      93: 101 | 1<<10, // application
+      91: 227 | 1<<10, // windows key or super key on linux or left command on Mac
+      93: 231 | 1<<10, // application or right command on Mac
       
       96: 98 | 1<<10, // keypad 0
       97: 89 | 1<<10, // keypad 1
@@ -173,7 +174,10 @@ var LibrarySDL = {
       182: 129, // audio volume down
       183: 128, // audio volume up
       
+      186: 59, // semicolon
+      187: 61, // equals
       188: 44, // comma
+      189: 45, // minus
       190: 46, // period
       191: 47, // slash (/)
       192: 96, // backtick/backquote (`)

--- a/src/am_backend_emscripten.cpp
+++ b/src/am_backend_emscripten.cpp
@@ -545,6 +545,8 @@ static am_key convert_key(SDL_Keycode key) {
         case SDLK_RCTRL: return AM_KEY_RCTRL;
         case SDLK_LSHIFT: return AM_KEY_LSHIFT;
         case SDLK_RSHIFT: return AM_KEY_RSHIFT;
+        case SDLK_LGUI: return AM_KEY_LGUI;
+        case SDLK_RGUI: return AM_KEY_RGUI;
         case SDLK_F1: return AM_KEY_F1;
         case SDLK_F2: return AM_KEY_F2;
         case SDLK_F3: return AM_KEY_F3;


### PR DESCRIPTION
This PR fixes this bug: When you export to html, the minus, equals, semicolon and command keys don't work.

Below is a demo program (modified from the keyboard.lua example) that illustrates the broken minus & equals keys. If you run this in the online Amulet editor http://www.amulet.xyz/editor.html you can see that pressing `-` and `=` do nothing. If you run with my fix then those keys will scale the figure: http://pixelverse.org/experiments/amulet_key_fix/ (extra debug logging turned on in this demo also, but not in the PR).

FYI, I tested the fix on Mac in Safari, Chrome, Firefox, and Opera, and on Windows in Edge, Chrome, Firefox, and Opera.

```
win = am.window{title = "Keyboard"}

img = [[
..W..
WWWWW
W.W.W
..W..
WWWWW
W...W
W...W
]]

x, y = 0, 0
scale = 8

person = am.translate(x, y) ^ am.scale(scale) ^ am.sprite(img)

person:action(function()
    local dt = am.delta_time
    if win:key_down"left" then
        x = x - 100 * dt
    elseif win:key_down"right" then
        x = x + 100 * dt
    end
    if win:key_down"down" then
        y = y - 100 * dt
    elseif win:key_down"up" then
        y = y + 100 * dt
    end
    if win:key_down"minus" then
        scale = scale * 0.95
    elseif win:key_down"equals" then
        scale = scale * 1.05
    end
    person.position2d = vec2(x, y)
    person"scale".scale2d = vec2(scale)

    if win:key_pressed"x" then
        person"sprite".color = vec4(
            math.random(),
            math.random(),
            math.random(), 1)
    end
end)

text = am.text("PRESS ARROW KEYS TO MOVE\nPRESS X TO CHANGE COLOUR")

win.scene = am.group{
    person,
    am.translate(0, -200) ^ text
}
```