### PR TITLE
Add support for highdpi in html exports.

### DIFF
--- a/html/library_sdl.js
+++ b/html/library_sdl.js
@@ -2581,15 +2581,26 @@ var LibrarySDL = {
     if (title) document.title = UTF8ToString(title);
   },
 
-  SDL_GetWindowSize: function(window, width, height){
+  SDL_GetWindowSize: function(sdl_window, width, height){
+    // Note: this function ignores the sdl_window argument
+    // which is intentionally named to avoid shadowing the
+    // global window variable, which is used below.
     var canvas = Module['canvas'];
     var w = canvas.width;
     var h = canvas.height;
+    var devicePixelRatio = 1;
+    // Did am.window ask for highdpi?
+    if (window.amulet.highdpi) {
+      // Does the browser & screen support it?
+      devicePixelRatio = window.devicePixelRatio || 1;
+    }
+    var desiredWidth = canvas.clientWidth * devicePixelRatio;
+    var desiredHeight = canvas.clientHeight * devicePixelRatio;
     // We call this each frame, so might as well update the 
     // rendering size of the canvas here as well.
-    if (w != canvas.clientWidth || h != canvas.clientHeight) {
-        w = canvas.clientWidth;
-        h = canvas.clientHeight;
+    if (w != desiredWidth || h != desiredHeight) {
+        w = desiredWidth;
+        h = desiredHeight;
         canvas.width = w;
         canvas.height = h;
         //console.log("updated canvas size to " + w + "x" + h);

--- a/src/am_backend_emscripten.cpp
+++ b/src/am_backend_emscripten.cpp
@@ -64,6 +64,9 @@ am_native_window *am_create_native_window(
         case AM_WINDOW_MODE_FULLSCREEN: flags |= SDL_FULLSCREEN; break;
         case AM_WINDOW_MODE_FULLSCREEN_DESKTOP: flags |= SDL_FULLSCREEN; break;
     }
+    EM_ASM({
+        window.amulet.highdpi = $0;
+    }, highdpi ? 1 : 0);
     if (resizable) flags |= SDL_RESIZABLE;
     if (width < 0) width = 0;
     if (height < 0) height = 0;


### PR DESCRIPTION
This PR adds support for high dpi screens to Amulet html exports. Prior to this change the highdpi option is already supported by other export platforms, but not html.

Amulet is using emscripten's SDL1 mode, and SDL1 doesn't seem to have `SDL_WINDOW_ALLOW_HIGHDPI`, and it looked like a big change to switch to SDL2, so I went a different route. I put the Lua `am.window` `highdpi` flag into a global `window.amulet.highdpi` JavaScript variable, and then make use of that in `SDL_GetWindowSize` where there was already code to adjust the resolution of the canvas.

In order for high dpi to be active, your Amulet app needs to ask for it via `highdpi = true` and the web browser needs to report a dpi multiplier via `window.devicePixelRatio`. There's a fallback to 1 if either of those is not set.

I've tested this on Mac and iOS with a couple of browsers, but I don't have a high dpi monitor to test on Windows.