### PR TITLE
Add documentation for am.type

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -22,6 +22,7 @@ SECTIONS = header.md \
 	conf.md \
 	models.md \
 	table.md \
+	types.md \
 	require.md \
 	misc.md
 
@@ -29,7 +30,7 @@ SECTIONS = header.md \
 GRAPHS = $(wildcard graphs/*.dot)
 GRAPH_PNGS = $(patsubst %.dot,%.png,$(GRAPHS))
 
-index.html: $(SECTIONS) $(GRAPH_PNGS) style.css template.html Makefile 
+index.html: $(SECTIONS) $(GRAPH_PNGS) style.css template.html Makefile
 	cat $(SECTIONS) | pandoc --mathjax --template template.html -c style.css --toc --toc-depth=4 -f markdown -o $@
 
 $(GRAPH_PNGS): %.png: %.dot

--- a/doc/index.html
+++ b/doc/index.html
@@ -12,41 +12,69 @@
     <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
   <style type="text/css">
-div.sourceCode { overflow-x: auto; }
-table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode {
-  margin: 0; padding: 0; vertical-align: baseline; border: none; }
-table.sourceCode { width: 100%; line-height: 100%; }
-td.lineNumbers { text-align: right; padding-right: 4px; padding-left: 4px; color: #aaaaaa; border-right: 1px solid #aaaaaa; }
-td.sourceCode { padding-left: 5px; }
-code > span.kw { color: #007020; font-weight: bold; } /* Keyword */
-code > span.dt { color: #902000; } /* DataType */
-code > span.dv { color: #40a070; } /* DecVal */
-code > span.bn { color: #40a070; } /* BaseN */
-code > span.fl { color: #40a070; } /* Float */
-code > span.ch { color: #4070a0; } /* Char */
-code > span.st { color: #4070a0; } /* String */
-code > span.co { color: #60a0b0; font-style: italic; } /* Comment */
-code > span.ot { color: #007020; } /* Other */
-code > span.al { color: #ff0000; font-weight: bold; } /* Alert */
-code > span.fu { color: #06287e; } /* Function */
-code > span.er { color: #ff0000; font-weight: bold; } /* Error */
-code > span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
-code > span.cn { color: #880000; } /* Constant */
-code > span.sc { color: #4070a0; } /* SpecialChar */
-code > span.vs { color: #4070a0; } /* VerbatimString */
-code > span.ss { color: #bb6688; } /* SpecialString */
-code > span.im { } /* Import */
-code > span.va { color: #19177c; } /* Variable */
-code > span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
-code > span.op { color: #666666; } /* Operator */
-code > span.bu { } /* BuiltIn */
-code > span.ex { } /* Extension */
-code > span.pp { color: #bc7a00; } /* Preprocessor */
-code > span.at { color: #7d9029; } /* Attribute */
-code > span.do { color: #ba2121; font-style: italic; } /* Documentation */
-code > span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
-code > span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
-code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+pre > code.sourceCode { white-space: pre; position: relative; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
+pre > code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode > span { color: inherit; text-decoration: inherit; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+pre > code.sourceCode { white-space: pre-wrap; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+}
+pre.numberSource code
+  { counter-reset: source-line 0; }
+pre.numberSource code > span
+  { position: relative; left: -4em; counter-increment: source-line; }
+pre.numberSource code > span > a:first-child::before
+  { content: counter(source-line);
+    position: relative; left: -1em; text-align: right; vertical-align: baseline;
+    border: none; display: inline-block;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+    color: #aaaaaa;
+  }
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+div.sourceCode
+  {   }
+@media screen {
+pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+}
+code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code span.at { color: #7d9029; } /* Attribute */
+code span.bn { color: #40a070; } /* BaseN */
+code span.bu { } /* BuiltIn */
+code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code span.ch { color: #4070a0; } /* Char */
+code span.cn { color: #880000; } /* Constant */
+code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code span.dt { color: #902000; } /* DataType */
+code span.dv { color: #40a070; } /* DecVal */
+code span.er { color: #ff0000; font-weight: bold; } /* Error */
+code span.ex { } /* Extension */
+code span.fl { color: #40a070; } /* Float */
+code span.fu { color: #06287e; } /* Function */
+code span.im { } /* Import */
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code span.op { color: #666666; } /* Operator */
+code span.ot { color: #007020; } /* Other */
+code span.pp { color: #bc7a00; } /* Preprocessor */
+code span.sc { color: #4070a0; } /* SpecialChar */
+code span.ss { color: #bb6688; } /* SpecialString */
+code span.st { color: #4070a0; } /* String */
+code span.va { color: #19177c; } /* Variable */
+code span.vs { color: #4070a0; } /* VerbatimString */
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
   </style>
   <link rel="stylesheet" href="style.css">
 <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
@@ -55,447 +83,826 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 <div id="content">
 <nav id="TOC">
 <ul>
-<li><a href="#introduction">Introduction</a></li>
-<li><a href="#how-to-use-this-document">How to use this document</a></li>
-<li><a href="#lua-primer">Lua primer</a></li>
-<li><a href="#quickstart">Quickstart tutorial</a><ul>
-<li><a href="#installing-amulet">Installing Amulet</a></li>
-<li><a href="#running-a-script">Running a script</a></li>
-<li><a href="#creating-a-window">Creating a window</a></li>
-<li><a href="#rendering-text">Rendering text</a></li>
-<li><a href="#transformation-nodes">Transformation nodes</a></li>
-<li><a href="#actions">Actions</a></li>
-<li><a href="#drawing-shapes">Drawing shapes</a></li>
-<li><a href="#responding-to-key-presses">Responding to key presses</a></li>
-<li><a href="#drawing-sprites">Drawing sprites</a></li>
-<li><a href="#responding-to-mouse-clicks">Responding to mouse clicks</a></li>
-<li><a href="#playing-audio">Playing audio</a></li>
-</ul></li>
-<li><a href="#math">Math</a><ul>
-<li><a href="#vectors">Vectors</a><ul>
-<li><a href="#constructing-vectors">Constructing vectors</a></li>
-<li><a href="#accessing-vector-components">Accessing vector components</a></li>
-<li><a href="#swizzle-fields">Swizzle fields</a></li>
-<li><a href="#vector-update-syntax">Vector update syntax</a></li>
-<li><a href="#vector-arithmetic">Vector arithmetic</a></li>
-</ul></li>
-<li><a href="#matrices">Matrices</a><ul>
-<li><a href="#constructing-matrices">Constructing matrices</a></li>
-<li><a href="#accessing-matrix-components">Accessing matrix components</a></li>
-<li><a href="#matrix-arithmetic">Matrix arithmetic</a></li>
-</ul></li>
-<li><a href="#quaternions">Quaternions</a><ul>
-<li><a href="#constructing-quaternions">Constructing quaternions</a></li>
-<li><a href="#quaternion-fields">Quaternion fields</a></li>
-<li><a href="#quaternion-operations">Quaternion operations</a></li>
-</ul></li>
-<li><a href="#math-functions">Math functions</a><ul>
-<li><a href="#math.sign">math.sign(n)</a></li>
-<li><a href="#math.fract">math.fract(v)</a></li>
-<li><a href="#math.clamp">math.clamp(v, min, max)</a></li>
-<li><a href="#math.randvec2">math.randvec2()</a></li>
-<li><a href="#math.randvec3">math.randvec3()</a></li>
-<li><a href="#math.randvec4">math.randvec4()</a></li>
-<li><a href="#math.dotvector1-vector2">math.dot(vector1, vector2)</a></li>
-<li><a href="#math.crossvector1-vector2">math.cross(vector1, vector2)</a></li>
-<li><a href="#math.normalizevector">math.normalize(vector)</a></li>
-<li><a href="#math.lengthvector">math.length(vector)</a></li>
-<li><a href="#math.distance">math.distance(vector1, vector2)</a></li>
-<li><a href="#math.inversematrix">math.inverse(matrix)</a></li>
-<li><a href="#math.lookateye-center-up">math.lookat(eye, center, up)</a></li>
-<li><a href="#math.perspectivefovy-aspect-near-far">math.perspective(fovy, aspect, near, far)</a></li>
-<li><a href="#math.ortho">math.ortho(left, right, bottom, top [, near, far])</a></li>
-<li><a href="#math.oblique">math.oblique(angle, zscale, left, right, bottom, top [, near, far])</a></li>
-<li><a href="#math.translate4">math.translate4(position)</a></li>
-<li><a href="#math.scale4">math.scale4(scaling)</a></li>
-<li><a href="#math.scale4">math.rotate4(rotation)</a></li>
-<li><a href="#math.perlin">math.perlin(pos [, period])</a></li>
-<li><a href="#math.simplex">math.simplex(pos)</a></li>
-<li><a href="#math.mix">math.mix(from, to, t)</a></li>
-<li><a href="#math.slerp">math.slerp(from, to, t)</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#buffers-and-views">Buffers and views</a><ul>
-<li><a href="#buffers">Buffers</a><ul>
-<li><a href="#am.buffer">am.buffer(size)</a></li>
-<li><a href="#am.load_buffer">am.load_buffer(filename)</a></li>
-<li><a href="#am.base64_encode">am.base64_encode(buffer)</a></li>
-<li><a href="#am.base64_decode">am.base64_decode(string)</a></li>
-</ul></li>
-<li><a href="#views">Views</a><ul>
-<li><a href="#buffer:view">buffer:view(type [, offset [, stride [, count]]])</a></li>
-</ul></li>
-<li><a href="#view-fields">View fields</a><ul>
-<li><a href="#view.buffer">view.buffer</a></li>
-</ul></li>
-<li><a href="#view-methods">View methods</a><ul>
-<li><a href="#view:slice">view:slice(n [, count [, stride_multiplier]])</a></li>
-<li><a href="#view:set">view:set(val [, start [, count]])</a></li>
-<li><a href="#am.float_array">am.float_array(table)</a></li>
-<li><a href="#am.byte_array">am.byte_array(table)</a></li>
-<li><a href="#am.ubyte_array">am.ubyte_array(table)</a></li>
-<li><a href="#am.byte_norm_array">am.byte_norm_array(table)</a></li>
-<li><a href="#am.ubyte_norm_array">am.ubyte_norm_array(table)</a></li>
-<li><a href="#am.short_array">am.short_array(table)</a></li>
-<li><a href="#am.ushort_array">am.ushort_array(table)</a></li>
-<li><a href="#am.short_norm_array">am.short_norm_array(table)</a></li>
-<li><a href="#am.ushort_norm_array">am.ushort_norm_array(table)</a></li>
-<li><a href="#am.int_array">am.int_array(table)</a></li>
-<li><a href="#am.uint_array">am.uint_array(table)</a></li>
-<li><a href="#am.int_norm_array">am.int_norm_array(table)</a></li>
-<li><a href="#am.uint_norm_array">am.uint_norm_array(table)</a></li>
-<li><a href="#am.ushort_elem_array">am.ushort_elem_array(table)</a></li>
-<li><a href="#am.uint_elem_array">am.uint_elem_array(table)</a></li>
-<li><a href="#am.vec2_array">am.vec2_array(table)</a></li>
-<li><a href="#am.vec3_array">am.vec3_array(table)</a></li>
-<li><a href="#am.vec4_array">am.vec4_array(table)</a></li>
-<li><a href="#am.struct_array">am.struct_array(size, spec)</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#windows-and-input">Windows and input</a><ul>
-<li><a href="#creating-a-window-1">Creating a window</a><ul>
-<li><a href="#am.window">am.window(settings)</a></li>
-</ul></li>
-<li><a href="#window-fields">Window fields</a><ul>
-<li><a href="#window.left">window.left</a></li>
-<li><a href="#window.right">window.right</a></li>
-<li><a href="#window.bottom">window.bottom</a></li>
-<li><a href="#window.top">window.top</a></li>
-<li><a href="#window.width">window.width</a></li>
-<li><a href="#window.height">window.height</a></li>
-<li><a href="#window.pixel_width">window.pixel_width</a></li>
-<li><a href="#window.pixel_height">window.pixel_height</a></li>
-<li><a href="#window.safe_left">window.safe_left</a></li>
-<li><a href="#window.safe_right">window.safe_right</a></li>
-<li><a href="#window.safe_bottom">window.safe_bottom</a></li>
-<li><a href="#window.safe_top">window.safe_top</a></li>
-<li><a href="#window.mode">window.mode</a></li>
-<li><a href="#window.clear_color">window.clear_color</a></li>
-<li><a href="#window.stencil_clear_value">window.stencil_clear_value</a></li>
-<li><a href="#window.letterbox">window.letterbox</a></li>
-<li><a href="#window.lock_pointer">window.lock_pointer</a></li>
-<li><a href="#window.show_cursor">window.show_cursor</a></li>
-<li><a href="#window.scene">window.scene</a></li>
-<li><a href="#window.projection">window.projection</a></li>
-</ul></li>
-<li><a href="#closing-a-window">Closing a window</a><ul>
-<li><a href="#windowclose">window:close()</a></li>
-</ul></li>
-<li><a href="#detecting-when-a-window-resizes">Detecting when a window resizes</a><ul>
-<li><a href="#windowresized">window:resized()</a></li>
-</ul></li>
-<li><a href="#detecting-key-presses">Detecting key presses</a><ul>
-<li><a href="#key_down">window:key_down(key)</a></li>
-<li><a href="#windowkeys_down">window:keys_down()</a></li>
-<li><a href="#windowkey_pressedkey">window:key_pressed(key)</a></li>
-<li><a href="#windowkeys_pressed">window:keys_pressed()</a></li>
-<li><a href="#windowkey_releasedkey">window:key_released(key)</a></li>
-<li><a href="#windowkeys_released">window:keys_released()</a></li>
-</ul></li>
-<li><a href="#detecting-mouse-events">Detecting mouse events</a><ul>
-<li><a href="#windowmouse_position">window:mouse_position()</a></li>
-<li><a href="#windowmouse_norm_position">window:mouse_norm_position()</a></li>
-<li><a href="#windowmouse_pixel_position">window:mouse_pixel_position()</a></li>
-<li><a href="#windowmouse_delta">window:mouse_delta()</a></li>
-<li><a href="#windowmouse_norm_delta">window:mouse_norm_delta()</a></li>
-<li><a href="#windowmouse_pixel_delta">window:mouse_pixel_delta()</a></li>
-<li><a href="#windowmouse_downbutton">window:mouse_down(button)</a></li>
-<li><a href="#windowmouse_pressedbutton">window:mouse_pressed(button)</a></li>
-<li><a href="#windowmouse_releasedbutton">window:mouse_released(button)</a></li>
-<li><a href="#windowmouse_wheel">window:mouse_wheel()</a></li>
-<li><a href="#windowmouse_wheel_delta">window:mouse_wheel_delta()</a></li>
-</ul></li>
-<li><a href="#detecting-touch-events">Detecting touch events</a><ul>
-<li><a href="#touches_began">window:touches_began()</a></li>
-<li><a href="#windowtouches_ended">window:touches_ended()</a></li>
-<li><a href="#windowactive_touches">window:active_touches()</a></li>
-<li><a href="#windowtouch_begantouch">window:touch_began([touch])</a></li>
-<li><a href="#windowtouch_endedtouch">window:touch_ended([touch])</a></li>
-<li><a href="#window:touch_active">window:touch_active([touch])</a></li>
-<li><a href="#windowtouch_positiontouch">window:touch_position([touch])</a></li>
-<li><a href="#windowtouch_norm_positiontouch">window:touch_norm_position([touch])</a></li>
-<li><a href="#windowtouch_pixel_positiontouch">window:touch_pixel_position([touch])</a></li>
-<li><a href="#windowtouch_deltatouch">window:touch_delta([touch])</a></li>
-<li><a href="#windowtouch_norm_deltatouch">window:touch_norm_delta([touch])</a></li>
-<li><a href="#windowtouch_pixel_deltatouch">window:touch_pixel_delta([touch])</a></li>
-<li><a href="#window:touch_force">window:touch_force([touch])</a></li>
-<li><a href="#window:touch_force_available">window:touch_force_available()</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#scenes">Scenes</a><ul>
-<li><a href="#scene-graph-syntax">Scene graph construction syntax</a></li>
-<li><a href="#scene-node-common-fields-and-methods">Scene node common fields and methods</a><ul>
-<li><a href="#node.hidden">node.hidden</a></li>
-<li><a href="#node.paused">node.paused</a></li>
-<li><a href="#node.num_children">node.num_children</a></li>
-<li><a href="#node.recursion_limit">node.recursion_limit</a></li>
-<li><a href="#node:tag">node:tag(tagname)</a></li>
-<li><a href="#node:untag">node:untag(tagname)</a></li>
-<li><a href="#node:all">node:all(tagname [, recurse])</a></li>
-<li><a href="#node:tagsearch">node(tagname)</a></li>
-<li><a href="#node:action">node:action([id,] action)</a></li>
-<li><a href="#node:late_action">node:late_action([id,] action)</a></li>
-<li><a href="#node:cancel">node:cancel(id)</a></li>
-<li><a href="#node:update">node:update()</a></li>
-<li><a href="#nodeappendchild">node:append(child)</a></li>
-<li><a href="#nodeprependchild">node:prepend(child)</a></li>
-<li><a href="#noderemovechild">node:remove(child)</a></li>
-<li><a href="#noderemovetagname">node:remove(tagname)</a></li>
-<li><a href="#noderemove_all">node:remove_all()</a></li>
-<li><a href="#nodereplacechild-replacement">node:replace(child, replacement)</a></li>
-<li><a href="#nodereplacetagname-replacement">node:replace(tagname, replacement)</a></li>
-<li><a href="#nodechildn">node:child(n)</a></li>
-<li><a href="#nodechild_pairs">node:child_pairs()</a></li>
-</ul></li>
-<li><a href="#basic-nodes">Basic nodes</a><ul>
-<li><a href="#am.groupchildren">am.group(children)</a></li>
-<li><a href="#am.text">am.text([font, ] string [, color] [, halign [, valign]])</a></li>
-<li><a href="#am.sprite">am.sprite(source [, color] [, halign [, valign]])</a></li>
-<li><a href="#am.rect">am.rect(x1, y1, x2, y2 [, color])</a></li>
-<li><a href="#am.circle">am.circle(center, radius [, color [, sides]])</a></li>
-<li><a href="#am.line">am.line(point1, point2 [, thickness [, color]])</a></li>
-<li><a href="#am.particles2d">am.particles2d(settings)</a></li>
-</ul></li>
-<li><a href="#transformation-nodes-1">Transformation nodes</a><ul>
-<li><a href="#am.translate">am.translate([uniform,] position)</a></li>
-<li><a href="#am.scale">am.scale([uniform,] scaling)</a></li>
-<li><a href="#am.rotate">am.rotate([uniform,] rotation)</a></li>
-<li><a href="#am.transform">am.transform([uniform,] matrix)</a></li>
-</ul></li>
-<li><a href="#advanced-nodes">Advanced nodes</a><ul>
-<li><a href="#am.use_program">am.use_program(program)</a></li>
-<li><a href="#am.bind">am.bind(bindings)</a></li>
-<li><a href="#am.draw">am.draw(primitive [, elements] [, first [, count]])</a></li>
-<li><a href="#am.blend">am.blend(mode)</a></li>
-<li><a href="#am.color_maskred-green-blue-alpha">am.color_mask(red, green, blue, alpha)</a></li>
-<li><a href="#am.cull_faceface">am.cull_face(face)</a></li>
-<li><a href="#am.depth_test">am.depth_test(func [, mask])</a></li>
-<li><a href="#am.stencil_test">am.stencil_test(settings)</a></li>
-<li><a href="#am.viewport">am.viewport(left, bottom, width, height)</a></li>
-<li><a href="#am.lookat">am.lookat([uniform,] eye, center, up)</a></li>
-<li><a href="#am.cull_sphere">am.cull_sphere([uniforms...,] radius [, center])</a></li>
-<li><a href="#am.cull_box">am.cull_box([uniforms...,] min, max)</a></li>
-<li><a href="#am.billboard">am.billboard([uniform,] [preserve_scaling])</a></li>
-<li><a href="#am.read_param">am.read_uniform(uniform)</a></li>
-<li><a href="#am.quads">am.quads(n, spec [, usage])</a></li>
-<li><a href="#am.postprocess">am.postprocess(settings)</a></li>
-</ul></li>
-<li><a href="#creating-custom-scene-nodes">Creating custom scene nodes</a><ul>
-<li><a href="#am.wrap">am.wrap(node)</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#shader-programs">Shader programs</a><ul>
-<li><a href="#compiling-a-shader-program">Compiling a shader program</a><ul>
-<li><a href="#am.program">am.program(vertex_shader, fragment_shader)</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#image-buffers">Image buffers</a><ul>
-<li><a href="#creating-image-buffers">Creating image buffers</a><ul>
-<li><a href="#am.image_buffer">am.image_buffer([buffer, ] width [, height])</a></li>
-<li><a href="#am.load_image">am.load_image(filename)</a></li>
-</ul></li>
-<li><a href="#saving-images">Saving images</a><ul>
-<li><a href="#image_buffer:save_png">image_buffer:save_png(filename)</a></li>
-</ul></li>
-<li><a href="#pasting-images">Pasting images</a><ul>
-<li><a href="#image_buffer:paste">image_buffer:paste(src, x, y)</a></li>
-</ul></li>
-<li><a href="#decodingencoding-pngs">Decoding/encoding PNGs</a><ul>
-<li><a href="#am.encode_png">am.encode_png(image_buffer)</a></li>
-<li><a href="#am.decode_png">am.decode_png(buffer)</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#textures">Textures</a><ul>
-<li><a href="#creating-a-texture">Creating a texture</a><ul>
-<li><a href="#am.texture2d">am.texture2d(width [, height])</a></li>
-<li><a href="#am.texture2dimage_buffer">am.texture2d(image_buffer)</a></li>
-<li><a href="#am.texture2dfilename">am.texture2d(filename)</a></li>
-</ul></li>
-<li><a href="#texture-fields">Texture fields</a><ul>
-<li><a href="#texture.width">texture.width</a></li>
-<li><a href="#texture.height">texture.height</a></li>
-<li><a href="#texture.image_buffer">texture.image_buffer</a></li>
-<li><a href="#texture.minfilter">texture.minfilter</a></li>
-<li><a href="#texture.magfilter">texture.magfilter</a></li>
-<li><a href="#texture.filter">texture.filter</a></li>
-<li><a href="#texture.swrap">texture.swrap</a></li>
-<li><a href="#texture.twrap">texture.twrap</a></li>
-<li><a href="#texture.wrap">texture.wrap</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#framebuffers">Framebuffers</a><ul>
-<li><a href="#creating-a-framebuffer">Creating a framebuffer</a><ul>
-<li><a href="#am.framebuffer">am.framebuffer(texture [, depth_buf [, stencil_buf]])</a></li>
-</ul></li>
-<li><a href="#framebuffer-fields">Framebuffer fields</a><ul>
-<li><a href="#framebuffer.clear_color">framebuffer.clear_color</a></li>
-<li><a href="#framebuffer.stencil_clear_value">framebuffer.stencil_clear_value</a></li>
-<li><a href="#framebuffer.projection">framebuffer.projection</a></li>
-<li><a href="#framebuffer.pixel_width">framebuffer.pixel_width</a></li>
-<li><a href="#framebuffer.pixel_height">framebuffer.pixel_height</a></li>
-</ul></li>
-<li><a href="#framebuffer-methods">Framebuffer methods</a><ul>
-<li><a href="#framebuffer:render">framebuffer:render(node)</a></li>
-<li><a href="#framebuffer:render_children">framebuffer:render_children(node)</a></li>
-<li><a href="#framebuffer:clear">framebuffer:clear([color [, depth [, stencil]]])</a></li>
-<li><a href="#framebuffer:read_back">framebuffer:read_back()</a></li>
-<li><a href="#framebuffer:resize">framebuffer:resize(width, height)</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#actions-1">Actions</a><ul>
-<li><a href="#delay-action">Delay action</a><ul>
-<li><a href="#am.delay">am.delay(seconds)</a></li>
-</ul></li>
-<li><a href="#combining-actions">Combining actions</a><ul>
-<li><a href="#am.series">am.series(actions)</a></li>
-<li><a href="#am.parallel">am.parallel(actions)</a></li>
-<li><a href="#am.loop">am.loop(func)</a></li>
-</ul></li>
-<li><a href="#tweens">Tweens</a><ul>
-<li><a href="#am.tween">am.tween([target,] time, values [, ease])</a></li>
-</ul></li>
-<li><a href="#coroutine-actions">Coroutine actions</a><ul>
-<li><a href="#am.wait">am.wait(action)</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#time">Time</a><ul>
-<li><a href="#frame-time">Frame time</a><ul>
-<li><a href="#am.frame_time">am.frame_time</a></li>
-</ul></li>
-<li><a href="#delta-time">Delta time</a><ul>
-<li><a href="#am.delta_time">am.delta_time</a></li>
-</ul></li>
-<li><a href="#real-time">Real time</a><ul>
-<li><a href="#am.current_time">am.current_time()</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#saving-and-loading-state">Saving and loading state</a><ul>
-<li><a href="#am.save_statekey-state-format">am.save_state(key, state [,format])</a></li>
-<li><a href="#am.load_statekey-format">am.load_state(key, [,format])</a></li>
-</ul></li>
-<li><a href="#audio">Audio</a><ul>
-<li><a href="#audio-buffers">Audio buffers</a><ul>
-<li><a href="#am.audio_buffer">am.audio_buffer(buffer, channels, sample_rate)</a></li>
-<li><a href="#am.load_audio">am.load_audio(filename)</a></li>
-</ul></li>
-<li><a href="#audio-buffer-fields">Audio buffer fields</a><ul>
-<li><a href="#audio_buffer.channels">audio_buffer.channels</a></li>
-<li><a href="#audio_buffer.sample_rate">audio_buffer.sample_rate</a></li>
-<li><a href="#audio_buffer.samples_per_channel">audio_buffer.samples_per_channel</a></li>
-<li><a href="#audio_buffer.length">audio_buffer.length</a></li>
-<li><a href="#audio_buffer.buffer">audio_buffer.buffer</a></li>
-</ul></li>
-<li><a href="#audio-tracks">Audio tracks</a><ul>
-<li><a href="#am.track">am.track(buffer [, loop [, playback_speed [, volume]]])</a></li>
-</ul></li>
-<li><a href="#audio-track-fields">Audio track fields</a><ul>
-<li><a href="#track.playback_speed">track.playback_speed</a></li>
-<li><a href="#track.volume">track.volume</a></li>
-</ul></li>
-<li><a href="#audio-track-methods">Audio track methods</a><ul>
-<li><a href="#track:reset">track:reset([position])</a></li>
-</ul></li>
-<li><a href="#playing-audio-1">Playing audio</a><ul>
-<li><a href="#am.play">am.play(source, loop, pitch, volume)</a></li>
-</ul></li>
-<li><a href="#generating-sound-effects">Generating sound effects</a><ul>
-<li><a href="#am.sfxr_synth">am.sfxr_synth(settings)</a></li>
-</ul></li>
-<li><a href="#audio-graphs">Audio graphs</a></li>
-<li><a href="#audio-graph-nodes">Audio graph nodes</a></li>
-<li><a href="#analysing-audio">Analysing audio</a></li>
-</ul></li>
-<li><a href="#controllers">Controllers</a><ul>
-<li><a href="#am.controller_present">am.controller_present(index)</a></li>
-<li><a href="#am.controller_attached">am.controller_attached(index)</a></li>
-<li><a href="#am.controller_detached">am.controller_detached(index)</a></li>
-<li><a href="#am.controllers_present">am.controllers_present()</a></li>
-<li><a href="#am.controllers_attached">am.controllers_attached()</a></li>
-<li><a href="#am.controllers_detached">am.controllers_detached()</a></li>
-<li><a href="#am.controller_lt_val">am.controller_lt_val(index)</a></li>
-<li><a href="#am.controller_rt_val">am.controller_rt_val(index)</a></li>
-<li><a href="#am.controller_lstick_pos">am.controller_lstick_pos(index)</a></li>
-<li><a href="#am.controller_rstick_pos">am.controller_rstick_pos(index)</a></li>
-<li><a href="#am.controller_button_pressed">am.controller_button_pressed(index, button)</a></li>
-<li><a href="#am.controller_button_released">am.controller_button_released(index, button)</a></li>
-<li><a href="#am.controller_button_down">am.controller_button_down(index, button)</a></li>
-</ul></li>
-<li><a href="#spritepack">Packing sprites and generating fonts</a><ul>
-<li><a href="#overview">Overview</a></li>
-<li><a href="#pack-options">Pack options</a></li>
-<li><a href="#padding">Padding</a></li>
-<li><a href="#specifying-which-font-glyphs-to-generate">Specifying which font glyphs to generate</a></li>
-<li><a href="#loading-bitmap-font-images">Loading bitmap font images</a><ul>
-<li><a href="#am.load_bitmap_font">am.load_bitmap_font(filename, key)</a></li>
-</ul></li>
-</ul></li>
-<li><a href="#exporting">Exporting</a></li>
-<li><a href="#config">Project Configuration</a><ul>
-<li><a href="#basic-metadata">Basic metadata</a></li>
-<li><a href="#language-configuration">Language configuration</a></li>
-<li><a href="#lua-version">Lua version</a></li>
-<li><a href="#windows-settings">Windows settings</a></li>
-<li><a href="#mac-settings">Mac settings</a></li>
-<li><a href="#ios-settings">iOS settings</a></li>
-<li><a href="#android-settings">Android settings</a></li>
-</ul></li>
-<li><a href="#d-models">3D models</a><ul>
-<li><a href="#am.load_obj">am.load_obj(filename)</a></li>
-</ul></li>
-<li><a href="#extra-table-functions">Extra table functions</a><ul>
-<li><a href="#table.shallow_copy">table.shallow_copy(t)</a></li>
-<li><a href="#table.deep_copy">table.deep_copy(t)</a></li>
-<li><a href="#table.search">table.search(arr, elem)</a></li>
-<li><a href="#table.shuffle">table.shuffle(t [,rand])</a></li>
-<li><a href="#table.clear">table.clear(t)</a></li>
-<li><a href="#table.remove_all">table.remove_all(arr, elem)</a></li>
-<li><a href="#table.append">table.append(arr1, arr2)</a></li>
-<li><a href="#table.merge">table.merge(t1, t2)</a></li>
-<li><a href="#table.keys">table.keys(t)</a></li>
-<li><a href="#table.values">table.values(t)</a></li>
-<li><a href="#table.filter">table.filter(arr, f)</a></li>
-<li><a href="#table.tostring">table.tostring(t)</a></li>
-<li><a href="#table.count">table.count(t)</a></li>
-</ul></li>
-<li><a href="#amulet-require-function">Amulet require function</a></li>
-<li><a href="#logging">Logging</a><ul>
-<li><a href="#log">log(msg, ...)</a></li>
-</ul></li>
-<li><a href="#preventing-accidental-global-variable-usage">Preventing accidental global variable usage</a><ul>
-<li><a href="#noglobals">noglobals()</a></li>
-</ul></li>
-<li><a href="#globbing">Globbing</a><ul>
-<li><a href="#am.glob">am.glob(patterns)</a></li>
-</ul></li>
-<li><a href="#running-javascript">Running JavaScript</a><ul>
-<li><a href="#am.eval_js">am.eval_js(js)</a></li>
-</ul></li>
-<li><a href="#converting-tofrom-json">Converting to/from JSON</a><ul>
-<li><a href="#am.to_json">am.to_json(value)</a></li>
-<li><a href="#am.parse_json">am.parse_json(json)</a></li>
-</ul></li>
-<li><a href="#loading-other-resources">Loading other resources</a><ul>
-<li><a href="#am.load_script">am.load_script(filename)</a></li>
-<li><a href="#am.load_string">am.load_string(filename)</a></li>
-</ul></li>
-<li><a href="#performance-stats">Performance stats</a><ul>
-<li><a href="#am.perf_stats">am.perf_stats()</a></li>
-</ul></li>
-<li><a href="#amulet-version">Amulet version</a><ul>
-<li><a href="#am.version">am.version</a></li>
-</ul></li>
-<li><a href="#platform">Platform</a><ul>
-<li><a href="#am.platform">am.platform</a></li>
-</ul></li>
-<li><a href="#language">Language</a><ul>
-<li><a href="#am.language">am.language()</a></li>
-</ul></li>
-<li><a href="#game-center-ios-only">Game Center (iOS only)</a><ul>
-<li><a href="#am.init_gamecenter">am.init_gamecenter()</a></li>
-<li><a href="#am.gamecenter_available">am.gamecenter_available()</a></li>
-<li><a href="#am.submit_gamecenter_score">am.submit_gamecenter_score(leaderboard_id, score)</a></li>
-<li><a href="#am.submit_gamecenter_achievement">am.submit_gamecenter_achievement(achievment_id)</a></li>
-<li><a href="#am.show_gamecenter_leaderboard">am.show_gamecenter_leaderboard(leaderboard_id)</a></li>
+<li><a href="#introduction" id="toc-introduction">Introduction</a></li>
+<li><a href="#how-to-use-this-document"
+id="toc-how-to-use-this-document">How to use this document</a></li>
+<li><a href="#lua-primer" id="toc-lua-primer">Lua primer</a></li>
+<li><a href="#quickstart" id="toc-quickstart">Quickstart tutorial</a>
+<ul>
+<li><a href="#installing-amulet" id="toc-installing-amulet">Installing
+Amulet</a></li>
+<li><a href="#running-a-script" id="toc-running-a-script">Running a
+script</a></li>
+<li><a href="#creating-a-window" id="toc-creating-a-window">Creating a
+window</a></li>
+<li><a href="#rendering-text" id="toc-rendering-text">Rendering
+text</a></li>
+<li><a href="#transformation-nodes"
+id="toc-transformation-nodes">Transformation nodes</a></li>
+<li><a href="#actions" id="toc-actions">Actions</a></li>
+<li><a href="#drawing-shapes" id="toc-drawing-shapes">Drawing
+shapes</a></li>
+<li><a href="#responding-to-key-presses"
+id="toc-responding-to-key-presses">Responding to key presses</a></li>
+<li><a href="#drawing-sprites" id="toc-drawing-sprites">Drawing
+sprites</a></li>
+<li><a href="#responding-to-mouse-clicks"
+id="toc-responding-to-mouse-clicks">Responding to mouse clicks</a></li>
+<li><a href="#playing-audio" id="toc-playing-audio">Playing
+audio</a></li>
+</ul></li>
+<li><a href="#math" id="toc-math">Math</a>
+<ul>
+<li><a href="#vectors" id="toc-vectors">Vectors</a>
+<ul>
+<li><a href="#constructing-vectors"
+id="toc-constructing-vectors">Constructing vectors</a></li>
+<li><a href="#accessing-vector-components"
+id="toc-accessing-vector-components">Accessing vector
+components</a></li>
+<li><a href="#swizzle-fields" id="toc-swizzle-fields">Swizzle
+fields</a></li>
+<li><a href="#vector-update-syntax" id="toc-vector-update-syntax">Vector
+update syntax</a></li>
+<li><a href="#vector-arithmetic" id="toc-vector-arithmetic">Vector
+arithmetic</a></li>
+</ul></li>
+<li><a href="#matrices" id="toc-matrices">Matrices</a>
+<ul>
+<li><a href="#constructing-matrices"
+id="toc-constructing-matrices">Constructing matrices</a></li>
+<li><a href="#accessing-matrix-components"
+id="toc-accessing-matrix-components">Accessing matrix
+components</a></li>
+<li><a href="#matrix-arithmetic" id="toc-matrix-arithmetic">Matrix
+arithmetic</a></li>
+</ul></li>
+<li><a href="#quaternions" id="toc-quaternions">Quaternions</a>
+<ul>
+<li><a href="#constructing-quaternions"
+id="toc-constructing-quaternions">Constructing quaternions</a></li>
+<li><a href="#quaternion-fields" id="toc-quaternion-fields">Quaternion
+fields</a></li>
+<li><a href="#quaternion-operations"
+id="toc-quaternion-operations">Quaternion operations</a></li>
+</ul></li>
+<li><a href="#math-functions" id="toc-math-functions">Math functions</a>
+<ul>
+<li><a href="#math.sign" id="toc-math.sign">math.sign(n)</a></li>
+<li><a href="#math.fract" id="toc-math.fract">math.fract(v)</a></li>
+<li><a href="#math.clamp" id="toc-math.clamp">math.clamp(v, min,
+max)</a></li>
+<li><a href="#math.randvec2"
+id="toc-math.randvec2">math.randvec2()</a></li>
+<li><a href="#math.randvec3"
+id="toc-math.randvec3">math.randvec3()</a></li>
+<li><a href="#math.randvec4"
+id="toc-math.randvec4">math.randvec4()</a></li>
+<li><a href="#math.dotvector1-vector2"
+id="toc-math.dotvector1-vector2">math.dot(vector1, vector2)</a></li>
+<li><a href="#math.crossvector1-vector2"
+id="toc-math.crossvector1-vector2">math.cross(vector1, vector2)</a></li>
+<li><a href="#math.normalizevector"
+id="toc-math.normalizevector">math.normalize(vector)</a></li>
+<li><a href="#math.lengthvector"
+id="toc-math.lengthvector">math.length(vector)</a></li>
+<li><a href="#math.distance"
+id="toc-math.distance">math.distance(vector1, vector2)</a></li>
+<li><a href="#math.inversematrix"
+id="toc-math.inversematrix">math.inverse(matrix)</a></li>
+<li><a href="#math.lookateye-center-up"
+id="toc-math.lookateye-center-up">math.lookat(eye, center, up)</a></li>
+<li><a href="#math.perspectivefovy-aspect-near-far"
+id="toc-math.perspectivefovy-aspect-near-far">math.perspective(fovy,
+aspect, near, far)</a></li>
+<li><a href="#math.ortho" id="toc-math.ortho">math.ortho(left, right,
+bottom, top [, near, far])</a></li>
+<li><a href="#math.oblique" id="toc-math.oblique">math.oblique(angle,
+zscale, left, right, bottom, top [, near, far])</a></li>
+<li><a href="#math.translate4"
+id="toc-math.translate4">math.translate4(position)</a></li>
+<li><a href="#math.scale4"
+id="toc-math.scale4">math.scale4(scaling)</a></li>
+<li><a href="#math.scale4"
+id="toc-math.scale4">math.rotate4(rotation)</a></li>
+<li><a href="#math.perlin" id="toc-math.perlin">math.perlin(pos [,
+period])</a></li>
+<li><a href="#math.simplex"
+id="toc-math.simplex">math.simplex(pos)</a></li>
+<li><a href="#math.mix" id="toc-math.mix">math.mix(from, to, t)</a></li>
+<li><a href="#math.slerp" id="toc-math.slerp">math.slerp(from, to,
+t)</a></li>
+</ul></li>
+</ul></li>
+<li><a href="#buffers-and-views" id="toc-buffers-and-views">Buffers and
+views</a>
+<ul>
+<li><a href="#buffers" id="toc-buffers">Buffers</a>
+<ul>
+<li><a href="#am.buffer" id="toc-am.buffer">am.buffer(size)</a></li>
+<li><a href="#am.load_buffer"
+id="toc-am.load_buffer">am.load_buffer(filename)</a></li>
+<li><a href="#am.base64_encode"
+id="toc-am.base64_encode">am.base64_encode(buffer)</a></li>
+<li><a href="#am.base64_decode"
+id="toc-am.base64_decode">am.base64_decode(string)</a></li>
+</ul></li>
+<li><a href="#views" id="toc-views">Views</a>
+<ul>
+<li><a href="#buffer:view" id="toc-buffer:view">buffer:view(type [,
+offset [, stride [, count]]])</a></li>
+</ul></li>
+<li><a href="#view-fields" id="toc-view-fields">View fields</a>
+<ul>
+<li><a href="#view.buffer" id="toc-view.buffer">view.buffer</a></li>
+</ul></li>
+<li><a href="#view-methods" id="toc-view-methods">View methods</a>
+<ul>
+<li><a href="#view:slice" id="toc-view:slice">view:slice(n [, count [,
+stride_multiplier]])</a></li>
+<li><a href="#view:set" id="toc-view:set">view:set(val [, start [,
+count]])</a></li>
+<li><a href="#am.float_array"
+id="toc-am.float_array">am.float_array(table)</a></li>
+<li><a href="#am.byte_array"
+id="toc-am.byte_array">am.byte_array(table)</a></li>
+<li><a href="#am.ubyte_array"
+id="toc-am.ubyte_array">am.ubyte_array(table)</a></li>
+<li><a href="#am.byte_norm_array"
+id="toc-am.byte_norm_array">am.byte_norm_array(table)</a></li>
+<li><a href="#am.ubyte_norm_array"
+id="toc-am.ubyte_norm_array">am.ubyte_norm_array(table)</a></li>
+<li><a href="#am.short_array"
+id="toc-am.short_array">am.short_array(table)</a></li>
+<li><a href="#am.ushort_array"
+id="toc-am.ushort_array">am.ushort_array(table)</a></li>
+<li><a href="#am.short_norm_array"
+id="toc-am.short_norm_array">am.short_norm_array(table)</a></li>
+<li><a href="#am.ushort_norm_array"
+id="toc-am.ushort_norm_array">am.ushort_norm_array(table)</a></li>
+<li><a href="#am.int_array"
+id="toc-am.int_array">am.int_array(table)</a></li>
+<li><a href="#am.uint_array"
+id="toc-am.uint_array">am.uint_array(table)</a></li>
+<li><a href="#am.int_norm_array"
+id="toc-am.int_norm_array">am.int_norm_array(table)</a></li>
+<li><a href="#am.uint_norm_array"
+id="toc-am.uint_norm_array">am.uint_norm_array(table)</a></li>
+<li><a href="#am.ushort_elem_array"
+id="toc-am.ushort_elem_array">am.ushort_elem_array(table)</a></li>
+<li><a href="#am.uint_elem_array"
+id="toc-am.uint_elem_array">am.uint_elem_array(table)</a></li>
+<li><a href="#am.vec2_array"
+id="toc-am.vec2_array">am.vec2_array(table)</a></li>
+<li><a href="#am.vec3_array"
+id="toc-am.vec3_array">am.vec3_array(table)</a></li>
+<li><a href="#am.vec4_array"
+id="toc-am.vec4_array">am.vec4_array(table)</a></li>
+<li><a href="#am.struct_array"
+id="toc-am.struct_array">am.struct_array(size, spec)</a></li>
+</ul></li>
+</ul></li>
+<li><a href="#windows-and-input" id="toc-windows-and-input">Windows and
+input</a>
+<ul>
+<li><a href="#creating-a-window-1" id="toc-creating-a-window-1">Creating
+a window</a>
+<ul>
+<li><a href="#am.window" id="toc-am.window">am.window(settings)</a></li>
+</ul></li>
+<li><a href="#window-fields" id="toc-window-fields">Window fields</a>
+<ul>
+<li><a href="#window.left" id="toc-window.left">window.left</a></li>
+<li><a href="#window.right" id="toc-window.right">window.right</a></li>
+<li><a href="#window.bottom"
+id="toc-window.bottom">window.bottom</a></li>
+<li><a href="#window.top" id="toc-window.top">window.top</a></li>
+<li><a href="#window.width" id="toc-window.width">window.width</a></li>
+<li><a href="#window.height"
+id="toc-window.height">window.height</a></li>
+<li><a href="#window.pixel_width"
+id="toc-window.pixel_width">window.pixel_width</a></li>
+<li><a href="#window.pixel_height"
+id="toc-window.pixel_height">window.pixel_height</a></li>
+<li><a href="#window.safe_left"
+id="toc-window.safe_left">window.safe_left</a></li>
+<li><a href="#window.safe_right"
+id="toc-window.safe_right">window.safe_right</a></li>
+<li><a href="#window.safe_bottom"
+id="toc-window.safe_bottom">window.safe_bottom</a></li>
+<li><a href="#window.safe_top"
+id="toc-window.safe_top">window.safe_top</a></li>
+<li><a href="#window.mode" id="toc-window.mode">window.mode</a></li>
+<li><a href="#window.clear_color"
+id="toc-window.clear_color">window.clear_color</a></li>
+<li><a href="#window.stencil_clear_value"
+id="toc-window.stencil_clear_value">window.stencil_clear_value</a></li>
+<li><a href="#window.letterbox"
+id="toc-window.letterbox">window.letterbox</a></li>
+<li><a href="#window.lock_pointer"
+id="toc-window.lock_pointer">window.lock_pointer</a></li>
+<li><a href="#window.show_cursor"
+id="toc-window.show_cursor">window.show_cursor</a></li>
+<li><a href="#window.scene" id="toc-window.scene">window.scene</a></li>
+<li><a href="#window.projection"
+id="toc-window.projection">window.projection</a></li>
+</ul></li>
+<li><a href="#closing-a-window" id="toc-closing-a-window">Closing a
+window</a>
+<ul>
+<li><a href="#windowclose" id="toc-windowclose">window:close()</a></li>
+</ul></li>
+<li><a href="#detecting-when-a-window-resizes"
+id="toc-detecting-when-a-window-resizes">Detecting when a window
+resizes</a>
+<ul>
+<li><a href="#windowresized"
+id="toc-windowresized">window:resized()</a></li>
+</ul></li>
+<li><a href="#detecting-key-presses"
+id="toc-detecting-key-presses">Detecting key presses</a>
+<ul>
+<li><a href="#key_down" id="toc-key_down">window:key_down(key)</a></li>
+<li><a href="#windowkeys_down"
+id="toc-windowkeys_down">window:keys_down()</a></li>
+<li><a href="#windowkey_pressedkey"
+id="toc-windowkey_pressedkey">window:key_pressed(key)</a></li>
+<li><a href="#windowkeys_pressed"
+id="toc-windowkeys_pressed">window:keys_pressed()</a></li>
+<li><a href="#windowkey_releasedkey"
+id="toc-windowkey_releasedkey">window:key_released(key)</a></li>
+<li><a href="#windowkeys_released"
+id="toc-windowkeys_released">window:keys_released()</a></li>
+</ul></li>
+<li><a href="#detecting-mouse-events"
+id="toc-detecting-mouse-events">Detecting mouse events</a>
+<ul>
+<li><a href="#windowmouse_position"
+id="toc-windowmouse_position">window:mouse_position()</a></li>
+<li><a href="#windowmouse_norm_position"
+id="toc-windowmouse_norm_position">window:mouse_norm_position()</a></li>
+<li><a href="#windowmouse_pixel_position"
+id="toc-windowmouse_pixel_position">window:mouse_pixel_position()</a></li>
+<li><a href="#windowmouse_delta"
+id="toc-windowmouse_delta">window:mouse_delta()</a></li>
+<li><a href="#windowmouse_norm_delta"
+id="toc-windowmouse_norm_delta">window:mouse_norm_delta()</a></li>
+<li><a href="#windowmouse_pixel_delta"
+id="toc-windowmouse_pixel_delta">window:mouse_pixel_delta()</a></li>
+<li><a href="#windowmouse_downbutton"
+id="toc-windowmouse_downbutton">window:mouse_down(button)</a></li>
+<li><a href="#windowmouse_pressedbutton"
+id="toc-windowmouse_pressedbutton">window:mouse_pressed(button)</a></li>
+<li><a href="#windowmouse_releasedbutton"
+id="toc-windowmouse_releasedbutton">window:mouse_released(button)</a></li>
+<li><a href="#windowmouse_wheel"
+id="toc-windowmouse_wheel">window:mouse_wheel()</a></li>
+<li><a href="#windowmouse_wheel_delta"
+id="toc-windowmouse_wheel_delta">window:mouse_wheel_delta()</a></li>
+</ul></li>
+<li><a href="#detecting-touch-events"
+id="toc-detecting-touch-events">Detecting touch events</a>
+<ul>
+<li><a href="#touches_began"
+id="toc-touches_began">window:touches_began()</a></li>
+<li><a href="#windowtouches_ended"
+id="toc-windowtouches_ended">window:touches_ended()</a></li>
+<li><a href="#windowactive_touches"
+id="toc-windowactive_touches">window:active_touches()</a></li>
+<li><a href="#windowtouch_begantouch"
+id="toc-windowtouch_begantouch">window:touch_began([touch])</a></li>
+<li><a href="#windowtouch_endedtouch"
+id="toc-windowtouch_endedtouch">window:touch_ended([touch])</a></li>
+<li><a href="#window:touch_active"
+id="toc-window:touch_active">window:touch_active([touch])</a></li>
+<li><a href="#windowtouch_positiontouch"
+id="toc-windowtouch_positiontouch">window:touch_position([touch])</a></li>
+<li><a href="#windowtouch_norm_positiontouch"
+id="toc-windowtouch_norm_positiontouch">window:touch_norm_position([touch])</a></li>
+<li><a href="#windowtouch_pixel_positiontouch"
+id="toc-windowtouch_pixel_positiontouch">window:touch_pixel_position([touch])</a></li>
+<li><a href="#windowtouch_deltatouch"
+id="toc-windowtouch_deltatouch">window:touch_delta([touch])</a></li>
+<li><a href="#windowtouch_norm_deltatouch"
+id="toc-windowtouch_norm_deltatouch">window:touch_norm_delta([touch])</a></li>
+<li><a href="#windowtouch_pixel_deltatouch"
+id="toc-windowtouch_pixel_deltatouch">window:touch_pixel_delta([touch])</a></li>
+<li><a href="#window:touch_force"
+id="toc-window:touch_force">window:touch_force([touch])</a></li>
+<li><a href="#window:touch_force_available"
+id="toc-window:touch_force_available">window:touch_force_available()</a></li>
+</ul></li>
+</ul></li>
+<li><a href="#scenes" id="toc-scenes">Scenes</a>
+<ul>
+<li><a href="#scene-graph-syntax" id="toc-scene-graph-syntax">Scene
+graph construction syntax</a></li>
+<li><a href="#scene-node-common-fields-and-methods"
+id="toc-scene-node-common-fields-and-methods">Scene node common fields
+and methods</a>
+<ul>
+<li><a href="#node.hidden" id="toc-node.hidden">node.hidden</a></li>
+<li><a href="#node.paused" id="toc-node.paused">node.paused</a></li>
+<li><a href="#node.num_children"
+id="toc-node.num_children">node.num_children</a></li>
+<li><a href="#node.recursion_limit"
+id="toc-node.recursion_limit">node.recursion_limit</a></li>
+<li><a href="#node:tag" id="toc-node:tag">node:tag(tagname)</a></li>
+<li><a href="#node:untag"
+id="toc-node:untag">node:untag(tagname)</a></li>
+<li><a href="#node:all" id="toc-node:all">node:all(tagname [,
+recurse])</a></li>
+<li><a href="#node:tagsearch"
+id="toc-node:tagsearch">node(tagname)</a></li>
+<li><a href="#node:action" id="toc-node:action">node:action([id,]
+action)</a></li>
+<li><a href="#node:late_action"
+id="toc-node:late_action">node:late_action([id,] action)</a></li>
+<li><a href="#node:cancel" id="toc-node:cancel">node:cancel(id)</a></li>
+<li><a href="#node:update" id="toc-node:update">node:update()</a></li>
+<li><a href="#nodeappendchild"
+id="toc-nodeappendchild">node:append(child)</a></li>
+<li><a href="#nodeprependchild"
+id="toc-nodeprependchild">node:prepend(child)</a></li>
+<li><a href="#noderemovechild"
+id="toc-noderemovechild">node:remove(child)</a></li>
+<li><a href="#noderemovetagname"
+id="toc-noderemovetagname">node:remove(tagname)</a></li>
+<li><a href="#noderemove_all"
+id="toc-noderemove_all">node:remove_all()</a></li>
+<li><a href="#nodereplacechild-replacement"
+id="toc-nodereplacechild-replacement">node:replace(child,
+replacement)</a></li>
+<li><a href="#nodereplacetagname-replacement"
+id="toc-nodereplacetagname-replacement">node:replace(tagname,
+replacement)</a></li>
+<li><a href="#nodechildn" id="toc-nodechildn">node:child(n)</a></li>
+<li><a href="#nodechild_pairs"
+id="toc-nodechild_pairs">node:child_pairs()</a></li>
+</ul></li>
+<li><a href="#basic-nodes" id="toc-basic-nodes">Basic nodes</a>
+<ul>
+<li><a href="#am.groupchildren"
+id="toc-am.groupchildren">am.group(children)</a></li>
+<li><a href="#am.text" id="toc-am.text">am.text([font, ] string [,
+color] [, halign [, valign]])</a></li>
+<li><a href="#am.sprite" id="toc-am.sprite">am.sprite(source [, color]
+[, halign [, valign]])</a></li>
+<li><a href="#am.rect" id="toc-am.rect">am.rect(x1, y1, x2, y2 [,
+color])</a></li>
+<li><a href="#am.circle" id="toc-am.circle">am.circle(center, radius [,
+color [, sides]])</a></li>
+<li><a href="#am.line" id="toc-am.line">am.line(point1, point2 [,
+thickness [, color]])</a></li>
+<li><a href="#am.particles2d"
+id="toc-am.particles2d">am.particles2d(settings)</a></li>
+</ul></li>
+<li><a href="#transformation-nodes-1"
+id="toc-transformation-nodes-1">Transformation nodes</a>
+<ul>
+<li><a href="#am.translate"
+id="toc-am.translate">am.translate([uniform,] position)</a></li>
+<li><a href="#am.scale" id="toc-am.scale">am.scale([uniform,]
+scaling)</a></li>
+<li><a href="#am.rotate" id="toc-am.rotate">am.rotate([uniform,]
+rotation)</a></li>
+<li><a href="#am.transform"
+id="toc-am.transform">am.transform([uniform,] matrix)</a></li>
+</ul></li>
+<li><a href="#advanced-nodes" id="toc-advanced-nodes">Advanced nodes</a>
+<ul>
+<li><a href="#am.use_program"
+id="toc-am.use_program">am.use_program(program)</a></li>
+<li><a href="#am.bind" id="toc-am.bind">am.bind(bindings)</a></li>
+<li><a href="#am.draw" id="toc-am.draw">am.draw(primitive [, elements]
+[, first [, count]])</a></li>
+<li><a href="#am.blend" id="toc-am.blend">am.blend(mode)</a></li>
+<li><a href="#am.color_maskred-green-blue-alpha"
+id="toc-am.color_maskred-green-blue-alpha">am.color_mask(red, green,
+blue, alpha)</a></li>
+<li><a href="#am.cull_faceface"
+id="toc-am.cull_faceface">am.cull_face(face)</a></li>
+<li><a href="#am.depth_test" id="toc-am.depth_test">am.depth_test(func
+[, mask])</a></li>
+<li><a href="#am.stencil_test"
+id="toc-am.stencil_test">am.stencil_test(settings)</a></li>
+<li><a href="#am.viewport" id="toc-am.viewport">am.viewport(left,
+bottom, width, height)</a></li>
+<li><a href="#am.lookat" id="toc-am.lookat">am.lookat([uniform,] eye,
+center, up)</a></li>
+<li><a href="#am.cull_sphere"
+id="toc-am.cull_sphere">am.cull_sphere([uniforms…,] radius [,
+center])</a></li>
+<li><a href="#am.cull_box" id="toc-am.cull_box">am.cull_box([uniforms…,]
+min, max)</a></li>
+<li><a href="#am.billboard"
+id="toc-am.billboard">am.billboard([uniform,]
+[preserve_scaling])</a></li>
+<li><a href="#am.read_param"
+id="toc-am.read_param">am.read_uniform(uniform)</a></li>
+<li><a href="#am.quads" id="toc-am.quads">am.quads(n, spec [,
+usage])</a></li>
+<li><a href="#am.postprocess"
+id="toc-am.postprocess">am.postprocess(settings)</a></li>
+</ul></li>
+<li><a href="#creating-custom-scene-nodes"
+id="toc-creating-custom-scene-nodes">Creating custom scene nodes</a>
+<ul>
+<li><a href="#am.wrap" id="toc-am.wrap">am.wrap(node)</a></li>
+</ul></li>
+</ul></li>
+<li><a href="#shader-programs" id="toc-shader-programs">Shader
+programs</a>
+<ul>
+<li><a href="#compiling-a-shader-program"
+id="toc-compiling-a-shader-program">Compiling a shader program</a>
+<ul>
+<li><a href="#am.program" id="toc-am.program">am.program(vertex_shader,
+fragment_shader)</a></li>
+</ul></li>
+</ul></li>
+<li><a href="#image-buffers" id="toc-image-buffers">Image buffers</a>
+<ul>
+<li><a href="#creating-image-buffers"
+id="toc-creating-image-buffers">Creating image buffers</a>
+<ul>
+<li><a href="#am.image_buffer"
+id="toc-am.image_buffer">am.image_buffer([buffer, ] width [,
+height])</a></li>
+<li><a href="#am.load_image"
+id="toc-am.load_image">am.load_image(filename)</a></li>
+</ul></li>
+<li><a href="#saving-images" id="toc-saving-images">Saving images</a>
+<ul>
+<li><a href="#image_buffer:save_png"
+id="toc-image_buffer:save_png">image_buffer:save_png(filename)</a></li>
+</ul></li>
+<li><a href="#pasting-images" id="toc-pasting-images">Pasting images</a>
+<ul>
+<li><a href="#image_buffer:paste"
+id="toc-image_buffer:paste">image_buffer:paste(src, x, y)</a></li>
+</ul></li>
+<li><a href="#decodingencoding-pngs"
+id="toc-decodingencoding-pngs">Decoding/encoding PNGs</a>
+<ul>
+<li><a href="#am.encode_png"
+id="toc-am.encode_png">am.encode_png(image_buffer)</a></li>
+<li><a href="#am.decode_png"
+id="toc-am.decode_png">am.decode_png(buffer)</a></li>
+</ul></li>
+</ul></li>
+<li><a href="#textures" id="toc-textures">Textures</a>
+<ul>
+<li><a href="#creating-a-texture" id="toc-creating-a-texture">Creating a
+texture</a>
+<ul>
+<li><a href="#am.texture2d" id="toc-am.texture2d">am.texture2d(width [,
+height])</a></li>
+<li><a href="#am.texture2dimage_buffer"
+id="toc-am.texture2dimage_buffer">am.texture2d(image_buffer)</a></li>
+<li><a href="#am.texture2dfilename"
+id="toc-am.texture2dfilename">am.texture2d(filename)</a></li>
+</ul></li>
+<li><a href="#texture-fields" id="toc-texture-fields">Texture fields</a>
+<ul>
+<li><a href="#texture.width"
+id="toc-texture.width">texture.width</a></li>
+<li><a href="#texture.height"
+id="toc-texture.height">texture.height</a></li>
+<li><a href="#texture.image_buffer"
+id="toc-texture.image_buffer">texture.image_buffer</a></li>
+<li><a href="#texture.minfilter"
+id="toc-texture.minfilter">texture.minfilter</a></li>
+<li><a href="#texture.magfilter"
+id="toc-texture.magfilter">texture.magfilter</a></li>
+<li><a href="#texture.filter"
+id="toc-texture.filter">texture.filter</a></li>
+<li><a href="#texture.swrap"
+id="toc-texture.swrap">texture.swrap</a></li>
+<li><a href="#texture.twrap"
+id="toc-texture.twrap">texture.twrap</a></li>
+<li><a href="#texture.wrap" id="toc-texture.wrap">texture.wrap</a></li>
+</ul></li>
+</ul></li>
+<li><a href="#framebuffers" id="toc-framebuffers">Framebuffers</a>
+<ul>
+<li><a href="#creating-a-framebuffer"
+id="toc-creating-a-framebuffer">Creating a framebuffer</a>
+<ul>
+<li><a href="#am.framebuffer"
+id="toc-am.framebuffer">am.framebuffer(texture [, depth_buf [,
+stencil_buf]])</a></li>
+</ul></li>
+<li><a href="#framebuffer-fields"
+id="toc-framebuffer-fields">Framebuffer fields</a>
+<ul>
+<li><a href="#framebuffer.clear_color"
+id="toc-framebuffer.clear_color">framebuffer.clear_color</a></li>
+<li><a href="#framebuffer.stencil_clear_value"
+id="toc-framebuffer.stencil_clear_value">framebuffer.stencil_clear_value</a></li>
+<li><a href="#framebuffer.projection"
+id="toc-framebuffer.projection">framebuffer.projection</a></li>
+<li><a href="#framebuffer.pixel_width"
+id="toc-framebuffer.pixel_width">framebuffer.pixel_width</a></li>
+<li><a href="#framebuffer.pixel_height"
+id="toc-framebuffer.pixel_height">framebuffer.pixel_height</a></li>
+</ul></li>
+<li><a href="#framebuffer-methods"
+id="toc-framebuffer-methods">Framebuffer methods</a>
+<ul>
+<li><a href="#framebuffer:render"
+id="toc-framebuffer:render">framebuffer:render(node)</a></li>
+<li><a href="#framebuffer:render_children"
+id="toc-framebuffer:render_children">framebuffer:render_children(node)</a></li>
+<li><a href="#framebuffer:clear"
+id="toc-framebuffer:clear">framebuffer:clear([color [, depth [,
+stencil]]])</a></li>
+<li><a href="#framebuffer:read_back"
+id="toc-framebuffer:read_back">framebuffer:read_back()</a></li>
+<li><a href="#framebuffer:resize"
+id="toc-framebuffer:resize">framebuffer:resize(width, height)</a></li>
+</ul></li>
+</ul></li>
+<li><a href="#actions-1" id="toc-actions-1">Actions</a>
+<ul>
+<li><a href="#delay-action" id="toc-delay-action">Delay action</a>
+<ul>
+<li><a href="#am.delay" id="toc-am.delay">am.delay(seconds)</a></li>
+</ul></li>
+<li><a href="#combining-actions" id="toc-combining-actions">Combining
+actions</a>
+<ul>
+<li><a href="#am.series" id="toc-am.series">am.series(actions)</a></li>
+<li><a href="#am.parallel"
+id="toc-am.parallel">am.parallel(actions)</a></li>
+<li><a href="#am.loop" id="toc-am.loop">am.loop(func)</a></li>
+</ul></li>
+<li><a href="#tweens" id="toc-tweens">Tweens</a>
+<ul>
+<li><a href="#am.tween" id="toc-am.tween">am.tween([target,] time,
+values [, ease])</a></li>
+</ul></li>
+<li><a href="#coroutine-actions" id="toc-coroutine-actions">Coroutine
+actions</a>
+<ul>
+<li><a href="#am.wait" id="toc-am.wait">am.wait(action)</a></li>
+</ul></li>
+</ul></li>
+<li><a href="#time" id="toc-time">Time</a>
+<ul>
+<li><a href="#frame-time" id="toc-frame-time">Frame time</a>
+<ul>
+<li><a href="#am.frame_time"
+id="toc-am.frame_time">am.frame_time</a></li>
+</ul></li>
+<li><a href="#delta-time" id="toc-delta-time">Delta time</a>
+<ul>
+<li><a href="#am.delta_time"
+id="toc-am.delta_time">am.delta_time</a></li>
+</ul></li>
+<li><a href="#real-time" id="toc-real-time">Real time</a>
+<ul>
+<li><a href="#am.current_time"
+id="toc-am.current_time">am.current_time()</a></li>
+</ul></li>
+</ul></li>
+<li><a href="#saving-and-loading-state"
+id="toc-saving-and-loading-state">Saving and loading state</a>
+<ul>
+<li><a href="#am.save_statekey-state-format"
+id="toc-am.save_statekey-state-format">am.save_state(key, state
+[,format])</a></li>
+<li><a href="#am.load_statekey-format"
+id="toc-am.load_statekey-format">am.load_state(key, [,format])</a></li>
+</ul></li>
+<li><a href="#audio" id="toc-audio">Audio</a>
+<ul>
+<li><a href="#audio-buffers" id="toc-audio-buffers">Audio buffers</a>
+<ul>
+<li><a href="#am.audio_buffer"
+id="toc-am.audio_buffer">am.audio_buffer(buffer, channels,
+sample_rate)</a></li>
+<li><a href="#am.load_audio"
+id="toc-am.load_audio">am.load_audio(filename)</a></li>
+</ul></li>
+<li><a href="#audio-buffer-fields" id="toc-audio-buffer-fields">Audio
+buffer fields</a>
+<ul>
+<li><a href="#audio_buffer.channels"
+id="toc-audio_buffer.channels">audio_buffer.channels</a></li>
+<li><a href="#audio_buffer.sample_rate"
+id="toc-audio_buffer.sample_rate">audio_buffer.sample_rate</a></li>
+<li><a href="#audio_buffer.samples_per_channel"
+id="toc-audio_buffer.samples_per_channel">audio_buffer.samples_per_channel</a></li>
+<li><a href="#audio_buffer.length"
+id="toc-audio_buffer.length">audio_buffer.length</a></li>
+<li><a href="#audio_buffer.buffer"
+id="toc-audio_buffer.buffer">audio_buffer.buffer</a></li>
+</ul></li>
+<li><a href="#audio-tracks" id="toc-audio-tracks">Audio tracks</a>
+<ul>
+<li><a href="#am.track" id="toc-am.track">am.track(buffer [, loop [,
+playback_speed [, volume]]])</a></li>
+</ul></li>
+<li><a href="#audio-track-fields" id="toc-audio-track-fields">Audio
+track fields</a>
+<ul>
+<li><a href="#track.playback_speed"
+id="toc-track.playback_speed">track.playback_speed</a></li>
+<li><a href="#track.volume" id="toc-track.volume">track.volume</a></li>
+</ul></li>
+<li><a href="#audio-track-methods" id="toc-audio-track-methods">Audio
+track methods</a>
+<ul>
+<li><a href="#track:reset"
+id="toc-track:reset">track:reset([position])</a></li>
+</ul></li>
+<li><a href="#playing-audio-1" id="toc-playing-audio-1">Playing
+audio</a>
+<ul>
+<li><a href="#am.play" id="toc-am.play">am.play(source, loop, pitch,
+volume)</a></li>
+</ul></li>
+<li><a href="#generating-sound-effects"
+id="toc-generating-sound-effects">Generating sound effects</a>
+<ul>
+<li><a href="#am.sfxr_synth"
+id="toc-am.sfxr_synth">am.sfxr_synth(settings)</a></li>
+</ul></li>
+<li><a href="#audio-graphs" id="toc-audio-graphs">Audio graphs</a></li>
+<li><a href="#audio-graph-nodes" id="toc-audio-graph-nodes">Audio graph
+nodes</a></li>
+<li><a href="#analysing-audio" id="toc-analysing-audio">Analysing
+audio</a></li>
+</ul></li>
+<li><a href="#controllers" id="toc-controllers">Controllers</a>
+<ul>
+<li><a href="#am.controller_present"
+id="toc-am.controller_present">am.controller_present(index)</a></li>
+<li><a href="#am.controller_attached"
+id="toc-am.controller_attached">am.controller_attached(index)</a></li>
+<li><a href="#am.controller_detached"
+id="toc-am.controller_detached">am.controller_detached(index)</a></li>
+<li><a href="#am.controllers_present"
+id="toc-am.controllers_present">am.controllers_present()</a></li>
+<li><a href="#am.controllers_attached"
+id="toc-am.controllers_attached">am.controllers_attached()</a></li>
+<li><a href="#am.controllers_detached"
+id="toc-am.controllers_detached">am.controllers_detached()</a></li>
+<li><a href="#am.controller_lt_val"
+id="toc-am.controller_lt_val">am.controller_lt_val(index)</a></li>
+<li><a href="#am.controller_rt_val"
+id="toc-am.controller_rt_val">am.controller_rt_val(index)</a></li>
+<li><a href="#am.controller_lstick_pos"
+id="toc-am.controller_lstick_pos">am.controller_lstick_pos(index)</a></li>
+<li><a href="#am.controller_rstick_pos"
+id="toc-am.controller_rstick_pos">am.controller_rstick_pos(index)</a></li>
+<li><a href="#am.controller_button_pressed"
+id="toc-am.controller_button_pressed">am.controller_button_pressed(index,
+button)</a></li>
+<li><a href="#am.controller_button_released"
+id="toc-am.controller_button_released">am.controller_button_released(index,
+button)</a></li>
+<li><a href="#am.controller_button_down"
+id="toc-am.controller_button_down">am.controller_button_down(index,
+button)</a></li>
+</ul></li>
+<li><a href="#spritepack" id="toc-spritepack">Packing sprites and
+generating fonts</a>
+<ul>
+<li><a href="#overview" id="toc-overview">Overview</a></li>
+<li><a href="#pack-options" id="toc-pack-options">Pack options</a></li>
+<li><a href="#padding" id="toc-padding">Padding</a></li>
+<li><a href="#specifying-which-font-glyphs-to-generate"
+id="toc-specifying-which-font-glyphs-to-generate">Specifying which font
+glyphs to generate</a></li>
+<li><a href="#loading-bitmap-font-images"
+id="toc-loading-bitmap-font-images">Loading bitmap font images</a>
+<ul>
+<li><a href="#am.load_bitmap_font"
+id="toc-am.load_bitmap_font">am.load_bitmap_font(filename, key)</a></li>
+</ul></li>
+</ul></li>
+<li><a href="#exporting" id="toc-exporting">Exporting</a></li>
+<li><a href="#config" id="toc-config">Project Configuration</a>
+<ul>
+<li><a href="#basic-metadata" id="toc-basic-metadata">Basic
+metadata</a></li>
+<li><a href="#language-configuration"
+id="toc-language-configuration">Language configuration</a></li>
+<li><a href="#lua-version" id="toc-lua-version">Lua version</a></li>
+<li><a href="#windows-settings" id="toc-windows-settings">Windows
+settings</a></li>
+<li><a href="#mac-settings" id="toc-mac-settings">Mac settings</a></li>
+<li><a href="#ios-settings" id="toc-ios-settings">iOS settings</a></li>
+<li><a href="#android-settings" id="toc-android-settings">Android
+settings</a></li>
+</ul></li>
+<li><a href="#d-models" id="toc-d-models">3D models</a>
+<ul>
+<li><a href="#am.load_obj"
+id="toc-am.load_obj">am.load_obj(filename)</a></li>
+</ul></li>
+<li><a href="#extra-table-functions"
+id="toc-extra-table-functions">Extra table functions</a>
+<ul>
+<li><a href="#table.shallow_copy"
+id="toc-table.shallow_copy">table.shallow_copy(t)</a></li>
+<li><a href="#table.deep_copy"
+id="toc-table.deep_copy">table.deep_copy(t)</a></li>
+<li><a href="#table.search" id="toc-table.search">table.search(arr,
+elem)</a></li>
+<li><a href="#table.shuffle" id="toc-table.shuffle">table.shuffle(t
+[,rand])</a></li>
+<li><a href="#table.clear" id="toc-table.clear">table.clear(t)</a></li>
+<li><a href="#table.remove_all"
+id="toc-table.remove_all">table.remove_all(arr, elem)</a></li>
+<li><a href="#table.append" id="toc-table.append">table.append(arr1,
+arr2)</a></li>
+<li><a href="#table.merge" id="toc-table.merge">table.merge(t1,
+t2)</a></li>
+<li><a href="#table.keys" id="toc-table.keys">table.keys(t)</a></li>
+<li><a href="#table.values"
+id="toc-table.values">table.values(t)</a></li>
+<li><a href="#table.filter" id="toc-table.filter">table.filter(arr,
+f)</a></li>
+<li><a href="#table.tostring"
+id="toc-table.tostring">table.tostring(t)</a></li>
+<li><a href="#table.count" id="toc-table.count">table.count(t)</a></li>
+</ul></li>
+<li><a href="#deriving-amulet-types"
+id="toc-deriving-amulet-types">Deriving Amulet Types</a>
+<ul>
+<li><a href="#am.type" id="toc-am.type">am.type(value)</a></li>
+</ul></li>
+<li><a href="#amulet-require-function"
+id="toc-amulet-require-function">Amulet require function</a></li>
+<li><a href="#logging" id="toc-logging">Logging</a>
+<ul>
+<li><a href="#log" id="toc-log">log(msg, …)</a></li>
+</ul></li>
+<li><a href="#preventing-accidental-global-variable-usage"
+id="toc-preventing-accidental-global-variable-usage">Preventing
+accidental global variable usage</a>
+<ul>
+<li><a href="#noglobals" id="toc-noglobals">noglobals()</a></li>
+</ul></li>
+<li><a href="#globbing" id="toc-globbing">Globbing</a>
+<ul>
+<li><a href="#am.glob" id="toc-am.glob">am.glob(patterns)</a></li>
+</ul></li>
+<li><a href="#running-javascript" id="toc-running-javascript">Running
+JavaScript</a>
+<ul>
+<li><a href="#am.eval_js" id="toc-am.eval_js">am.eval_js(js)</a></li>
+</ul></li>
+<li><a href="#converting-tofrom-json"
+id="toc-converting-tofrom-json">Converting to/from JSON</a>
+<ul>
+<li><a href="#am.to_json" id="toc-am.to_json">am.to_json(value)</a></li>
+<li><a href="#am.parse_json"
+id="toc-am.parse_json">am.parse_json(json)</a></li>
+</ul></li>
+<li><a href="#loading-other-resources"
+id="toc-loading-other-resources">Loading other resources</a>
+<ul>
+<li><a href="#am.load_script"
+id="toc-am.load_script">am.load_script(filename)</a></li>
+<li><a href="#am.load_string"
+id="toc-am.load_string">am.load_string(filename)</a></li>
+</ul></li>
+<li><a href="#performance-stats" id="toc-performance-stats">Performance
+stats</a>
+<ul>
+<li><a href="#am.perf_stats"
+id="toc-am.perf_stats">am.perf_stats()</a></li>
+</ul></li>
+<li><a href="#amulet-version" id="toc-amulet-version">Amulet version</a>
+<ul>
+<li><a href="#am.version" id="toc-am.version">am.version</a></li>
+</ul></li>
+<li><a href="#platform" id="toc-platform">Platform</a>
+<ul>
+<li><a href="#am.platform" id="toc-am.platform">am.platform</a></li>
+</ul></li>
+<li><a href="#language" id="toc-language">Language</a>
+<ul>
+<li><a href="#am.language" id="toc-am.language">am.language()</a></li>
+</ul></li>
+<li><a href="#game-center-ios-only" id="toc-game-center-ios-only">Game
+Center (iOS only)</a>
+<ul>
+<li><a href="#am.init_gamecenter"
+id="toc-am.init_gamecenter">am.init_gamecenter()</a></li>
+<li><a href="#am.gamecenter_available"
+id="toc-am.gamecenter_available">am.gamecenter_available()</a></li>
+<li><a href="#am.submit_gamecenter_score"
+id="toc-am.submit_gamecenter_score">am.submit_gamecenter_score(leaderboard_id,
+score)</a></li>
+<li><a href="#am.submit_gamecenter_achievement"
+id="toc-am.submit_gamecenter_achievement">am.submit_gamecenter_achievement(achievment_id)</a></li>
+<li><a href="#am.show_gamecenter_leaderboard"
+id="toc-am.show_gamecenter_leaderboard">am.show_gamecenter_leaderboard(leaderboard_id)</a></li>
 </ul></li>
 </ul>
 </nav>
@@ -506,8 +913,12 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 <!--<h2 class="author">Ian MacLarty</h2>-->
 </header>
 <h1 id="introduction">Introduction</h1>
-<p>Amulet is a Lua-based toolkit for experimenting with interactive graphics and audio. It provides a cross-platform API for drawing graphics, playing audio and responding to user input, and a command-line interpreter for running Amulet scripts.</p>
-<p>It tries to be simple to use, but without making too many assumptions about how you want to use it.</p>
+<p>Amulet is a Lua-based toolkit for experimenting with interactive
+graphics and audio. It provides a cross-platform API for drawing
+graphics, playing audio and responding to user input, and a command-line
+interpreter for running Amulet scripts.</p>
+<p>It tries to be simple to use, but without making too many assumptions
+about how you want to use it.</p>
 <p>Amulet currently runs on the following platforms:</p>
 <ul>
 <li>Windows 7+ (Intel 32 and 64 bit, Direct3D or OpenGL)</li>
@@ -518,657 +929,875 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 <li>Android (ARM 32 and 64 bit, OpenGLES)</li>
 </ul>
 <h1 id="how-to-use-this-document">How to use this document</h1>
-<p>If you have some programming experience, but are new to Lua then the <a href="#lua-primer">Lua primer</a> should bring you up to speed.</p>
-<p>The <a href="#quickstart">quickstart tutorial</a> introduces basic concepts and walks you through drawing things on screen, playing audio and responding to user input.</p>
-<p>The <a href="http://www.amulet.xyz/editor.html">online editor</a> contains numerous examples you can experiment with from your browser.</p>
-<p>If you see a function argument with square brackets around it in a function signature, then that argument is optional.</p>
-<div class="figure">
-<img src="images/screenshot7.jpg" />
-
-</div>
+<p>If you have some programming experience, but are new to Lua then the
+<a href="#lua-primer">Lua primer</a> should bring you up to speed.</p>
+<p>The <a href="#quickstart">quickstart tutorial</a> introduces basic
+concepts and walks you through drawing things on screen, playing audio
+and responding to user input.</p>
+<p>The <a href="http://www.amulet.xyz/editor.html">online editor</a>
+contains numerous examples you can experiment with from your
+browser.</p>
+<p>If you see a function argument with square brackets around it in a
+function signature, then that argument is optional.</p>
+<p><img src="images/screenshot7.jpg" /></p>
 <h1 id="lua-primer">Lua primer</h1>
-<p>Amulet code is written in <a href="http://www.lua.org">Lua</a>. The version of Lua used by default is LuaJIT-2 on Windows, Mac and Linux and Lua-5.1 on all other platforms.</p>
-<p>What follows is a quick introduction to Lua. For more detail please see the <a href="http://www.lua.org/manual/5.1/">Lua manual</a>.</p>
+<p>Amulet code is written in <a href="http://www.lua.org">Lua</a>. The
+version of Lua used by default is LuaJIT-2 on Windows, Mac and Linux and
+Lua-5.1 on all other platforms.</p>
+<p>What follows is a quick introduction to Lua. For more detail please
+see the <a href="http://www.lua.org/manual/5.1/">Lua manual</a>.</p>
 <p><strong>Comments:</strong></p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="do">-- This is a single line comment</span>
-
-<span class="do">--[[ This is</span>
-<span class="do">a multi-line</span>
-<span class="do">comment ]]</span></code></pre></div>
+<div class="sourceCode" id="cb1"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- This is a single line comment</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="co">--[[ This is</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="co">a multi-line</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a><span class="co">comment ]]</span></span></code></pre></div>
 <p><strong>Local variables (block scope):</strong></p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> x <span class="ot">=</span> <span class="dv">3.14</span> <span class="do">-- a number</span>
-<span class="kw">local</span> str <span class="ot">=</span> <span class="st">&quot;a string&quot;</span>
-<span class="kw">local</span> str2 <span class="ot">=</span> <span class="st">[[</span>
-<span class="st">a</span>
-<span class="st">multi-line</span>
-<span class="st">string]]</span>
-<span class="kw">local</span> bool <span class="ot">=</span> <span class="kw">true</span> <span class="do">-- a bool, can also be false</span>
-<span class="kw">local</span> y <span class="ot">=</span> <span class="kw">nil</span> <span class="do">-- nil value</span>
-<span class="kw">local</span> v1<span class="ot">,</span> v2 <span class="ot">=</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span> <span class="do">-- create two local variables at once</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> x <span class="op">=</span> <span class="dv">3.14</span> <span class="co">-- a number</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> str <span class="op">=</span> <span class="st">&quot;a string&quot;</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> str2 <span class="op">=</span> <span class="vs">[[</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a><span class="vs">a</span></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a><span class="vs">multi-line</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a><span class="vs">string]]</span></span>
+<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> bool <span class="op">=</span> <span class="kw">true</span> <span class="co">-- a bool, can also be false</span></span>
+<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> y <span class="op">=</span> <span class="kw">nil</span> <span class="co">-- nil value</span></span>
+<span id="cb2-9"><a href="#cb2-9" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> v1<span class="op">,</span> v2 <span class="op">=</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">2</span> <span class="co">-- create two local variables at once</span></span></code></pre></div>
 <p><strong>Global variables:</strong></p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">score <span class="ot">=</span> <span class="dv">0</span>
-title <span class="ot">=</span> <span class="st">&quot;My Game&quot;</span></code></pre></div>
+<div class="sourceCode" id="cb3"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a>score <span class="op">=</span> <span class="dv">0</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>title <span class="op">=</span> <span class="st">&quot;My Game&quot;</span></span></code></pre></div>
 <p><strong>If-then-else:</strong></p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> x <span class="ot">=</span> <span class="dv">2</span>
-<span class="kw">if</span> x <span class="ot">&gt;</span> <span class="dv">1</span> <span class="kw">then</span>
-    <span class="fu">print</span><span class="ot">(</span><span class="st">&quot;x &gt; 1&quot;</span><span class="ot">)</span>
-<span class="kw">elseif</span> x <span class="ot">&gt;</span> <span class="dv">0</span> <span class="kw">then</span>
-    <span class="fu">print</span><span class="ot">(</span><span class="st">&quot;0 &lt; x &lt;= 0&quot;</span><span class="ot">)</span>
-<span class="kw">else</span>
-    <span class="fu">print</span><span class="ot">(</span><span class="st">&quot;x &lt;= 0&quot;</span><span class="ot">)</span>
-<span class="kw">end</span></code></pre></div>
-<p>The else part of an if-then-else executes only if the condition evaluates to <code>false</code> or <code>nil</code>.</p>
+<div class="sourceCode" id="cb4"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> x <span class="op">=</span> <span class="dv">2</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> x <span class="op">&gt;</span> <span class="dv">1</span> <span class="cf">then</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span><span class="st">&quot;x &gt; 1&quot;</span><span class="op">)</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a><span class="cf">elseif</span> x <span class="op">&gt;</span> <span class="dv">0</span> <span class="cf">then</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span><span class="st">&quot;0 &lt; x &lt;= 0&quot;</span><span class="op">)</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a><span class="cf">else</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span><span class="st">&quot;x &lt;= 0&quot;</span><span class="op">)</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span></span></code></pre></div>
+<p>The else part of an if-then-else executes only if the condition
+evaluates to <code>false</code> or <code>nil</code>.</p>
 <p><strong>While loop:</strong></p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> n <span class="ot">=</span> <span class="dv">5</span>
-<span class="kw">while</span> n <span class="ot">&gt;</span> <span class="dv">0</span> <span class="kw">do</span>
-    <span class="fu">print</span><span class="ot">(</span>n<span class="ot">)</span>
-    n <span class="ot">=</span> n <span class="ot">-</span> <span class="dv">1</span>
-<span class="kw">end</span>
-<span class="do">-- prints 5 4 3 2 1</span></code></pre></div>
+<div class="sourceCode" id="cb5"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> n <span class="op">=</span> <span class="dv">5</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="cf">while</span> n <span class="op">&gt;</span> <span class="dv">0</span> <span class="cf">do</span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span>n<span class="op">)</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>    n <span class="op">=</span> n <span class="op">-</span> <span class="dv">1</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a><span class="co">-- prints 5 4 3 2 1</span></span></code></pre></div>
 <p><strong>Repeat-until loop:</strong></p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> n <span class="ot">=</span> <span class="dv">0</span>
-<span class="kw">repeat</span>
-    n <span class="ot">=</span> n <span class="ot">+</span> <span class="dv">1</span>
-    <span class="fu">print</span><span class="ot">(</span>n<span class="ot">)</span>
-<span class="kw">until</span> n <span class="ot">==</span> <span class="dv">5</span>
-<span class="do">-- prints 1 2 3 4 5</span></code></pre></div>
+<div class="sourceCode" id="cb6"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> n <span class="op">=</span> <span class="dv">0</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="cf">repeat</span></span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a>    n <span class="op">=</span> n <span class="op">+</span> <span class="dv">1</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span>n<span class="op">)</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a><span class="cf">until</span> n <span class="op">==</span> <span class="dv">5</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a><span class="co">-- prints 1 2 3 4 5</span></span></code></pre></div>
 <p><strong>For loop:</strong></p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">for</span> i <span class="ot">=</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">5</span> <span class="kw">do</span>
-    <span class="fu">print</span><span class="ot">(</span>i<span class="ot">)</span>
-<span class="kw">end</span>
-<span class="do">-- prints 1 2 3 4 5</span>
-<span class="kw">for</span> j <span class="ot">=</span> <span class="dv">10</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">2</span> <span class="kw">do</span>
-    <span class="fu">print</span><span class="ot">(</span>j<span class="ot">)</span>
-<span class="kw">end</span>
-<span class="do">-- prints 10 8 6 4 2</span></code></pre></div>
-<p>You can break out of a loop using the <code>break</code> statement:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">for</span> j <span class="ot">=</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">10</span> <span class="kw">do</span>
-    <span class="fu">print</span><span class="ot">(</span>j<span class="ot">)</span>
-    <span class="kw">if</span> j <span class="ot">==</span> <span class="dv">5</span> <span class="kw">then</span>
-        <span class="kw">break</span>
-    <span class="kw">end</span>
-<span class="kw">end</span>
-<span class="do">-- prints 1 2 3 4 5</span></code></pre></div>
+<div class="sourceCode" id="cb7"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> i <span class="op">=</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">5</span> <span class="cf">do</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span>i<span class="op">)</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a><span class="co">-- prints 1 2 3 4 5</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> j <span class="op">=</span> <span class="dv">10</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="op">-</span><span class="dv">2</span> <span class="cf">do</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span>j<span class="op">)</span></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a><span class="co">-- prints 10 8 6 4 2</span></span></code></pre></div>
+<p>You can break out of a loop using the <code>break</code>
+statement:</p>
+<div class="sourceCode" id="cb8"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> j <span class="op">=</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">10</span> <span class="cf">do</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span>j<span class="op">)</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> j <span class="op">==</span> <span class="dv">5</span> <span class="cf">then</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>        <span class="cf">break</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">end</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a><span class="co">-- prints 1 2 3 4 5</span></span></code></pre></div>
 <p><strong>Operators:</strong></p>
-<p>The arithmetic operators are: <code>+</code>, <code>-</code>, <code>*</code>, <code>/</code>, <code>^</code> (exponent) and <code>%</code> (modulo).</p>
-<p>Note that Amulet also overloads the <code>^</code> operator for constructing scene graphs (see <a href="#scene-graph-syntax">here</a> for more details).</p>
-<p>The relational operators are: <code>==</code>, <code>~=</code> (not equal), <code>&lt;</code>, <code>&gt;</code>, <code>&lt;=</code> and <code>&gt;=</code></p>
-<p>The logical operators are: <code>and</code>, <code>or</code> and <code>not</code>.</p>
-<p>The string concatenation operator is two dots (e.g. <code>&quot;abc&quot;..&quot;def&quot;</code>).</p>
+<p>The arithmetic operators are: <code>+</code>, <code>-</code>,
+<code>*</code>, <code>/</code>, <code>^</code> (exponent) and
+<code>%</code> (modulo).</p>
+<p>Note that Amulet also overloads the <code>^</code> operator for
+constructing scene graphs (see <a href="#scene-graph-syntax">here</a>
+for more details).</p>
+<p>The relational operators are: <code>==</code>, <code>~=</code> (not
+equal), <code>&lt;</code>, <code>&gt;</code>, <code>&lt;=</code> and
+<code>&gt;=</code></p>
+<p>The logical operators are: <code>and</code>, <code>or</code> and
+<code>not</code>.</p>
+<p>The string concatenation operator is two dots
+(e.g. <code>"abc".."def"</code>).</p>
 <p><strong>Tables:</strong></p>
-<p>Tables are the only data structure in Lua. They can be used as key-value maps or arrays.</p>
+<p>Tables are the only data structure in Lua. They can be used as
+key-value maps or arrays.</p>
 <p>Keys and values can be of any type except <code>nil</code>.</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> t <span class="ot">=</span> <span class="ot">{}</span> <span class="do">-- create empty table</span>
-t<span class="ot">[</span><span class="st">&quot;score&quot;</span><span class="ot">]</span> <span class="ot">=</span> <span class="dv">10</span>
-t<span class="ot">[</span><span class="dv">1</span><span class="ot">]</span> <span class="ot">=</span> <span class="st">&quot;foo&quot;</span>
-t<span class="ot">[</span><span class="kw">true</span><span class="ot">]</span> <span class="ot">=</span> <span class="st">&quot;x&quot;</span>
-
-<span class="do">-- this creates a table with 2 string keys:</span>
-<span class="kw">local</span> t2 <span class="ot">=</span> <span class="ot">{</span>foo <span class="ot">=</span> <span class="st">&quot;bar&quot;</span><span class="ot">,</span> baz <span class="ot">=</span> <span class="dv">123</span><span class="ot">}</span></code></pre></div>
+<div class="sourceCode" id="cb9"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> t <span class="op">=</span> <span class="op">{}</span> <span class="co">-- create empty table</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>t<span class="op">[</span><span class="st">&quot;score&quot;</span><span class="op">]</span> <span class="op">=</span> <span class="dv">10</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>t<span class="op">[</span><span class="dv">1</span><span class="op">]</span> <span class="op">=</span> <span class="st">&quot;foo&quot;</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>t<span class="op">[</span><span class="kw">true</span><span class="op">]</span> <span class="op">=</span> <span class="st">&quot;x&quot;</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a><span class="co">-- this creates a table with 2 string keys:</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> t2 <span class="op">=</span> <span class="op">{</span>foo <span class="op">=</span> <span class="st">&quot;bar&quot;</span><span class="op">,</span> baz <span class="op">=</span> <span class="dv">123</span><span class="op">}</span></span></code></pre></div>
 <p>Special syntax is provided for string keys:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> t <span class="ot">=</span> <span class="ot">{}</span>
-t<span class="ot">.</span>score <span class="ot">=</span> <span class="dv">10</span>
-<span class="fu">print</span><span class="ot">(</span>t<span class="ot">.</span>score<span class="ot">)</span></code></pre></div>
-<p>The <code>#</code> operator returns the length of an array and array indices start at 1 by default.</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> arr <span class="ot">=</span> <span class="ot">{</span><span class="dv">3</span><span class="ot">,</span> <span class="dv">4</span><span class="ot">,</span> <span class="dv">5</span><span class="ot">}</span>
-<span class="kw">for</span> i <span class="ot">=</span> <span class="dv">1</span><span class="ot">,</span> <span class="ot">#</span>arr <span class="kw">do</span>
-    <span class="fu">print</span><span class="ot">(</span>arr<span class="ot">[</span>i<span class="ot">])</span>
-<span class="kw">end</span>
-<span class="do">-- prints 3, 4, 5</span>
-<span class="fu">table.insert</span><span class="ot">(</span>arr<span class="ot">,</span> <span class="dv">6</span><span class="ot">)</span> <span class="do">-- appends 6 to end of arr</span>
-<span class="fu">table.remove</span><span class="ot">(</span>arr<span class="ot">,</span> <span class="dv">1</span><span class="ot">)</span> <span class="do">-- removes the first element of arr</span>
-<span class="do">-- arr is now {4, 5, 6}</span></code></pre></div>
-<p>Setting a key's value to <code>nil</code> removes the key and indexing a missing key returns <code>nil</code>.</p>
-<p>You can iterate over all key/value pairs using the <code>pairs</code> function. Note that the order is not preserved.</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> t <span class="ot">=</span> <span class="ot">{</span>a <span class="ot">=</span> <span class="dv">1</span><span class="ot">,</span> b <span class="ot">=</span> <span class="dv">2</span><span class="ot">,</span> c <span class="ot">=</span> <span class="dv">3</span><span class="ot">}</span>
-<span class="kw">for</span> k<span class="ot">,</span> v <span class="kw">in</span> <span class="fu">pairs</span><span class="ot">(</span>t<span class="ot">)</span> <span class="kw">do</span>
-    <span class="fu">print</span><span class="ot">(</span>k<span class="ot">..</span><span class="st">&quot;:&quot;</span><span class="ot">..</span>v<span class="ot">)</span>
-<span class="kw">end</span>
-<span class="do">-- prints a:1 c:3 b:2</span></code></pre></div>
-<p>To iterate over an array table, keeping the order, use <code>ipairs</code>:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> arr <span class="ot">=</span> <span class="ot">{</span><span class="st">&quot;a&quot;</span><span class="ot">,</span> <span class="st">&quot;b&quot;</span><span class="ot">,</span> <span class="st">&quot;c&quot;</span><span class="ot">}</span>
-<span class="kw">for</span> k<span class="ot">,</span> v <span class="kw">in</span> <span class="fu">ipairs</span><span class="ot">(</span>arr<span class="ot">)</span> <span class="kw">do</span>
-    <span class="fu">print</span><span class="ot">(</span>k<span class="ot">..</span><span class="st">&quot;:&quot;</span><span class="ot">..</span>v<span class="ot">)</span>
-<span class="kw">end</span>
-<span class="do">-- prints 1:a 2:b 3:c</span></code></pre></div>
+<div class="sourceCode" id="cb10"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> t <span class="op">=</span> <span class="op">{}</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>t<span class="op">.</span>score <span class="op">=</span> <span class="dv">10</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>t<span class="op">.</span>score<span class="op">)</span></span></code></pre></div>
+<p>The <code>#</code> operator returns the length of an array and array
+indices start at 1 by default.</p>
+<div class="sourceCode" id="cb11"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> arr <span class="op">=</span> <span class="op">{</span><span class="dv">3</span><span class="op">,</span> <span class="dv">4</span><span class="op">,</span> <span class="dv">5</span><span class="op">}</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> i <span class="op">=</span> <span class="dv">1</span><span class="op">,</span> <span class="op">#</span>arr <span class="cf">do</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span>arr<span class="op">[</span>i<span class="op">])</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a><span class="co">-- prints 3, 4, 5</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a><span class="fu">table.insert</span><span class="op">(</span>arr<span class="op">,</span> <span class="dv">6</span><span class="op">)</span> <span class="co">-- appends 6 to end of arr</span></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a><span class="fu">table.remove</span><span class="op">(</span>arr<span class="op">,</span> <span class="dv">1</span><span class="op">)</span> <span class="co">-- removes the first element of arr</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a><span class="co">-- arr is now {4, 5, 6}</span></span></code></pre></div>
+<p>Setting a key’s value to <code>nil</code> removes the key and
+indexing a missing key returns <code>nil</code>.</p>
+<p>You can iterate over all key/value pairs using the <code>pairs</code>
+function. Note that the order is not preserved.</p>
+<div class="sourceCode" id="cb12"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> t <span class="op">=</span> <span class="op">{</span>a <span class="op">=</span> <span class="dv">1</span><span class="op">,</span> b <span class="op">=</span> <span class="dv">2</span><span class="op">,</span> c <span class="op">=</span> <span class="dv">3</span><span class="op">}</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> k<span class="op">,</span> v <span class="kw">in</span> <span class="fu">pairs</span><span class="op">(</span>t<span class="op">)</span> <span class="cf">do</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span>k<span class="op">..</span><span class="st">&quot;:&quot;</span><span class="op">..</span>v<span class="op">)</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a><span class="co">-- prints a:1 c:3 b:2</span></span></code></pre></div>
+<p>To iterate over an array table, keeping the order, use
+<code>ipairs</code>:</p>
+<div class="sourceCode" id="cb13"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> arr <span class="op">=</span> <span class="op">{</span><span class="st">&quot;a&quot;</span><span class="op">,</span> <span class="st">&quot;b&quot;</span><span class="op">,</span> <span class="st">&quot;c&quot;</span><span class="op">}</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> k<span class="op">,</span> v <span class="kw">in</span> <span class="fu">ipairs</span><span class="op">(</span>arr<span class="op">)</span> <span class="cf">do</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span>k<span class="op">..</span><span class="st">&quot;:&quot;</span><span class="op">..</span>v<span class="op">)</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a><span class="co">-- prints 1:a 2:b 3:c</span></span></code></pre></div>
 <p><strong>Functions:</strong></p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">function</span> factorial<span class="ot">(</span>n<span class="ot">)</span>
-    <span class="kw">if</span> n <span class="ot">&lt;=</span> <span class="dv">1</span> <span class="kw">then</span>
-        <span class="kw">return</span> <span class="dv">1</span>
-    <span class="kw">else</span>
-        <span class="kw">return</span> n <span class="ot">*</span> factorial<span class="ot">(</span>n<span class="ot">-</span><span class="dv">1</span><span class="ot">)</span>
-    <span class="kw">end</span>
-<span class="kw">end</span>
-<span class="fu">print</span><span class="ot">(</span>factorial<span class="ot">(</span><span class="dv">3</span><span class="ot">))</span> <span class="do">-- prints 6</span></code></pre></div>
+<div class="sourceCode" id="cb14"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> factorial<span class="op">(</span>n<span class="op">)</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> n <span class="op">&lt;=</span> <span class="dv">1</span> <span class="cf">then</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> <span class="dv">1</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>    <span class="cf">else</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> n <span class="op">*</span> factorial<span class="op">(</span>n<span class="op">-</span><span class="dv">1</span><span class="op">)</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>    <span class="cf">end</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>factorial<span class="op">(</span><span class="dv">3</span><span class="op">))</span> <span class="co">-- prints 6</span></span></code></pre></div>
 <p>Functions are values in Lua so they can be assigned to variables:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> add <span class="ot">=</span> <span class="kw">function</span><span class="ot">(</span>a<span class="ot">,</span> b<span class="ot">)</span>
-    <span class="kw">return</span> a <span class="ot">+</span> b
-<span class="kw">end</span>
-<span class="fu">print</span><span class="ot">(</span>add<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">))</span> <span class="do">-- prints 3</span></code></pre></div>
+<div class="sourceCode" id="cb15"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> add <span class="op">=</span> <span class="kw">function</span><span class="op">(</span>a<span class="op">,</span> b<span class="op">)</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> a <span class="op">+</span> b</span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>add<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">))</span> <span class="co">-- prints 3</span></span></code></pre></div>
 <p>Special syntax is provided for adding functions to tables:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> t <span class="ot">=</span> <span class="ot">{}</span>
-<span class="kw">function</span> t<span class="ot">.</span>say_hello<span class="ot">()</span>
-    <span class="fu">print</span><span class="ot">(</span><span class="st">&quot;hello&quot;</span><span class="ot">)</span>
-<span class="kw">end</span></code></pre></div>
+<div class="sourceCode" id="cb16"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> t <span class="op">=</span> <span class="op">{}</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> t<span class="op">.</span>say_hello<span class="op">()</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span><span class="st">&quot;hello&quot;</span><span class="op">)</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
 <p>This is equivalent to:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> t <span class="ot">=</span> <span class="ot">{}</span>
-t<span class="ot">.</span>say_hello <span class="ot">=</span> <span class="kw">function</span><span class="ot">()</span>
-    <span class="fu">print</span><span class="ot">(</span><span class="st">&quot;hello&quot;</span><span class="ot">)</span>
-<span class="kw">end</span></code></pre></div>
-<p>Special syntactic sugar allows you to use function fields like methods in object oriented languages:</p>
+<div class="sourceCode" id="cb17"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> t <span class="op">=</span> <span class="op">{}</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>t<span class="op">.</span>say_hello <span class="op">=</span> <span class="kw">function</span><span class="op">()</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span><span class="st">&quot;hello&quot;</span><span class="op">)</span></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
+<p>Special syntactic sugar allows you to use function fields like
+methods in object oriented languages:</p>
 <p>The code:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">function</span> t:f<span class="ot">()</span>
-    <span class="ot">...</span>
-<span class="kw">end</span></code></pre></div>
+<div class="sourceCode" id="cb18"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> t<span class="op">:</span>f<span class="op">()</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>    <span class="op">...</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
 <p>is equivalent to:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">function</span> t<span class="ot">.</span>f<span class="ot">(</span>self<span class="ot">)</span>
-    <span class="ot">...</span>
-<span class="kw">end</span></code></pre></div>
+<div class="sourceCode" id="cb19"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> t<span class="op">.</span>f<span class="op">(</span>self<span class="op">)</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>    <span class="op">...</span></span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
 <p>and the code:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">t:f<span class="ot">()</span></code></pre></div>
+<div class="sourceCode" id="cb20"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a>t<span class="op">:</span>f<span class="op">()</span></span></code></pre></div>
 <p>is equivalent to:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">t<span class="ot">.</span>f<span class="ot">(</span>t<span class="ot">)</span></code></pre></div>
+<div class="sourceCode" id="cb21"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a>t<span class="op">.</span>f<span class="op">(</span>t<span class="op">)</span></span></code></pre></div>
 <p>For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> t <span class="ot">=</span> <span class="ot">{</span>x <span class="ot">=</span> <span class="dv">3</span><span class="ot">}</span>
-<span class="kw">function</span> t:print_x<span class="ot">()</span>
-    <span class="fu">print</span><span class="ot">(</span>self<span class="ot">.</span>x<span class="ot">)</span>
-<span class="kw">end</span>
-t:print_x<span class="ot">()</span>   <span class="do">-- prints 3</span>
-t<span class="ot">.</span>x <span class="ot">=</span> <span class="dv">4</span>
-t:print_x<span class="ot">()</span>   <span class="do">-- prints 4</span></code></pre></div>
-<p>If a function call has only a single string or table argument, the parentheses can be omitted:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span>
-<span class="kw">function</span> append_z<span class="ot">(</span>str<span class="ot">)</span>
-    <span class="kw">return</span> str<span class="ot">..</span><span class="st">&quot;z&quot;</span>
-<span class="kw">end</span>
-<span class="fu">print</span><span class="ot">(</span>append_z<span class="st">&quot;xy&quot;</span><span class="ot">)</span> <span class="do">-- prints xyz</span>
-
-<span class="kw">local</span>
-<span class="kw">function</span> sum<span class="ot">(</span>values<span class="ot">)</span>
-    <span class="kw">local</span> total <span class="ot">=</span> <span class="dv">0</span>
-    <span class="kw">for</span> _<span class="ot">,</span> value <span class="kw">in</span> <span class="fu">ipairs</span><span class="ot">(</span>values<span class="ot">)</span> <span class="kw">do</span>
-        total <span class="ot">=</span> total <span class="ot">+</span> value
-    <span class="kw">end</span>
-    <span class="kw">return</span> total
-<span class="kw">end</span>
-<span class="fu">print</span><span class="ot">(</span>sum<span class="ot">{</span><span class="dv">3</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">6</span><span class="ot">})</span> <span class="do">-- prints 10</span></code></pre></div>
+<div class="sourceCode" id="cb22"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> t <span class="op">=</span> <span class="op">{</span>x <span class="op">=</span> <span class="dv">3</span><span class="op">}</span></span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> t<span class="op">:</span>print_x<span class="op">()</span></span>
+<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span>self<span class="op">.</span>x<span class="op">)</span></span>
+<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a>t<span class="op">:</span>print_x<span class="op">()</span>   <span class="co">-- prints 3</span></span>
+<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a>t<span class="op">.</span>x <span class="op">=</span> <span class="dv">4</span></span>
+<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a>t<span class="op">:</span>print_x<span class="op">()</span>   <span class="co">-- prints 4</span></span></code></pre></div>
+<p>If a function call has only a single string or table argument, the
+parentheses can be omitted:</p>
+<div class="sourceCode" id="cb23"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span></span>
+<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> append_z<span class="op">(</span>str<span class="op">)</span></span>
+<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> str<span class="op">..</span><span class="st">&quot;z&quot;</span></span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>append_z<span class="st">&quot;xy&quot;</span><span class="op">)</span> <span class="co">-- prints xyz</span></span>
+<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span></span>
+<span id="cb23-8"><a href="#cb23-8" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> sum<span class="op">(</span>values<span class="op">)</span></span>
+<span id="cb23-9"><a href="#cb23-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">local</span> total <span class="op">=</span> <span class="dv">0</span></span>
+<span id="cb23-10"><a href="#cb23-10" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> <span class="cn">_</span><span class="op">,</span> value <span class="kw">in</span> <span class="fu">ipairs</span><span class="op">(</span>values<span class="op">)</span> <span class="cf">do</span></span>
+<span id="cb23-11"><a href="#cb23-11" aria-hidden="true" tabindex="-1"></a>        total <span class="op">=</span> total <span class="op">+</span> value</span>
+<span id="cb23-12"><a href="#cb23-12" aria-hidden="true" tabindex="-1"></a>    <span class="cf">end</span></span>
+<span id="cb23-13"><a href="#cb23-13" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> total</span>
+<span id="cb23-14"><a href="#cb23-14" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb23-15"><a href="#cb23-15" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>sum<span class="op">{</span><span class="dv">3</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">6</span><span class="op">})</span> <span class="co">-- prints 10</span></span></code></pre></div>
 <p>Functions may also return multiple values:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">function</span> f<span class="ot">()</span>
-    <span class="kw">return</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span>
-<span class="kw">end</span>
-<span class="kw">local</span> x<span class="ot">,</span> y <span class="ot">=</span> f<span class="ot">()</span>
-<span class="fu">print</span><span class="ot">(</span>x <span class="ot">+</span> y<span class="ot">)</span> <span class="do">-- prints 3</span></code></pre></div>
+<div class="sourceCode" id="cb24"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> f<span class="op">()</span></span>
+<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">2</span></span>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> x<span class="op">,</span> y <span class="op">=</span> f<span class="op">()</span></span>
+<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>x <span class="op">+</span> y<span class="op">)</span> <span class="co">-- prints 3</span></span></code></pre></div>
 <hr />
-<div class="figure">
-<img src="images/screenshot6.jpg" />
-
-</div>
+<p><img src="images/screenshot6.jpg" /></p>
 <h1 id="quickstart">Quickstart tutorial</h1>
 <h2 id="installing-amulet">Installing Amulet</h2>
 <p><strong>Windows:</strong></p>
-<p><a href="http://www.amulet.xyz">Download</a> the Windows installer and run it. Or, if you prefer, download the Windows zip archive, extract it to a directory of your choice and add that directory to your PATH.</p>
+<p><a href="http://www.amulet.xyz">Download</a> the Windows installer
+and run it. Or, if you prefer, download the Windows zip archive, extract
+it to a directory of your choice and add that directory to your
+PATH.</p>
 <p><strong>Mac:</strong></p>
-<p><a href="http://www.amulet.xyz">Download</a> the OSX pkg file and run it. Or, if you prefer, download the OSX zip archive, extract it to a directory of your choice and add that directory to your PATH.</p>
+<p><a href="http://www.amulet.xyz">Download</a> the OSX pkg file and run
+it. Or, if you prefer, download the OSX zip archive, extract it to a
+directory of your choice and add that directory to your PATH.</p>
 <p><strong>Linux:</strong></p>
-<p><a href="http://www.amulet.xyz">Download</a> and extract the Linux zip archive to a directory of your choice. Then add the directory to your PATH. The <code>amulet</code> executable is for x86_64. If you're running a 32 bit system, rename the file <code>amulet.i686</code> to <code>amulet</code>.</p>
-<p><strong>Online editor:</strong> There is also an <a href="http://www.amulet.xyz/editor.html">online editor</a> which you can use without having to download or install anything. However be aware that there are some limitations when using the online editor: you can't load image or audio files and only one lua module is allowed per project. These restrictions do not apply when exporting to HTML from the desktop version.</p>
+<p><a href="http://www.amulet.xyz">Download</a> and extract the Linux
+zip archive to a directory of your choice. Then add the directory to
+your PATH. The <code>amulet</code> executable is for x86_64. If you’re
+running a 32 bit system, rename the file <code>amulet.i686</code> to
+<code>amulet</code>.</p>
+<p><strong>Online editor:</strong> There is also an <a
+href="http://www.amulet.xyz/editor.html">online editor</a> which you can
+use without having to download or install anything. However be aware
+that there are some limitations when using the online editor: you can’t
+load image or audio files and only one lua module is allowed per
+project. These restrictions do not apply when exporting to HTML from the
+desktop version.</p>
 <h2 id="running-a-script">Running a script</h2>
-<p>Create a text file called <code>main.lua</code> containing the following:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="fu">log</span><span class="ot">(</span><span class="st">&quot;It works!&quot;</span><span class="ot">)</span></code></pre></div>
-<p>Open a terminal (&quot;command prompt&quot; on Windows) and change to the directory containing the file. Then type &quot;<code>amulet main.lua</code>&quot;:</p>
+<p>Create a text file called <code>main.lua</code> containing the
+following:</p>
+<div class="sourceCode" id="cb25"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a>log<span class="op">(</span><span class="st">&quot;It works!&quot;</span><span class="op">)</span></span></code></pre></div>
+<p>Open a terminal (“command prompt” on Windows) and change to the
+directory containing the file. Then type
+“<code>amulet main.lua</code>”:</p>
 <pre class="console"><code>&gt; amulet main.lua
 main.lua:1: It works!</code></pre>
-<p>If you see the text &quot;<code>main.lua:1: It works!</code>&quot;, Amulet is installed and working.</p>
-<p>If you are using the online editor, just type this into the main text area and click &quot;Run&quot;.</p>
+<p>If you see the text “<code>main.lua:1: It works!</code>”, Amulet is
+installed and working.</p>
+<p>If you are using the online editor, just type this into the main text
+area and click “Run”.</p>
 <h2 id="creating-a-window">Creating a window</h2>
 <p>Type the following into <code>main.lua</code>:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> win <span class="ot">=</span> am<span class="ot">.</span>window<span class="ot">{</span>
-    title <span class="ot">=</span> <span class="st">&quot;Hi&quot;</span><span class="ot">,</span>
-    width <span class="ot">=</span> <span class="dv">400</span><span class="ot">,</span>
-    height <span class="ot">=</span> <span class="dv">300</span><span class="ot">,</span>
-    clear_color <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0.5</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)</span>
-<span class="ot">}</span></code></pre></div>
-<p>and run it as before. This time a bright pink window should appear.</p>
+<div class="sourceCode" id="cb27"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> win <span class="op">=</span> am<span class="op">.</span>window<span class="op">{</span></span>
+<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>    title <span class="op">=</span> <span class="st">&quot;Hi&quot;</span><span class="op">,</span></span>
+<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>    width <span class="op">=</span> <span class="dv">400</span><span class="op">,</span></span>
+<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>    height <span class="op">=</span> <span class="dv">300</span><span class="op">,</span></span>
+<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>    clear_color <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0.5</span><span class="op">,</span> <span class="dv">1</span><span class="op">)</span></span>
+<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>and run it as before. This time a bright pink window should
+appear.</p>
 <h2 id="rendering-text">Rendering text</h2>
-<p>Add the following line to main.lua after the line that creates the window:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">win<span class="ot">.</span>scene <span class="ot">=</span> am<span class="ot">.</span>text<span class="ot">(</span><span class="st">&quot;Hello!&quot;</span><span class="ot">)</span></code></pre></div>
-<p>This assigns a <em>scene graph</em> to the window. The scene has a single text node. The window will render its scene graph each frame.</p>
-<div class="figure">
-<img src="images/hello1.png" />
-
-</div>
+<p>Add the following line to main.lua after the line that creates the
+window:</p>
+<div class="sourceCode" id="cb28"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene <span class="op">=</span> am<span class="op">.</span>text<span class="op">(</span><span class="st">&quot;Hello!&quot;</span><span class="op">)</span></span></code></pre></div>
+<p>This assigns a <em>scene graph</em> to the window. The scene has a
+single text node. The window will render its scene graph each frame.</p>
+<p><img src="images/hello1.png" /></p>
 <h2 id="transformation-nodes">Transformation nodes</h2>
 <p>Change the previous line to:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">win<span class="ot">.</span>scene <span class="ot">=</span> 
-    am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">150</span><span class="ot">,</span> <span class="dv">100</span><span class="ot">)</span>
-    <span class="ot">^</span> am<span class="ot">.</span>scale<span class="ot">(</span><span class="dv">2</span><span class="ot">)</span>
-    <span class="ot">^</span> am<span class="ot">.</span>rotate<span class="ot">(</span><span class="fu">math.rad</span><span class="ot">(</span><span class="dv">90</span><span class="ot">))</span>
-    <span class="ot">^</span> am<span class="ot">.</span>text<span class="ot">(</span><span class="st">&quot;Hello!&quot;</span><span class="ot">)</span></code></pre></div>
-<p>This adds translate, scale and rotate nodes as parents of the text node. These nodes transform the position, size and rotation of all their children. The resulting scene graph looks like this:</p>
-<div class="figure">
-<img src="graphs/scene1.png" />
-
-</div>
-<p>The translate node moves its descendants to the right 150 and up 100 (by convention the y axis increases in upward direction). The scale node doubles its descendant's size and the rotate node rotates its descendants by 90 degrees (<code>math.rad</code> converts degrees to radians). Finally the text node renders some text to the screen.</p>
+<div class="sourceCode" id="cb29"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene <span class="op">=</span> </span>
+<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a>    am<span class="op">.</span>translate<span class="op">(</span><span class="dv">150</span><span class="op">,</span> <span class="dv">100</span><span class="op">)</span></span>
+<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> am<span class="op">.</span>scale<span class="op">(</span><span class="dv">2</span><span class="op">)</span></span>
+<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> am<span class="op">.</span>rotate<span class="op">(</span><span class="fu">math.rad</span><span class="op">(</span><span class="dv">90</span><span class="op">))</span></span>
+<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> am<span class="op">.</span>text<span class="op">(</span><span class="st">&quot;Hello!&quot;</span><span class="op">)</span></span></code></pre></div>
+<p>This adds translate, scale and rotate nodes as parents of the text
+node. These nodes transform the position, size and rotation of all their
+children. The resulting scene graph looks like this:</p>
+<p><img src="graphs/scene1.png" /></p>
+<p>The translate node moves its descendants to the right 150 and up 100
+(by convention the y axis increases in upward direction). The scale node
+doubles its descendant’s size and the rotate node rotates its
+descendants by 90 degrees (<code>math.rad</code> converts degrees to
+radians). Finally the text node renders some text to the screen.</p>
 <p>When you run the program you should see something like this:</p>
-<div class="figure">
-<img src="images/hello2.png" />
-
-</div>
+<p><img src="images/hello2.png" /></p>
 <h2 id="actions">Actions</h2>
 <p>Add the following to the end of main.lua:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">win<span class="ot">.</span>scene:action<span class="ot">(</span><span class="kw">function</span><span class="ot">(</span>scene<span class="ot">)</span>
-    scene<span class="st">&quot;rotate&quot;</span><span class="ot">.</span>angle <span class="ot">=</span> am<span class="ot">.</span>frame_time <span class="ot">*</span> <span class="dv">4</span>
-<span class="kw">end</span><span class="ot">)</span></code></pre></div>
+<div class="sourceCode" id="cb30"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene<span class="op">:</span>action<span class="op">(</span><span class="kw">function</span><span class="op">(</span>scene<span class="op">)</span></span>
+<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a>    scene<span class="st">&quot;rotate&quot;</span><span class="op">.</span>angle <span class="op">=</span> am<span class="op">.</span>frame_time <span class="op">*</span> <span class="dv">4</span></span>
+<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span><span class="op">)</span></span></code></pre></div>
 <p>When you run it the text will spin.</p>
-<p>This code adds an <em>action</em> to the scene, which is a function that's run once per frame. Actions can be added to any scene node. In this case we've added it to the node <code>win.scene</code>, which is the top <code>translate</code> node of our scene graph. The node to which an action is attached is passed as an argument to the action function.</p>
+<p>This code adds an <em>action</em> to the scene, which is a function
+that’s run once per frame. Actions can be added to any scene node. In
+this case we’ve added it to the node <code>win.scene</code>, which is
+the top <code>translate</code> node of our scene graph. The node to
+which an action is attached is passed as an argument to the action
+function.</p>
 <p>The line:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">scene<span class="st">&quot;rotate&quot;</span><span class="ot">.</span>angle <span class="ot">=</span> am<span class="ot">.</span>frame_time <span class="ot">*</span> <span class="dv">4</span></code></pre></div>
-<p>first finds a node with the <em>tag</em> <code>&quot;rotate&quot;</code> in the scene graph. By default nodes have tags that correspond to their names, so this returns the rotate node. You can also add your own tags to nodes using the <code>tag</code> method which we'll discuss in more detail in the next section.</p>
-<p>Then we set the <code>angle</code> property of the rotate node to the current frame time (the time at the beginning of the frame, in seconds) times 4.</p>
-<p>Note that <code>scene&quot;rotate&quot;</code> could also be written as <code>scene(&quot;rotate&quot;)</code>. The first form takes advantage of some Lua syntactic sugar that allows function parenthesis to be omitted if the argument is a single literal string.</p>
+<div class="sourceCode" id="cb31"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a>scene<span class="st">&quot;rotate&quot;</span><span class="op">.</span>angle <span class="op">=</span> am<span class="op">.</span>frame_time <span class="op">*</span> <span class="dv">4</span></span></code></pre></div>
+<p>first finds a node with the <em>tag</em> <code>"rotate"</code> in the
+scene graph. By default nodes have tags that correspond to their names,
+so this returns the rotate node. You can also add your own tags to nodes
+using the <code>tag</code> method which we’ll discuss in more detail in
+the next section.</p>
+<p>Then we set the <code>angle</code> property of the rotate node to the
+current frame time (the time at the beginning of the frame, in seconds)
+times 4.</p>
+<p>Note that <code>scene"rotate"</code> could also be written as
+<code>scene("rotate")</code>. The first form takes advantage of some Lua
+syntactic sugar that allows function parenthesis to be omitted if the
+argument is a single literal string.</p>
 <p>Since this code is run each frame, it causes the text to spin.</p>
 <p>Here is the complete code listing:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> win <span class="ot">=</span> am<span class="ot">.</span>window<span class="ot">{</span>
-    title <span class="ot">=</span> <span class="st">&quot;Hi&quot;</span><span class="ot">,</span>
-    width <span class="ot">=</span> <span class="dv">400</span><span class="ot">,</span>
-    height <span class="ot">=</span> <span class="dv">300</span><span class="ot">,</span>
-    clear_color <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0.5</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)</span>
-<span class="ot">}</span>
-win<span class="ot">.</span>scene <span class="ot">=</span> 
-    am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">150</span><span class="ot">,</span> <span class="dv">100</span><span class="ot">)</span>
-    <span class="ot">^</span> am<span class="ot">.</span>scale<span class="ot">(</span><span class="dv">2</span><span class="ot">)</span>
-    <span class="ot">^</span> am<span class="ot">.</span>rotate<span class="ot">(</span><span class="fu">math.rad</span><span class="ot">(</span><span class="dv">90</span><span class="ot">))</span>
-    <span class="ot">^</span> am<span class="ot">.</span>text<span class="ot">(</span><span class="st">&quot;Hello!&quot;</span><span class="ot">)</span>
-win<span class="ot">.</span>scene:action<span class="ot">(</span><span class="kw">function</span><span class="ot">(</span>scene<span class="ot">)</span>
-    scene<span class="st">&quot;rotate&quot;</span><span class="ot">.</span>angle <span class="ot">=</span> am<span class="ot">.</span>frame_time <span class="ot">*</span> <span class="dv">4</span>
-<span class="kw">end</span><span class="ot">)</span></code></pre></div>
+<div class="sourceCode" id="cb32"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> win <span class="op">=</span> am<span class="op">.</span>window<span class="op">{</span></span>
+<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a>    title <span class="op">=</span> <span class="st">&quot;Hi&quot;</span><span class="op">,</span></span>
+<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a>    width <span class="op">=</span> <span class="dv">400</span><span class="op">,</span></span>
+<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a>    height <span class="op">=</span> <span class="dv">300</span><span class="op">,</span></span>
+<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a>    clear_color <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0.5</span><span class="op">,</span> <span class="dv">1</span><span class="op">)</span></span>
+<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb32-7"><a href="#cb32-7" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene <span class="op">=</span> </span>
+<span id="cb32-8"><a href="#cb32-8" aria-hidden="true" tabindex="-1"></a>    am<span class="op">.</span>translate<span class="op">(</span><span class="dv">150</span><span class="op">,</span> <span class="dv">100</span><span class="op">)</span></span>
+<span id="cb32-9"><a href="#cb32-9" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> am<span class="op">.</span>scale<span class="op">(</span><span class="dv">2</span><span class="op">)</span></span>
+<span id="cb32-10"><a href="#cb32-10" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> am<span class="op">.</span>rotate<span class="op">(</span><span class="fu">math.rad</span><span class="op">(</span><span class="dv">90</span><span class="op">))</span></span>
+<span id="cb32-11"><a href="#cb32-11" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> am<span class="op">.</span>text<span class="op">(</span><span class="st">&quot;Hello!&quot;</span><span class="op">)</span></span>
+<span id="cb32-12"><a href="#cb32-12" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene<span class="op">:</span>action<span class="op">(</span><span class="kw">function</span><span class="op">(</span>scene<span class="op">)</span></span>
+<span id="cb32-13"><a href="#cb32-13" aria-hidden="true" tabindex="-1"></a>    scene<span class="st">&quot;rotate&quot;</span><span class="op">.</span>angle <span class="op">=</span> am<span class="op">.</span>frame_time <span class="op">*</span> <span class="dv">4</span></span>
+<span id="cb32-14"><a href="#cb32-14" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span><span class="op">)</span></span></code></pre></div>
 <h2 id="drawing-shapes">Drawing shapes</h2>
-<p>Here is a simple program that draws 2 red circles on either side of a yellow square on a blue background.</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> red <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)</span>
-<span class="kw">local</span> blue <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)</span>
-<span class="kw">local</span> yellow <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)</span>
-
-<span class="kw">local</span> win <span class="ot">=</span> am<span class="ot">.</span>window<span class="ot">{</span>
-    title <span class="ot">=</span> <span class="st">&quot;Hi&quot;</span><span class="ot">,</span>
-    width <span class="ot">=</span> <span class="dv">400</span><span class="ot">,</span>
-    height <span class="ot">=</span> <span class="dv">300</span><span class="ot">,</span>
-    clear_color <span class="ot">=</span> blue<span class="ot">,</span>
-<span class="ot">}</span>
-
-win<span class="ot">.</span>scene <span class="ot">=</span>
-    am<span class="ot">.</span>group<span class="ot">()</span>
-    <span class="ot">^</span> <span class="ot">{</span>
-        am<span class="ot">.</span>translate<span class="ot">(-</span><span class="dv">150</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">)</span>
-        <span class="ot">^</span> am<span class="ot">.</span>circle<span class="ot">(</span>vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> <span class="dv">50</span><span class="ot">,</span> red<span class="ot">)</span>
-        <span class="ot">,</span>
-        am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">150</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">)</span>
-        <span class="ot">^</span> am<span class="ot">.</span>circle<span class="ot">(</span>vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> <span class="dv">50</span><span class="ot">,</span> red<span class="ot">)</span>
-        <span class="ot">,</span>
-        am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">25</span><span class="ot">)</span>
-        <span class="ot">^</span> am<span class="ot">.</span>rect<span class="ot">(-</span><span class="dv">50</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">50</span><span class="ot">,</span> <span class="dv">50</span><span class="ot">,</span> <span class="dv">50</span><span class="ot">,</span> yellow<span class="ot">)</span>
-    <span class="ot">}</span></code></pre></div>
-<div class="figure">
-<img src="images/shapes.png" />
-
-</div>
-<p>This time, we've created variables for the different colours we'll need. In Amulet colours are 4-dimensional vectors. Each component of the vector represents the red, green, blue and alpha intensity of the colour and ranges from 0 to 1.</p>
-<p>The scene graph has a <code>group</code> node at the top. <code>group</code> nodes don't have any effect on the rendering and are only used to group other nodes together. The group node has 3 children, each of which is a <code>translate</code> node with a shape child. The scene graph looks like this:</p>
-<div class="figure">
-<img src="graphs/scene2.png" />
-
-</div>
-<p>Instead of building the scene graph using the <code>^</code> operator as we've done above, we can also do it step-by-step using the <code>append</code> method, which adds a node to the child list of another node:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> circle1_node <span class="ot">=</span> am<span class="ot">.</span>translate<span class="ot">(-</span><span class="dv">150</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">)</span>
-circle1_node:append<span class="ot">(</span>am<span class="ot">.</span>circle<span class="ot">(</span>vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> <span class="dv">50</span><span class="ot">,</span> red<span class="ot">))</span>
-
-<span class="kw">local</span> circle2_node <span class="ot">=</span> am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">150</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">)</span>
-circle2_node:append<span class="ot">(</span>am<span class="ot">.</span>circle<span class="ot">(</span>vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> <span class="dv">50</span><span class="ot">,</span> red<span class="ot">))</span>
-
-<span class="kw">local</span> rect_node <span class="ot">=</span> am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">25</span><span class="ot">)</span>
-rect_node:append<span class="ot">(</span>am<span class="ot">.</span>rect<span class="ot">(-</span><span class="dv">50</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">50</span><span class="ot">,</span> <span class="dv">50</span><span class="ot">,</span> <span class="dv">50</span><span class="ot">,</span> yellow<span class="ot">))</span>
-
-<span class="kw">local</span> group_node <span class="ot">=</span> am<span class="ot">.</span>group<span class="ot">()</span>
-group_node:append<span class="ot">(</span>circle1_node<span class="ot">)</span>
-group_node:append<span class="ot">(</span>circle2_node<span class="ot">)</span>
-group_node:append<span class="ot">(</span>rect_node<span class="ot">)</span>
-
-win<span class="ot">.</span>scene <span class="ot">=</span> group_node</code></pre></div>
+<p>Here is a simple program that draws 2 red circles on either side of a
+yellow square on a blue background.</p>
+<div class="sourceCode" id="cb33"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> red <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">)</span></span>
+<span id="cb33-2"><a href="#cb33-2" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> blue <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">)</span></span>
+<span id="cb33-3"><a href="#cb33-3" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> yellow <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">)</span></span>
+<span id="cb33-4"><a href="#cb33-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb33-5"><a href="#cb33-5" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> win <span class="op">=</span> am<span class="op">.</span>window<span class="op">{</span></span>
+<span id="cb33-6"><a href="#cb33-6" aria-hidden="true" tabindex="-1"></a>    title <span class="op">=</span> <span class="st">&quot;Hi&quot;</span><span class="op">,</span></span>
+<span id="cb33-7"><a href="#cb33-7" aria-hidden="true" tabindex="-1"></a>    width <span class="op">=</span> <span class="dv">400</span><span class="op">,</span></span>
+<span id="cb33-8"><a href="#cb33-8" aria-hidden="true" tabindex="-1"></a>    height <span class="op">=</span> <span class="dv">300</span><span class="op">,</span></span>
+<span id="cb33-9"><a href="#cb33-9" aria-hidden="true" tabindex="-1"></a>    clear_color <span class="op">=</span> blue<span class="op">,</span></span>
+<span id="cb33-10"><a href="#cb33-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb33-11"><a href="#cb33-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb33-12"><a href="#cb33-12" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene <span class="op">=</span></span>
+<span id="cb33-13"><a href="#cb33-13" aria-hidden="true" tabindex="-1"></a>    am<span class="op">.</span>group<span class="op">()</span></span>
+<span id="cb33-14"><a href="#cb33-14" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> <span class="op">{</span></span>
+<span id="cb33-15"><a href="#cb33-15" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>translate<span class="op">(-</span><span class="dv">150</span><span class="op">,</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb33-16"><a href="#cb33-16" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> am<span class="op">.</span>circle<span class="op">(</span>vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> <span class="dv">50</span><span class="op">,</span> red<span class="op">)</span></span>
+<span id="cb33-17"><a href="#cb33-17" aria-hidden="true" tabindex="-1"></a>        <span class="op">,</span></span>
+<span id="cb33-18"><a href="#cb33-18" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>translate<span class="op">(</span><span class="dv">150</span><span class="op">,</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb33-19"><a href="#cb33-19" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> am<span class="op">.</span>circle<span class="op">(</span>vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> <span class="dv">50</span><span class="op">,</span> red<span class="op">)</span></span>
+<span id="cb33-20"><a href="#cb33-20" aria-hidden="true" tabindex="-1"></a>        <span class="op">,</span></span>
+<span id="cb33-21"><a href="#cb33-21" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>translate<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="op">-</span><span class="dv">25</span><span class="op">)</span></span>
+<span id="cb33-22"><a href="#cb33-22" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> am<span class="op">.</span>rect<span class="op">(-</span><span class="dv">50</span><span class="op">,</span> <span class="op">-</span><span class="dv">50</span><span class="op">,</span> <span class="dv">50</span><span class="op">,</span> <span class="dv">50</span><span class="op">,</span> yellow<span class="op">)</span></span>
+<span id="cb33-23"><a href="#cb33-23" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span></code></pre></div>
+<p><img src="images/shapes.png" /></p>
+<p>This time, we’ve created variables for the different colours we’ll
+need. In Amulet colours are 4-dimensional vectors. Each component of the
+vector represents the red, green, blue and alpha intensity of the colour
+and ranges from 0 to 1.</p>
+<p>The scene graph has a <code>group</code> node at the top.
+<code>group</code> nodes don’t have any effect on the rendering and are
+only used to group other nodes together. The group node has 3 children,
+each of which is a <code>translate</code> node with a shape child. The
+scene graph looks like this:</p>
+<p><img src="graphs/scene2.png" /></p>
+<p>Instead of building the scene graph using the <code>^</code> operator
+as we’ve done above, we can also do it step-by-step using the
+<code>append</code> method, which adds a node to the child list of
+another node:</p>
+<div class="sourceCode" id="cb34"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> circle1_node <span class="op">=</span> am<span class="op">.</span>translate<span class="op">(-</span><span class="dv">150</span><span class="op">,</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb34-2"><a href="#cb34-2" aria-hidden="true" tabindex="-1"></a>circle1_node<span class="op">:</span>append<span class="op">(</span>am<span class="op">.</span>circle<span class="op">(</span>vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> <span class="dv">50</span><span class="op">,</span> red<span class="op">))</span></span>
+<span id="cb34-3"><a href="#cb34-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-4"><a href="#cb34-4" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> circle2_node <span class="op">=</span> am<span class="op">.</span>translate<span class="op">(</span><span class="dv">150</span><span class="op">,</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb34-5"><a href="#cb34-5" aria-hidden="true" tabindex="-1"></a>circle2_node<span class="op">:</span>append<span class="op">(</span>am<span class="op">.</span>circle<span class="op">(</span>vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> <span class="dv">50</span><span class="op">,</span> red<span class="op">))</span></span>
+<span id="cb34-6"><a href="#cb34-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-7"><a href="#cb34-7" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> rect_node <span class="op">=</span> am<span class="op">.</span>translate<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="op">-</span><span class="dv">25</span><span class="op">)</span></span>
+<span id="cb34-8"><a href="#cb34-8" aria-hidden="true" tabindex="-1"></a>rect_node<span class="op">:</span>append<span class="op">(</span>am<span class="op">.</span>rect<span class="op">(-</span><span class="dv">50</span><span class="op">,</span> <span class="op">-</span><span class="dv">50</span><span class="op">,</span> <span class="dv">50</span><span class="op">,</span> <span class="dv">50</span><span class="op">,</span> yellow<span class="op">))</span></span>
+<span id="cb34-9"><a href="#cb34-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-10"><a href="#cb34-10" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> group_node <span class="op">=</span> am<span class="op">.</span>group<span class="op">()</span></span>
+<span id="cb34-11"><a href="#cb34-11" aria-hidden="true" tabindex="-1"></a>group_node<span class="op">:</span>append<span class="op">(</span>circle1_node<span class="op">)</span></span>
+<span id="cb34-12"><a href="#cb34-12" aria-hidden="true" tabindex="-1"></a>group_node<span class="op">:</span>append<span class="op">(</span>circle2_node<span class="op">)</span></span>
+<span id="cb34-13"><a href="#cb34-13" aria-hidden="true" tabindex="-1"></a>group_node<span class="op">:</span>append<span class="op">(</span>rect_node<span class="op">)</span></span>
+<span id="cb34-14"><a href="#cb34-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb34-15"><a href="#cb34-15" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene <span class="op">=</span> group_node</span></code></pre></div>
 <p>This results in the exact same scene graph.</p>
 <h2 id="responding-to-key-presses">Responding to key presses</h2>
-<p>Let's change the above program so that the left circle only appears while the A key is down and the right circle only appears while the B key is down.</p>
-<p>In order to distinguish the two circles in the scene graph we'll give them different tags.</p>
+<p>Let’s change the above program so that the left circle only appears
+while the A key is down and the right circle only appears while the B
+key is down.</p>
+<p>In order to distinguish the two circles in the scene graph we’ll give
+them different tags.</p>
 <p>Change the scene setup code to look like this:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">win<span class="ot">.</span>scene <span class="ot">=</span>
-    am<span class="ot">.</span>group<span class="ot">()</span>
-    <span class="ot">^</span> <span class="ot">{</span>
-        am<span class="ot">.</span>translate<span class="ot">(-</span><span class="dv">150</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">)</span>:<span class="fu">tag</span><span class="st">&quot;left_eye&quot;</span>
-        <span class="ot">^</span> am<span class="ot">.</span>circle<span class="ot">(</span>vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> <span class="dv">50</span><span class="ot">,</span> red<span class="ot">)</span>
-        <span class="ot">,</span>
-        am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">150</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">)</span>:<span class="fu">tag</span><span class="st">&quot;right_eye&quot;</span>
-        <span class="ot">^</span> am<span class="ot">.</span>circle<span class="ot">(</span>vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> <span class="dv">50</span><span class="ot">,</span> red<span class="ot">)</span>
-        <span class="ot">,</span>
-        am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">25</span><span class="ot">)</span>
-        <span class="ot">^</span> am<span class="ot">.</span>rect<span class="ot">(-</span><span class="dv">50</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">50</span><span class="ot">,</span> <span class="dv">50</span><span class="ot">,</span> <span class="dv">50</span><span class="ot">,</span> yellow<span class="ot">)</span>
-    <span class="ot">}</span></code></pre></div>
-<p>The only difference is the addition of <code>:tag&quot;left_eye&quot;</code> and <code>:tag&quot;right_eye&quot;</code>. These add the tag <code>&quot;left_eye&quot;</code> to the translate node which is the parent of the left circle node and <code>&quot;right_eye&quot;</code> to the right translate node which is the parent of the right circle node.</p>
+<div class="sourceCode" id="cb35"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb35-1"><a href="#cb35-1" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene <span class="op">=</span></span>
+<span id="cb35-2"><a href="#cb35-2" aria-hidden="true" tabindex="-1"></a>    am<span class="op">.</span>group<span class="op">()</span></span>
+<span id="cb35-3"><a href="#cb35-3" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> <span class="op">{</span></span>
+<span id="cb35-4"><a href="#cb35-4" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>translate<span class="op">(-</span><span class="dv">150</span><span class="op">,</span> <span class="dv">0</span><span class="op">):</span>tag<span class="st">&quot;left_eye&quot;</span></span>
+<span id="cb35-5"><a href="#cb35-5" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> am<span class="op">.</span>circle<span class="op">(</span>vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> <span class="dv">50</span><span class="op">,</span> red<span class="op">)</span></span>
+<span id="cb35-6"><a href="#cb35-6" aria-hidden="true" tabindex="-1"></a>        <span class="op">,</span></span>
+<span id="cb35-7"><a href="#cb35-7" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>translate<span class="op">(</span><span class="dv">150</span><span class="op">,</span> <span class="dv">0</span><span class="op">):</span>tag<span class="st">&quot;right_eye&quot;</span></span>
+<span id="cb35-8"><a href="#cb35-8" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> am<span class="op">.</span>circle<span class="op">(</span>vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> <span class="dv">50</span><span class="op">,</span> red<span class="op">)</span></span>
+<span id="cb35-9"><a href="#cb35-9" aria-hidden="true" tabindex="-1"></a>        <span class="op">,</span></span>
+<span id="cb35-10"><a href="#cb35-10" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>translate<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="op">-</span><span class="dv">25</span><span class="op">)</span></span>
+<span id="cb35-11"><a href="#cb35-11" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> am<span class="op">.</span>rect<span class="op">(-</span><span class="dv">50</span><span class="op">,</span> <span class="op">-</span><span class="dv">50</span><span class="op">,</span> <span class="dv">50</span><span class="op">,</span> <span class="dv">50</span><span class="op">,</span> yellow<span class="op">)</span></span>
+<span id="cb35-12"><a href="#cb35-12" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span></code></pre></div>
+<p>The only difference is the addition of <code>:tag"left_eye"</code>
+and <code>:tag"right_eye"</code>. These add the tag
+<code>"left_eye"</code> to the translate node which is the parent of the
+left circle node and <code>"right_eye"</code> to the right translate
+node which is the parent of the right circle node.</p>
 <p>Now add the following action:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">win<span class="ot">.</span>scene:action<span class="ot">(</span><span class="kw">function</span><span class="ot">(</span>scene<span class="ot">)</span>
-    scene<span class="st">&quot;left_eye&quot;</span><span class="ot">.</span>hidden <span class="ot">=</span> <span class="kw">not</span> win:key_down<span class="st">&quot;a&quot;</span>
-    scene<span class="st">&quot;right_eye&quot;</span><span class="ot">.</span>hidden <span class="ot">=</span> <span class="kw">not</span> win:key_down<span class="st">&quot;b&quot;</span>
-<span class="kw">end</span><span class="ot">)</span></code></pre></div>
-<p>The <code>hidden</code> field of a node determines whether it is drawn or not. Each frame we set the <code>hidden</code> field of the left and right translate nodes to whether the A or B keys are being pressed. <code>win:key_down(X)</code> returns true if key <code>X</code> was being held down at the start of the frame.</p>
-<p>You may notice that the three shapes appear briefly when the window is first shown and then disappear immediately. This is because actions only start running in the next frame, so the shapes are only hidden on the second frame. To fix this we can add the following lines either before or after we add the action (it doesn't matter where):</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">win<span class="ot">.</span>scene<span class="st">&quot;left_eye&quot;</span><span class="ot">.</span>hidden <span class="ot">=</span> <span class="kw">true</span>
-win<span class="ot">.</span>scene<span class="st">&quot;right_eye&quot;</span><span class="ot">.</span>hidden <span class="ot">=</span> <span class="kw">true</span></code></pre></div>
+<div class="sourceCode" id="cb36"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb36-1"><a href="#cb36-1" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene<span class="op">:</span>action<span class="op">(</span><span class="kw">function</span><span class="op">(</span>scene<span class="op">)</span></span>
+<span id="cb36-2"><a href="#cb36-2" aria-hidden="true" tabindex="-1"></a>    scene<span class="st">&quot;left_eye&quot;</span><span class="op">.</span>hidden <span class="op">=</span> <span class="kw">not</span> win<span class="op">:</span>key_down<span class="st">&quot;a&quot;</span></span>
+<span id="cb36-3"><a href="#cb36-3" aria-hidden="true" tabindex="-1"></a>    scene<span class="st">&quot;right_eye&quot;</span><span class="op">.</span>hidden <span class="op">=</span> <span class="kw">not</span> win<span class="op">:</span>key_down<span class="st">&quot;b&quot;</span></span>
+<span id="cb36-4"><a href="#cb36-4" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span><span class="op">)</span></span></code></pre></div>
+<p>The <code>hidden</code> field of a node determines whether it is
+drawn or not. Each frame we set the <code>hidden</code> field of the
+left and right translate nodes to whether the A or B keys are being
+pressed. <code>win:key_down(X)</code> returns true if key <code>X</code>
+was being held down at the start of the frame.</p>
+<p>You may notice that the three shapes appear briefly when the window
+is first shown and then disappear immediately. This is because actions
+only start running in the next frame, so the shapes are only hidden on
+the second frame. To fix this we can add the following lines either
+before or after we add the action (it doesn’t matter where):</p>
+<div class="sourceCode" id="cb37"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb37-1"><a href="#cb37-1" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene<span class="st">&quot;left_eye&quot;</span><span class="op">.</span>hidden <span class="op">=</span> <span class="kw">true</span></span>
+<span id="cb37-2"><a href="#cb37-2" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene<span class="st">&quot;right_eye&quot;</span><span class="op">.</span>hidden <span class="op">=</span> <span class="kw">true</span></span></code></pre></div>
 <p>Here is the complete code listing:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> red <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)</span>
-<span class="kw">local</span> blue <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)</span>
-<span class="kw">local</span> yellow <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)</span>
-
-<span class="kw">local</span> win <span class="ot">=</span> am<span class="ot">.</span>window<span class="ot">{</span>
-    title <span class="ot">=</span> <span class="st">&quot;Hi&quot;</span><span class="ot">,</span>
-    width <span class="ot">=</span> <span class="dv">400</span><span class="ot">,</span>
-    height <span class="ot">=</span> <span class="dv">300</span><span class="ot">,</span>
-    clear_color <span class="ot">=</span> blue<span class="ot">,</span>
-<span class="ot">}</span>
-
-win<span class="ot">.</span>scene <span class="ot">=</span>
-    am<span class="ot">.</span>group<span class="ot">()</span>
-    <span class="ot">^</span> <span class="ot">{</span>
-        am<span class="ot">.</span>translate<span class="ot">(-</span><span class="dv">150</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">)</span>:<span class="fu">tag</span><span class="st">&quot;left_eye&quot;</span>
-        <span class="ot">^</span> am<span class="ot">.</span>circle<span class="ot">(</span>vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> <span class="dv">50</span><span class="ot">,</span> red<span class="ot">)</span>
-        <span class="ot">,</span>
-        am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">150</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">)</span>:<span class="fu">tag</span><span class="st">&quot;right_eye&quot;</span>
-        <span class="ot">^</span> am<span class="ot">.</span>circle<span class="ot">(</span>vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> <span class="dv">50</span><span class="ot">,</span> red<span class="ot">)</span>
-        <span class="ot">,</span>
-        am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">25</span><span class="ot">)</span>
-        <span class="ot">^</span> am<span class="ot">.</span>rect<span class="ot">(-</span><span class="dv">50</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">50</span><span class="ot">,</span> <span class="dv">50</span><span class="ot">,</span> <span class="dv">50</span><span class="ot">,</span> yellow<span class="ot">)</span>
-    <span class="ot">}</span>
-
-win<span class="ot">.</span>scene:action<span class="ot">(</span><span class="kw">function</span><span class="ot">(</span>scene<span class="ot">)</span>
-    scene<span class="st">&quot;left_eye&quot;</span><span class="ot">.</span>hidden <span class="ot">=</span> <span class="kw">not</span> win:key_down<span class="st">&quot;a&quot;</span>
-    scene<span class="st">&quot;right_eye&quot;</span><span class="ot">.</span>hidden <span class="ot">=</span> <span class="kw">not</span> win:key_down<span class="st">&quot;b&quot;</span>
-<span class="kw">end</span><span class="ot">)</span>
-
-win<span class="ot">.</span>scene<span class="st">&quot;left_eye&quot;</span><span class="ot">.</span>hidden <span class="ot">=</span> <span class="kw">true</span>
-win<span class="ot">.</span>scene<span class="st">&quot;right_eye&quot;</span><span class="ot">.</span>hidden <span class="ot">=</span> <span class="kw">true</span></code></pre></div>
+<div class="sourceCode" id="cb38"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb38-1"><a href="#cb38-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> red <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">)</span></span>
+<span id="cb38-2"><a href="#cb38-2" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> blue <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">)</span></span>
+<span id="cb38-3"><a href="#cb38-3" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> yellow <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">)</span></span>
+<span id="cb38-4"><a href="#cb38-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb38-5"><a href="#cb38-5" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> win <span class="op">=</span> am<span class="op">.</span>window<span class="op">{</span></span>
+<span id="cb38-6"><a href="#cb38-6" aria-hidden="true" tabindex="-1"></a>    title <span class="op">=</span> <span class="st">&quot;Hi&quot;</span><span class="op">,</span></span>
+<span id="cb38-7"><a href="#cb38-7" aria-hidden="true" tabindex="-1"></a>    width <span class="op">=</span> <span class="dv">400</span><span class="op">,</span></span>
+<span id="cb38-8"><a href="#cb38-8" aria-hidden="true" tabindex="-1"></a>    height <span class="op">=</span> <span class="dv">300</span><span class="op">,</span></span>
+<span id="cb38-9"><a href="#cb38-9" aria-hidden="true" tabindex="-1"></a>    clear_color <span class="op">=</span> blue<span class="op">,</span></span>
+<span id="cb38-10"><a href="#cb38-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb38-11"><a href="#cb38-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb38-12"><a href="#cb38-12" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene <span class="op">=</span></span>
+<span id="cb38-13"><a href="#cb38-13" aria-hidden="true" tabindex="-1"></a>    am<span class="op">.</span>group<span class="op">()</span></span>
+<span id="cb38-14"><a href="#cb38-14" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> <span class="op">{</span></span>
+<span id="cb38-15"><a href="#cb38-15" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>translate<span class="op">(-</span><span class="dv">150</span><span class="op">,</span> <span class="dv">0</span><span class="op">):</span>tag<span class="st">&quot;left_eye&quot;</span></span>
+<span id="cb38-16"><a href="#cb38-16" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> am<span class="op">.</span>circle<span class="op">(</span>vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> <span class="dv">50</span><span class="op">,</span> red<span class="op">)</span></span>
+<span id="cb38-17"><a href="#cb38-17" aria-hidden="true" tabindex="-1"></a>        <span class="op">,</span></span>
+<span id="cb38-18"><a href="#cb38-18" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>translate<span class="op">(</span><span class="dv">150</span><span class="op">,</span> <span class="dv">0</span><span class="op">):</span>tag<span class="st">&quot;right_eye&quot;</span></span>
+<span id="cb38-19"><a href="#cb38-19" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> am<span class="op">.</span>circle<span class="op">(</span>vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> <span class="dv">50</span><span class="op">,</span> red<span class="op">)</span></span>
+<span id="cb38-20"><a href="#cb38-20" aria-hidden="true" tabindex="-1"></a>        <span class="op">,</span></span>
+<span id="cb38-21"><a href="#cb38-21" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>translate<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="op">-</span><span class="dv">25</span><span class="op">)</span></span>
+<span id="cb38-22"><a href="#cb38-22" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> am<span class="op">.</span>rect<span class="op">(-</span><span class="dv">50</span><span class="op">,</span> <span class="op">-</span><span class="dv">50</span><span class="op">,</span> <span class="dv">50</span><span class="op">,</span> <span class="dv">50</span><span class="op">,</span> yellow<span class="op">)</span></span>
+<span id="cb38-23"><a href="#cb38-23" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb38-24"><a href="#cb38-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb38-25"><a href="#cb38-25" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene<span class="op">:</span>action<span class="op">(</span><span class="kw">function</span><span class="op">(</span>scene<span class="op">)</span></span>
+<span id="cb38-26"><a href="#cb38-26" aria-hidden="true" tabindex="-1"></a>    scene<span class="st">&quot;left_eye&quot;</span><span class="op">.</span>hidden <span class="op">=</span> <span class="kw">not</span> win<span class="op">:</span>key_down<span class="st">&quot;a&quot;</span></span>
+<span id="cb38-27"><a href="#cb38-27" aria-hidden="true" tabindex="-1"></a>    scene<span class="st">&quot;right_eye&quot;</span><span class="op">.</span>hidden <span class="op">=</span> <span class="kw">not</span> win<span class="op">:</span>key_down<span class="st">&quot;b&quot;</span></span>
+<span id="cb38-28"><a href="#cb38-28" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span><span class="op">)</span></span>
+<span id="cb38-29"><a href="#cb38-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb38-30"><a href="#cb38-30" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene<span class="st">&quot;left_eye&quot;</span><span class="op">.</span>hidden <span class="op">=</span> <span class="kw">true</span></span>
+<span id="cb38-31"><a href="#cb38-31" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene<span class="st">&quot;right_eye&quot;</span><span class="op">.</span>hidden <span class="op">=</span> <span class="kw">true</span></span></code></pre></div>
 <h2 id="drawing-sprites">Drawing sprites</h2>
-<p>Sprites can be drawn using sprite nodes. To create a sprite node, pass the name of a .png or .jpg file to the <code>am.sprite()</code> function and add it to your scene graph.</p>
-<p>Let's create a beach scene using the following two images:</p>
-<div class="figure">
+<p>Sprites can be drawn using sprite nodes. To create a sprite node,
+pass the name of a .png or .jpg file to the <code>am.sprite()</code>
+function and add it to your scene graph.</p>
+<p>Let’s create a beach scene using the following two images:</p>
+<figure>
 <img src="images/beach.jpg" alt="beach.jpg" />
-<p class="caption">beach.jpg</p>
-</div>
-<div class="figure">
+<figcaption aria-hidden="true">beach.jpg</figcaption>
+</figure>
+<figure>
 <img src="images/ball.png" alt="ball.png" />
-<p class="caption">ball.png</p>
-</div>
-<p>Download these images and copy them to the same directory as your <code>main.lua</code> file. Then copy the following into <code>main.lua</code>:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> win <span class="ot">=</span> am<span class="ot">.</span>window<span class="ot">{</span>
-    title <span class="ot">=</span> <span class="st">&quot;Beach&quot;</span><span class="ot">,</span>
-    width <span class="ot">=</span> <span class="dv">400</span><span class="ot">,</span>
-    height <span class="ot">=</span> <span class="dv">300</span><span class="ot">,</span>
-<span class="ot">}</span>
-
-win<span class="ot">.</span>scene <span class="ot">=</span> 
-    am<span class="ot">.</span>group<span class="ot">()</span>
-    <span class="ot">^</span> <span class="ot">{</span>
-        am<span class="ot">.</span>sprite<span class="st">&quot;beach.jpg&quot;</span>
-        <span class="ot">,</span>
-        am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">60</span><span class="ot">)</span>
-        <span class="ot">^</span> am<span class="ot">.</span>sprite<span class="st">&quot;ball.png&quot;</span>
-    <span class="ot">}</span></code></pre></div>
+<figcaption aria-hidden="true">ball.png</figcaption>
+</figure>
+<p>Download these images and copy them to the same directory as your
+<code>main.lua</code> file. Then copy the following into
+<code>main.lua</code>:</p>
+<div class="sourceCode" id="cb39"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb39-1"><a href="#cb39-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> win <span class="op">=</span> am<span class="op">.</span>window<span class="op">{</span></span>
+<span id="cb39-2"><a href="#cb39-2" aria-hidden="true" tabindex="-1"></a>    title <span class="op">=</span> <span class="st">&quot;Beach&quot;</span><span class="op">,</span></span>
+<span id="cb39-3"><a href="#cb39-3" aria-hidden="true" tabindex="-1"></a>    width <span class="op">=</span> <span class="dv">400</span><span class="op">,</span></span>
+<span id="cb39-4"><a href="#cb39-4" aria-hidden="true" tabindex="-1"></a>    height <span class="op">=</span> <span class="dv">300</span><span class="op">,</span></span>
+<span id="cb39-5"><a href="#cb39-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb39-6"><a href="#cb39-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb39-7"><a href="#cb39-7" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene <span class="op">=</span> </span>
+<span id="cb39-8"><a href="#cb39-8" aria-hidden="true" tabindex="-1"></a>    am<span class="op">.</span>group<span class="op">()</span></span>
+<span id="cb39-9"><a href="#cb39-9" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> <span class="op">{</span></span>
+<span id="cb39-10"><a href="#cb39-10" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>sprite<span class="st">&quot;beach.jpg&quot;</span></span>
+<span id="cb39-11"><a href="#cb39-11" aria-hidden="true" tabindex="-1"></a>        <span class="op">,</span></span>
+<span id="cb39-12"><a href="#cb39-12" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>translate<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="op">-</span><span class="dv">60</span><span class="op">)</span></span>
+<span id="cb39-13"><a href="#cb39-13" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> am<span class="op">.</span>sprite<span class="st">&quot;ball.png&quot;</span></span>
+<span id="cb39-14"><a href="#cb39-14" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span></code></pre></div>
 <p>Run the program and you should get something like this:</p>
-<div class="figure">
-<img src="images/beach1.png" />
-
-</div>
-<p>The children of any scene node are always drawn in order, so first the beach.jpg sprite node is drawn and then the ball.png sprite, with it's corresponding translation, is drawn. This ensures the ball is visible on the beach. If we draw the beach second it would obscure the ball.</p>
-<p>If you are using the online editor then you won't be able to load image files. Instead you'll need to draw the sprites using text. See the &quot;Beach ball&quot; example in the online editor for an equivalent example that doesn't load any image files. See also the documentation for <a href="#am.sprite">am.sprite</a> for how to create sprites with text.</p>
+<p><img src="images/beach1.png" /></p>
+<p>The children of any scene node are always drawn in order, so first
+the beach.jpg sprite node is drawn and then the ball.png sprite, with
+it’s corresponding translation, is drawn. This ensures the ball is
+visible on the beach. If we draw the beach second it would obscure the
+ball.</p>
+<p>If you are using the online editor then you won’t be able to load
+image files. Instead you’ll need to draw the sprites using text. See the
+“Beach ball” example in the online editor for an equivalent example that
+doesn’t load any image files. See also the documentation for <a
+href="#am.sprite">am.sprite</a> for how to create sprites with text.</p>
 <h2 id="responding-to-mouse-clicks">Responding to mouse clicks</h2>
-<p>Let's make the ball bounce when we click it. We'll add a rotate node so we can make the ball spin when it's in the air. We'll also tag the ball's translate and rotate nodes so we can easily access them:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">win<span class="ot">.</span>scene <span class="ot">=</span> 
-    am<span class="ot">.</span>group<span class="ot">()</span>
-    <span class="ot">^</span> <span class="ot">{</span>
-        am<span class="ot">.</span>sprite<span class="st">&quot;beach.jpg&quot;</span>
-        <span class="ot">,</span>
-        am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">60</span><span class="ot">)</span>:<span class="fu">tag</span><span class="st">&quot;ballt&quot;</span>
-        <span class="ot">^</span> am<span class="ot">.</span>rotate<span class="ot">(</span><span class="dv">0</span><span class="ot">)</span>:<span class="fu">tag</span><span class="st">&quot;ballr&quot;</span>
-        <span class="ot">^</span> am<span class="ot">.</span>sprite<span class="st">&quot;ball.png&quot;</span>
-    <span class="ot">}</span></code></pre></div>
-<p>Now add an action to animate the ball when it's clicked:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="do">-- ball state variables:</span>
-<span class="kw">local</span> ball_pos <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">60</span><span class="ot">)</span>
-<span class="kw">local</span> ball_angle <span class="ot">=</span> <span class="dv">0</span>
-<span class="kw">local</span> velocity <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">)</span>
-<span class="kw">local</span> spin <span class="ot">=</span> <span class="dv">0</span>
-
-<span class="do">-- constants:</span>
-<span class="kw">local</span> min_pos <span class="ot">=</span> vec2<span class="ot">(-</span><span class="dv">180</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">60</span><span class="ot">)</span>
-<span class="kw">local</span> max_pos <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">180</span><span class="ot">,</span> <span class="dv">500</span><span class="ot">)</span>
-<span class="do">-- min and max impulse velocity:</span>
-<span class="kw">local</span> min_v <span class="ot">=</span> vec2<span class="ot">(-</span><span class="dv">50</span><span class="ot">,</span> <span class="dv">150</span><span class="ot">)</span>
-<span class="kw">local</span> max_v <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">50</span><span class="ot">,</span> <span class="dv">300</span><span class="ot">)</span>
-<span class="kw">local</span> gravity <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">500</span><span class="ot">)</span>
-
-win<span class="ot">.</span>scene:action<span class="ot">(</span><span class="kw">function</span><span class="ot">(</span>scene<span class="ot">)</span>
-    <span class="do">-- check if the left mouse button was pressed</span>
-    <span class="kw">if</span> win:mouse_pressed<span class="st">&quot;left&quot;</span> <span class="kw">then</span>
-        <span class="kw">local</span> mouse_pos <span class="ot">=</span> win:mouse_position<span class="ot">()</span>
-        <span class="do">-- check if the mouse click is on the ball</span>
-        <span class="kw">if</span> math<span class="ot">.</span>distance<span class="ot">(</span>mouse_pos<span class="ot">,</span> ball_pos<span class="ot">)</span> <span class="ot">&lt;</span> <span class="dv">50</span> <span class="kw">then</span>
-            <span class="do">-- compute a velocity based on click position</span>
-            <span class="kw">local</span> dir <span class="ot">=</span> math<span class="ot">.</span>normalize<span class="ot">(</span>ball_pos <span class="ot">-</span> mouse_pos<span class="ot">)</span>
-            velocity <span class="ot">=</span> dir <span class="ot">*</span> <span class="dv">300</span>
-            velocity <span class="ot">=</span> math<span class="ot">.</span>clamp<span class="ot">(</span>velocity<span class="ot">,</span> min_v<span class="ot">,</span> max_v<span class="ot">)</span>
-            <span class="do">-- set a random spin</span>
-            spin <span class="ot">=</span> <span class="fu">math.random</span><span class="ot">()</span> <span class="ot">*</span> <span class="dv">4</span> <span class="ot">-</span> <span class="dv">2</span>
-        <span class="kw">end</span>
-    <span class="kw">end</span>
-
-    <span class="do">-- update the ball position</span>
-    ball_pos <span class="ot">=</span> ball_pos <span class="ot">+</span> velocity <span class="ot">*</span> am<span class="ot">.</span>delta_time
-
-    <span class="do">-- if the ball is on the ground, set the</span>
-    <span class="do">-- velocity and spin to zero.</span>
-    <span class="kw">if</span> ball_pos<span class="ot">.</span>y <span class="ot">&lt;=</span> <span class="ot">-</span><span class="dv">60</span> <span class="kw">then</span>
-        velocity <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">)</span>
-        spin <span class="ot">=</span> <span class="dv">0</span>
-    <span class="kw">end</span>
-
-    <span class="do">-- clamp the ball position so it doesn&#39;t disappear</span>
-    <span class="do">-- off the edge of the screen</span>
-    ball_pos <span class="ot">=</span> math<span class="ot">.</span>clamp<span class="ot">(</span>ball_pos<span class="ot">,</span> min_pos<span class="ot">,</span> max_pos<span class="ot">)</span>
-
-    <span class="do">-- update the ball angle</span>
-    ball_angle <span class="ot">=</span> ball_angle <span class="ot">+</span> spin <span class="ot">*</span> am<span class="ot">.</span>delta_time
-
-    <span class="do">-- update the ball translate and rotate nodes</span>
-    scene<span class="st">&quot;ballt&quot;</span><span class="ot">.</span>position2d <span class="ot">=</span> ball_pos
-    scene<span class="st">&quot;ballr&quot;</span><span class="ot">.</span>angle <span class="ot">=</span> ball_angle
-
-    <span class="do">-- apply gravity to the velocity</span>
-    velocity <span class="ot">=</span> velocity <span class="ot">+</span> gravity <span class="ot">*</span> am<span class="ot">.</span>delta_time
-<span class="kw">end</span><span class="ot">)</span></code></pre></div>
-<p>First we create some variables to keep track of the ball's state. We need to track its position, angle, velocity and spin (angular velocity). The <code>ball_pos</code> and <code>velocity</code> variables are 2 dimensional vectors, since we want to track position and velocity along both the x and y axes. We could have made separate variables for the x and y components, but using a <code>vec2</code> is more concise. Note that if the values of the x and y components of the vector are the same, we only need to give the value once, so we just need to write <code>vec2(0)</code> when initialising the velocity instead of <code>vec2(0, 0)</code>.</p>
-<p>We also create some constants that we'll need. We define the minimum and maximum positions of the ball (<code>min_pos</code>, <code>max_pos</code>). We also define the minimum and maximum impulse velocity to apply to the ball when it's clicked (<code>min_v</code>, <code>max_v</code>). And finally we create a constant for gravity.</p>
-<p>Next comes the action itself. The comments in the body of the action should help you work out what's going on, but here are some things to note:</p>
+<p>Let’s make the ball bounce when we click it. We’ll add a rotate node
+so we can make the ball spin when it’s in the air. We’ll also tag the
+ball’s translate and rotate nodes so we can easily access them:</p>
+<div class="sourceCode" id="cb40"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb40-1"><a href="#cb40-1" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene <span class="op">=</span> </span>
+<span id="cb40-2"><a href="#cb40-2" aria-hidden="true" tabindex="-1"></a>    am<span class="op">.</span>group<span class="op">()</span></span>
+<span id="cb40-3"><a href="#cb40-3" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> <span class="op">{</span></span>
+<span id="cb40-4"><a href="#cb40-4" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>sprite<span class="st">&quot;beach.jpg&quot;</span></span>
+<span id="cb40-5"><a href="#cb40-5" aria-hidden="true" tabindex="-1"></a>        <span class="op">,</span></span>
+<span id="cb40-6"><a href="#cb40-6" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>translate<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="op">-</span><span class="dv">60</span><span class="op">):</span>tag<span class="st">&quot;ballt&quot;</span></span>
+<span id="cb40-7"><a href="#cb40-7" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> am<span class="op">.</span>rotate<span class="op">(</span><span class="dv">0</span><span class="op">):</span>tag<span class="st">&quot;ballr&quot;</span></span>
+<span id="cb40-8"><a href="#cb40-8" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> am<span class="op">.</span>sprite<span class="st">&quot;ball.png&quot;</span></span>
+<span id="cb40-9"><a href="#cb40-9" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span></code></pre></div>
+<p>Now add an action to animate the ball when it’s clicked:</p>
+<div class="sourceCode" id="cb41"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb41-1"><a href="#cb41-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- ball state variables:</span></span>
+<span id="cb41-2"><a href="#cb41-2" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> ball_pos <span class="op">=</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="op">-</span><span class="dv">60</span><span class="op">)</span></span>
+<span id="cb41-3"><a href="#cb41-3" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> ball_angle <span class="op">=</span> <span class="dv">0</span></span>
+<span id="cb41-4"><a href="#cb41-4" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> velocity <span class="op">=</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">)</span></span>
+<span id="cb41-5"><a href="#cb41-5" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> spin <span class="op">=</span> <span class="dv">0</span></span>
+<span id="cb41-6"><a href="#cb41-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb41-7"><a href="#cb41-7" aria-hidden="true" tabindex="-1"></a><span class="co">-- constants:</span></span>
+<span id="cb41-8"><a href="#cb41-8" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> min_pos <span class="op">=</span> vec2<span class="op">(-</span><span class="dv">180</span><span class="op">,</span> <span class="op">-</span><span class="dv">60</span><span class="op">)</span></span>
+<span id="cb41-9"><a href="#cb41-9" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> max_pos <span class="op">=</span> vec2<span class="op">(</span><span class="dv">180</span><span class="op">,</span> <span class="dv">500</span><span class="op">)</span></span>
+<span id="cb41-10"><a href="#cb41-10" aria-hidden="true" tabindex="-1"></a><span class="co">-- min and max impulse velocity:</span></span>
+<span id="cb41-11"><a href="#cb41-11" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> min_v <span class="op">=</span> vec2<span class="op">(-</span><span class="dv">50</span><span class="op">,</span> <span class="dv">150</span><span class="op">)</span></span>
+<span id="cb41-12"><a href="#cb41-12" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> max_v <span class="op">=</span> vec2<span class="op">(</span><span class="dv">50</span><span class="op">,</span> <span class="dv">300</span><span class="op">)</span></span>
+<span id="cb41-13"><a href="#cb41-13" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> gravity <span class="op">=</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="op">-</span><span class="dv">500</span><span class="op">)</span></span>
+<span id="cb41-14"><a href="#cb41-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb41-15"><a href="#cb41-15" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene<span class="op">:</span>action<span class="op">(</span><span class="kw">function</span><span class="op">(</span>scene<span class="op">)</span></span>
+<span id="cb41-16"><a href="#cb41-16" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- check if the left mouse button was pressed</span></span>
+<span id="cb41-17"><a href="#cb41-17" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> win<span class="op">:</span>mouse_pressed<span class="st">&quot;left&quot;</span> <span class="cf">then</span></span>
+<span id="cb41-18"><a href="#cb41-18" aria-hidden="true" tabindex="-1"></a>        <span class="kw">local</span> mouse_pos <span class="op">=</span> win<span class="op">:</span>mouse_position<span class="op">()</span></span>
+<span id="cb41-19"><a href="#cb41-19" aria-hidden="true" tabindex="-1"></a>        <span class="co">-- check if the mouse click is on the ball</span></span>
+<span id="cb41-20"><a href="#cb41-20" aria-hidden="true" tabindex="-1"></a>        <span class="cf">if</span> math<span class="op">.</span>distance<span class="op">(</span>mouse_pos<span class="op">,</span> ball_pos<span class="op">)</span> <span class="op">&lt;</span> <span class="dv">50</span> <span class="cf">then</span></span>
+<span id="cb41-21"><a href="#cb41-21" aria-hidden="true" tabindex="-1"></a>            <span class="co">-- compute a velocity based on click position</span></span>
+<span id="cb41-22"><a href="#cb41-22" aria-hidden="true" tabindex="-1"></a>            <span class="kw">local</span> dir <span class="op">=</span> math<span class="op">.</span>normalize<span class="op">(</span>ball_pos <span class="op">-</span> mouse_pos<span class="op">)</span></span>
+<span id="cb41-23"><a href="#cb41-23" aria-hidden="true" tabindex="-1"></a>            velocity <span class="op">=</span> dir <span class="op">*</span> <span class="dv">300</span></span>
+<span id="cb41-24"><a href="#cb41-24" aria-hidden="true" tabindex="-1"></a>            velocity <span class="op">=</span> math<span class="op">.</span>clamp<span class="op">(</span>velocity<span class="op">,</span> min_v<span class="op">,</span> max_v<span class="op">)</span></span>
+<span id="cb41-25"><a href="#cb41-25" aria-hidden="true" tabindex="-1"></a>            <span class="co">-- set a random spin</span></span>
+<span id="cb41-26"><a href="#cb41-26" aria-hidden="true" tabindex="-1"></a>            spin <span class="op">=</span> <span class="fu">math.random</span><span class="op">()</span> <span class="op">*</span> <span class="dv">4</span> <span class="op">-</span> <span class="dv">2</span></span>
+<span id="cb41-27"><a href="#cb41-27" aria-hidden="true" tabindex="-1"></a>        <span class="cf">end</span></span>
+<span id="cb41-28"><a href="#cb41-28" aria-hidden="true" tabindex="-1"></a>    <span class="cf">end</span></span>
+<span id="cb41-29"><a href="#cb41-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb41-30"><a href="#cb41-30" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- update the ball position</span></span>
+<span id="cb41-31"><a href="#cb41-31" aria-hidden="true" tabindex="-1"></a>    ball_pos <span class="op">=</span> ball_pos <span class="op">+</span> velocity <span class="op">*</span> am<span class="op">.</span>delta_time</span>
+<span id="cb41-32"><a href="#cb41-32" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb41-33"><a href="#cb41-33" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- if the ball is on the ground, set the</span></span>
+<span id="cb41-34"><a href="#cb41-34" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- velocity and spin to zero.</span></span>
+<span id="cb41-35"><a href="#cb41-35" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> ball_pos<span class="op">.</span>y <span class="op">&lt;=</span> <span class="op">-</span><span class="dv">60</span> <span class="cf">then</span></span>
+<span id="cb41-36"><a href="#cb41-36" aria-hidden="true" tabindex="-1"></a>        velocity <span class="op">=</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">)</span></span>
+<span id="cb41-37"><a href="#cb41-37" aria-hidden="true" tabindex="-1"></a>        spin <span class="op">=</span> <span class="dv">0</span></span>
+<span id="cb41-38"><a href="#cb41-38" aria-hidden="true" tabindex="-1"></a>    <span class="cf">end</span></span>
+<span id="cb41-39"><a href="#cb41-39" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb41-40"><a href="#cb41-40" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- clamp the ball position so it doesn&#39;t disappear</span></span>
+<span id="cb41-41"><a href="#cb41-41" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- off the edge of the screen</span></span>
+<span id="cb41-42"><a href="#cb41-42" aria-hidden="true" tabindex="-1"></a>    ball_pos <span class="op">=</span> math<span class="op">.</span>clamp<span class="op">(</span>ball_pos<span class="op">,</span> min_pos<span class="op">,</span> max_pos<span class="op">)</span></span>
+<span id="cb41-43"><a href="#cb41-43" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb41-44"><a href="#cb41-44" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- update the ball angle</span></span>
+<span id="cb41-45"><a href="#cb41-45" aria-hidden="true" tabindex="-1"></a>    ball_angle <span class="op">=</span> ball_angle <span class="op">+</span> spin <span class="op">*</span> am<span class="op">.</span>delta_time</span>
+<span id="cb41-46"><a href="#cb41-46" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb41-47"><a href="#cb41-47" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- update the ball translate and rotate nodes</span></span>
+<span id="cb41-48"><a href="#cb41-48" aria-hidden="true" tabindex="-1"></a>    scene<span class="st">&quot;ballt&quot;</span><span class="op">.</span>position2d <span class="op">=</span> ball_pos</span>
+<span id="cb41-49"><a href="#cb41-49" aria-hidden="true" tabindex="-1"></a>    scene<span class="st">&quot;ballr&quot;</span><span class="op">.</span>angle <span class="op">=</span> ball_angle</span>
+<span id="cb41-50"><a href="#cb41-50" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb41-51"><a href="#cb41-51" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- apply gravity to the velocity</span></span>
+<span id="cb41-52"><a href="#cb41-52" aria-hidden="true" tabindex="-1"></a>    velocity <span class="op">=</span> velocity <span class="op">+</span> gravity <span class="op">*</span> am<span class="op">.</span>delta_time</span>
+<span id="cb41-53"><a href="#cb41-53" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span><span class="op">)</span></span></code></pre></div>
+<p>First we create some variables to keep track of the ball’s state. We
+need to track its position, angle, velocity and spin (angular velocity).
+The <code>ball_pos</code> and <code>velocity</code> variables are 2
+dimensional vectors, since we want to track position and velocity along
+both the x and y axes. We could have made separate variables for the x
+and y components, but using a <code>vec2</code> is more concise. Note
+that if the values of the x and y components of the vector are the same,
+we only need to give the value once, so we just need to write
+<code>vec2(0)</code> when initialising the velocity instead of
+<code>vec2(0, 0)</code>.</p>
+<p>We also create some constants that we’ll need. We define the minimum
+and maximum positions of the ball (<code>min_pos</code>,
+<code>max_pos</code>). We also define the minimum and maximum impulse
+velocity to apply to the ball when it’s clicked (<code>min_v</code>,
+<code>max_v</code>). And finally we create a constant for gravity.</p>
+<p>Next comes the action itself. The comments in the body of the action
+should help you work out what’s going on, but here are some things to
+note:</p>
 <ul>
-<li><code>win:mouse_pressed(button)</code> can be used to check whether a mouse button was pressed in the last frame. <code>button</code> can be <code>&quot;left&quot;</code>, <code>&quot;right&quot;</code> or <code>&quot;middle&quot;</code>.</li>
-<li><code>win:mouse_position()</code> returns the current mouse position as a <code>vec2</code> value.</li>
-<li><code>math.distance</code> computes the distance between two vectors.</li>
-<li><code>math.clamp</code> clamps a value between two other values. It works with both numbers and vectors.</li>
-<li><code>math.random()</code> returns a random number between 0 and 1.</li>
+<li><code>win:mouse_pressed(button)</code> can be used to check whether
+a mouse button was pressed in the last frame. <code>button</code> can be
+<code>"left"</code>, <code>"right"</code> or <code>"middle"</code>.</li>
+<li><code>win:mouse_position()</code> returns the current mouse position
+as a <code>vec2</code> value.</li>
+<li><code>math.distance</code> computes the distance between two
+vectors.</li>
+<li><code>math.clamp</code> clamps a value between two other values. It
+works with both numbers and vectors.</li>
+<li><code>math.random()</code> returns a random number between 0 and
+1.</li>
 <li><code>am.delta_time</code> is the time since the last frame.</li>
-<li>Vector values can be added, subtracted and multiplied just like numbers. You can also combine numbers and vectors, for example when we multiply <code>gravity</code> by <code>am.delta_time</code>. The result of <code>vec2(x, y) * c</code> is <code>vec2(x*c, y*c)</code>.</li>
+<li>Vector values can be added, subtracted and multiplied just like
+numbers. You can also combine numbers and vectors, for example when we
+multiply <code>gravity</code> by <code>am.delta_time</code>. The result
+of <code>vec2(x, y) * c</code> is <code>vec2(x*c, y*c)</code>.</li>
 </ul>
 <h2 id="playing-audio">Playing audio</h2>
-<p>To play a sound, attach a <code>play</code> action to a scene node in the current scene. For example to play a sound file <code>bounce.ogg</code> we could do the following:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">scene:action<span class="ot">(</span>am<span class="ot">.</span>play<span class="ot">(</span><span class="st">&quot;bounce.ogg&quot;</span><span class="ot">))</span></code></pre></div>
-<p>The file <code>bounce.ogg</code> must exist in the same directory as the script.</p>
-<p>To have a sound loop, pass in a second argument of <code>true</code>, like so:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">win<span class="ot">.</span>scene:action<span class="ot">(</span>am<span class="ot">.</span>play<span class="ot">(</span><span class="st">&quot;ocean.ogg&quot;</span><span class="ot">,</span> <span class="kw">true</span><span class="ot">))</span></code></pre></div>
+<p>To play a sound, attach a <code>play</code> action to a scene node in
+the current scene. For example to play a sound file
+<code>bounce.ogg</code> we could do the following:</p>
+<div class="sourceCode" id="cb42"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb42-1"><a href="#cb42-1" aria-hidden="true" tabindex="-1"></a>scene<span class="op">:</span>action<span class="op">(</span>am<span class="op">.</span>play<span class="op">(</span><span class="st">&quot;bounce.ogg&quot;</span><span class="op">))</span></span></code></pre></div>
+<p>The file <code>bounce.ogg</code> must exist in the same directory as
+the script.</p>
+<p>To have a sound loop, pass in a second argument of <code>true</code>,
+like so:</p>
+<div class="sourceCode" id="cb43"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb43-1"><a href="#cb43-1" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene<span class="op">:</span>action<span class="op">(</span>am<span class="op">.</span>play<span class="op">(</span><span class="st">&quot;ocean.ogg&quot;</span><span class="op">,</span> <span class="kw">true</span><span class="op">))</span></span></code></pre></div>
 <p>Note that Amulet only reads Ogg Vorbis audio files.</p>
-<p>Here are some audio files you can try out with the beach ball game we made previously:</p>
+<p>Here are some audio files you can try out with the beach ball game we
+made previously:</p>
 <ul>
 <li><a href="sounds/bounce.ogg"><code>sounds/bounce.ogg</code></a></li>
 <li><a href="sounds/ocean.ogg"><code>sounds/ocean.ogg</code></a></li>
 <li><a href="sounds/land.ogg"><code>sounds/land.ogg</code></a></li>
 </ul>
-<p>And here is the complete code listing for the beach ball game with sounds included. Note that we need an extra variable <code>on_ground</code> to keep track of whether the ball was on the ground, so we don't play the landing sound every frame.</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> win <span class="ot">=</span> am<span class="ot">.</span>window<span class="ot">{</span>
-    title <span class="ot">=</span> <span class="st">&quot;Beach&quot;</span><span class="ot">,</span>
-    width <span class="ot">=</span> <span class="dv">400</span><span class="ot">,</span>
-    height <span class="ot">=</span> <span class="dv">300</span><span class="ot">,</span>
-<span class="ot">}</span>
-
-win<span class="ot">.</span>scene <span class="ot">=</span> 
-    am<span class="ot">.</span>group<span class="ot">()</span>
-    <span class="ot">^</span> <span class="ot">{</span>
-        am<span class="ot">.</span>sprite<span class="st">&quot;beach.jpg&quot;</span>
-        <span class="ot">,</span>
-        am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">60</span><span class="ot">)</span>:<span class="fu">tag</span><span class="st">&quot;ballt&quot;</span>
-        <span class="ot">^</span> am<span class="ot">.</span>rotate<span class="ot">(</span><span class="dv">0</span><span class="ot">)</span>:<span class="fu">tag</span><span class="st">&quot;ballr&quot;</span>
-        <span class="ot">^</span> am<span class="ot">.</span>sprite<span class="st">&quot;ball.png&quot;</span>
-    <span class="ot">}</span>
-
-<span class="kw">local</span> ball_pos <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">60</span><span class="ot">)</span>
-<span class="kw">local</span> ball_angle <span class="ot">=</span> <span class="dv">0</span>
-<span class="kw">local</span> velocity <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">)</span>
-<span class="kw">local</span> spin <span class="ot">=</span> <span class="dv">0</span>
-<span class="kw">local</span> min_pos <span class="ot">=</span> vec2<span class="ot">(-</span><span class="dv">180</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">60</span><span class="ot">)</span>
-<span class="kw">local</span> max_pos <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">180</span><span class="ot">,</span> <span class="dv">500</span><span class="ot">)</span>
-<span class="kw">local</span> min_v <span class="ot">=</span> vec2<span class="ot">(-</span><span class="dv">50</span><span class="ot">,</span> <span class="dv">150</span><span class="ot">)</span>
-<span class="kw">local</span> max_v <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">50</span><span class="ot">,</span> <span class="dv">300</span><span class="ot">)</span>
-<span class="kw">local</span> gravity <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">500</span><span class="ot">)</span>
-<span class="kw">local</span> on_ground <span class="ot">=</span> <span class="kw">true</span>
-
-win<span class="ot">.</span>scene:action<span class="ot">(</span><span class="kw">function</span><span class="ot">(</span>scene<span class="ot">)</span>
-    <span class="do">-- check if the left mouse button was pressed</span>
-    <span class="kw">if</span> win:mouse_pressed<span class="st">&quot;left&quot;</span> <span class="kw">then</span>
-        <span class="kw">local</span> mouse_pos <span class="ot">=</span> win:mouse_position<span class="ot">()</span>
-        <span class="do">-- check if the mouse click is on the ball</span>
-        <span class="kw">if</span> math<span class="ot">.</span>distance<span class="ot">(</span>mouse_pos<span class="ot">,</span> ball_pos<span class="ot">)</span> <span class="ot">&lt;</span> <span class="dv">50</span> <span class="kw">then</span>
-            <span class="do">-- compute a velocity based on click position</span>
-            <span class="kw">local</span> dir <span class="ot">=</span> math<span class="ot">.</span>normalize<span class="ot">(</span>ball_pos <span class="ot">-</span> mouse_pos<span class="ot">)</span>
-            velocity <span class="ot">=</span> dir <span class="ot">*</span> <span class="dv">300</span>
-            velocity <span class="ot">=</span> math<span class="ot">.</span>clamp<span class="ot">(</span>velocity<span class="ot">,</span> min_v<span class="ot">,</span> max_v<span class="ot">)</span>
-            <span class="do">-- set a random spin</span>
-            spin <span class="ot">=</span> <span class="fu">math.random</span><span class="ot">()</span> <span class="ot">*</span> <span class="dv">4</span> <span class="ot">-</span> <span class="dv">2</span>
-            <span class="do">-- play bounce sound</span>
-            scene:action<span class="ot">(</span>am<span class="ot">.</span>play<span class="ot">(</span><span class="st">&quot;bounce.ogg&quot;</span><span class="ot">))</span>
-            on_ground <span class="ot">=</span> <span class="kw">false</span>
-        <span class="kw">end</span>
-    <span class="kw">end</span>
-
-    <span class="do">-- update the ball position</span>
-    ball_pos <span class="ot">=</span> ball_pos <span class="ot">+</span> velocity <span class="ot">*</span> am<span class="ot">.</span>delta_time
-
-    <span class="do">-- if the ball lands on the ground, set the</span>
-    <span class="do">-- velocity and spin to zero.</span>
-    <span class="kw">if</span> ball_pos<span class="ot">.</span>y <span class="ot">&lt;=</span> <span class="ot">-</span><span class="dv">60</span> <span class="kw">and</span> <span class="kw">not</span> on_ground <span class="kw">then</span>
-        velocity <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">)</span>
-        spin <span class="ot">=</span> <span class="dv">0</span>
-        <span class="do">-- play land sound</span>
-        scene:action<span class="ot">(</span>am<span class="ot">.</span>play<span class="ot">(</span><span class="st">&quot;land.ogg&quot;</span><span class="ot">))</span>
-        on_ground <span class="ot">=</span> <span class="kw">true</span>
-    <span class="kw">end</span>
-
-    <span class="do">-- clamp the ball position so it doesn&#39;t disappear</span>
-    <span class="do">-- off the edge of the screen</span>
-    ball_pos <span class="ot">=</span> math<span class="ot">.</span>clamp<span class="ot">(</span>ball_pos<span class="ot">,</span> min_pos<span class="ot">,</span> max_pos<span class="ot">)</span>
-
-    <span class="do">-- update the ball angle</span>
-    ball_angle <span class="ot">=</span> ball_angle <span class="ot">+</span> spin <span class="ot">*</span> am<span class="ot">.</span>delta_time
-
-    <span class="do">-- update the ball translate and rotate nodes</span>
-    scene<span class="st">&quot;ballt&quot;</span><span class="ot">.</span>position2d <span class="ot">=</span> ball_pos
-    scene<span class="st">&quot;ballr&quot;</span><span class="ot">.</span>angle <span class="ot">=</span> ball_angle
-
-    <span class="do">-- apply gravity to the velocity</span>
-    velocity <span class="ot">=</span> velocity <span class="ot">+</span> gravity <span class="ot">*</span> am<span class="ot">.</span>delta_time
-<span class="kw">end</span><span class="ot">)</span>
-
-<span class="do">-- play ocean sound in a loop</span>
-win<span class="ot">.</span>scene:action<span class="ot">(</span>am<span class="ot">.</span>play<span class="ot">(</span><span class="st">&quot;ocean.ogg&quot;</span><span class="ot">,</span> <span class="kw">true</span><span class="ot">))</span></code></pre></div>
+<p>And here is the complete code listing for the beach ball game with
+sounds included. Note that we need an extra variable
+<code>on_ground</code> to keep track of whether the ball was on the
+ground, so we don’t play the landing sound every frame.</p>
+<div class="sourceCode" id="cb44"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb44-1"><a href="#cb44-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> win <span class="op">=</span> am<span class="op">.</span>window<span class="op">{</span></span>
+<span id="cb44-2"><a href="#cb44-2" aria-hidden="true" tabindex="-1"></a>    title <span class="op">=</span> <span class="st">&quot;Beach&quot;</span><span class="op">,</span></span>
+<span id="cb44-3"><a href="#cb44-3" aria-hidden="true" tabindex="-1"></a>    width <span class="op">=</span> <span class="dv">400</span><span class="op">,</span></span>
+<span id="cb44-4"><a href="#cb44-4" aria-hidden="true" tabindex="-1"></a>    height <span class="op">=</span> <span class="dv">300</span><span class="op">,</span></span>
+<span id="cb44-5"><a href="#cb44-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb44-6"><a href="#cb44-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb44-7"><a href="#cb44-7" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene <span class="op">=</span> </span>
+<span id="cb44-8"><a href="#cb44-8" aria-hidden="true" tabindex="-1"></a>    am<span class="op">.</span>group<span class="op">()</span></span>
+<span id="cb44-9"><a href="#cb44-9" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> <span class="op">{</span></span>
+<span id="cb44-10"><a href="#cb44-10" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>sprite<span class="st">&quot;beach.jpg&quot;</span></span>
+<span id="cb44-11"><a href="#cb44-11" aria-hidden="true" tabindex="-1"></a>        <span class="op">,</span></span>
+<span id="cb44-12"><a href="#cb44-12" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>translate<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="op">-</span><span class="dv">60</span><span class="op">):</span>tag<span class="st">&quot;ballt&quot;</span></span>
+<span id="cb44-13"><a href="#cb44-13" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> am<span class="op">.</span>rotate<span class="op">(</span><span class="dv">0</span><span class="op">):</span>tag<span class="st">&quot;ballr&quot;</span></span>
+<span id="cb44-14"><a href="#cb44-14" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> am<span class="op">.</span>sprite<span class="st">&quot;ball.png&quot;</span></span>
+<span id="cb44-15"><a href="#cb44-15" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb44-16"><a href="#cb44-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb44-17"><a href="#cb44-17" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> ball_pos <span class="op">=</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="op">-</span><span class="dv">60</span><span class="op">)</span></span>
+<span id="cb44-18"><a href="#cb44-18" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> ball_angle <span class="op">=</span> <span class="dv">0</span></span>
+<span id="cb44-19"><a href="#cb44-19" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> velocity <span class="op">=</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">)</span></span>
+<span id="cb44-20"><a href="#cb44-20" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> spin <span class="op">=</span> <span class="dv">0</span></span>
+<span id="cb44-21"><a href="#cb44-21" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> min_pos <span class="op">=</span> vec2<span class="op">(-</span><span class="dv">180</span><span class="op">,</span> <span class="op">-</span><span class="dv">60</span><span class="op">)</span></span>
+<span id="cb44-22"><a href="#cb44-22" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> max_pos <span class="op">=</span> vec2<span class="op">(</span><span class="dv">180</span><span class="op">,</span> <span class="dv">500</span><span class="op">)</span></span>
+<span id="cb44-23"><a href="#cb44-23" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> min_v <span class="op">=</span> vec2<span class="op">(-</span><span class="dv">50</span><span class="op">,</span> <span class="dv">150</span><span class="op">)</span></span>
+<span id="cb44-24"><a href="#cb44-24" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> max_v <span class="op">=</span> vec2<span class="op">(</span><span class="dv">50</span><span class="op">,</span> <span class="dv">300</span><span class="op">)</span></span>
+<span id="cb44-25"><a href="#cb44-25" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> gravity <span class="op">=</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="op">-</span><span class="dv">500</span><span class="op">)</span></span>
+<span id="cb44-26"><a href="#cb44-26" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> on_ground <span class="op">=</span> <span class="kw">true</span></span>
+<span id="cb44-27"><a href="#cb44-27" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb44-28"><a href="#cb44-28" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene<span class="op">:</span>action<span class="op">(</span><span class="kw">function</span><span class="op">(</span>scene<span class="op">)</span></span>
+<span id="cb44-29"><a href="#cb44-29" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- check if the left mouse button was pressed</span></span>
+<span id="cb44-30"><a href="#cb44-30" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> win<span class="op">:</span>mouse_pressed<span class="st">&quot;left&quot;</span> <span class="cf">then</span></span>
+<span id="cb44-31"><a href="#cb44-31" aria-hidden="true" tabindex="-1"></a>        <span class="kw">local</span> mouse_pos <span class="op">=</span> win<span class="op">:</span>mouse_position<span class="op">()</span></span>
+<span id="cb44-32"><a href="#cb44-32" aria-hidden="true" tabindex="-1"></a>        <span class="co">-- check if the mouse click is on the ball</span></span>
+<span id="cb44-33"><a href="#cb44-33" aria-hidden="true" tabindex="-1"></a>        <span class="cf">if</span> math<span class="op">.</span>distance<span class="op">(</span>mouse_pos<span class="op">,</span> ball_pos<span class="op">)</span> <span class="op">&lt;</span> <span class="dv">50</span> <span class="cf">then</span></span>
+<span id="cb44-34"><a href="#cb44-34" aria-hidden="true" tabindex="-1"></a>            <span class="co">-- compute a velocity based on click position</span></span>
+<span id="cb44-35"><a href="#cb44-35" aria-hidden="true" tabindex="-1"></a>            <span class="kw">local</span> dir <span class="op">=</span> math<span class="op">.</span>normalize<span class="op">(</span>ball_pos <span class="op">-</span> mouse_pos<span class="op">)</span></span>
+<span id="cb44-36"><a href="#cb44-36" aria-hidden="true" tabindex="-1"></a>            velocity <span class="op">=</span> dir <span class="op">*</span> <span class="dv">300</span></span>
+<span id="cb44-37"><a href="#cb44-37" aria-hidden="true" tabindex="-1"></a>            velocity <span class="op">=</span> math<span class="op">.</span>clamp<span class="op">(</span>velocity<span class="op">,</span> min_v<span class="op">,</span> max_v<span class="op">)</span></span>
+<span id="cb44-38"><a href="#cb44-38" aria-hidden="true" tabindex="-1"></a>            <span class="co">-- set a random spin</span></span>
+<span id="cb44-39"><a href="#cb44-39" aria-hidden="true" tabindex="-1"></a>            spin <span class="op">=</span> <span class="fu">math.random</span><span class="op">()</span> <span class="op">*</span> <span class="dv">4</span> <span class="op">-</span> <span class="dv">2</span></span>
+<span id="cb44-40"><a href="#cb44-40" aria-hidden="true" tabindex="-1"></a>            <span class="co">-- play bounce sound</span></span>
+<span id="cb44-41"><a href="#cb44-41" aria-hidden="true" tabindex="-1"></a>            scene<span class="op">:</span>action<span class="op">(</span>am<span class="op">.</span>play<span class="op">(</span><span class="st">&quot;bounce.ogg&quot;</span><span class="op">))</span></span>
+<span id="cb44-42"><a href="#cb44-42" aria-hidden="true" tabindex="-1"></a>            on_ground <span class="op">=</span> <span class="kw">false</span></span>
+<span id="cb44-43"><a href="#cb44-43" aria-hidden="true" tabindex="-1"></a>        <span class="cf">end</span></span>
+<span id="cb44-44"><a href="#cb44-44" aria-hidden="true" tabindex="-1"></a>    <span class="cf">end</span></span>
+<span id="cb44-45"><a href="#cb44-45" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb44-46"><a href="#cb44-46" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- update the ball position</span></span>
+<span id="cb44-47"><a href="#cb44-47" aria-hidden="true" tabindex="-1"></a>    ball_pos <span class="op">=</span> ball_pos <span class="op">+</span> velocity <span class="op">*</span> am<span class="op">.</span>delta_time</span>
+<span id="cb44-48"><a href="#cb44-48" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb44-49"><a href="#cb44-49" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- if the ball lands on the ground, set the</span></span>
+<span id="cb44-50"><a href="#cb44-50" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- velocity and spin to zero.</span></span>
+<span id="cb44-51"><a href="#cb44-51" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> ball_pos<span class="op">.</span>y <span class="op">&lt;=</span> <span class="op">-</span><span class="dv">60</span> <span class="kw">and</span> <span class="kw">not</span> on_ground <span class="cf">then</span></span>
+<span id="cb44-52"><a href="#cb44-52" aria-hidden="true" tabindex="-1"></a>        velocity <span class="op">=</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">)</span></span>
+<span id="cb44-53"><a href="#cb44-53" aria-hidden="true" tabindex="-1"></a>        spin <span class="op">=</span> <span class="dv">0</span></span>
+<span id="cb44-54"><a href="#cb44-54" aria-hidden="true" tabindex="-1"></a>        <span class="co">-- play land sound</span></span>
+<span id="cb44-55"><a href="#cb44-55" aria-hidden="true" tabindex="-1"></a>        scene<span class="op">:</span>action<span class="op">(</span>am<span class="op">.</span>play<span class="op">(</span><span class="st">&quot;land.ogg&quot;</span><span class="op">))</span></span>
+<span id="cb44-56"><a href="#cb44-56" aria-hidden="true" tabindex="-1"></a>        on_ground <span class="op">=</span> <span class="kw">true</span></span>
+<span id="cb44-57"><a href="#cb44-57" aria-hidden="true" tabindex="-1"></a>    <span class="cf">end</span></span>
+<span id="cb44-58"><a href="#cb44-58" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb44-59"><a href="#cb44-59" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- clamp the ball position so it doesn&#39;t disappear</span></span>
+<span id="cb44-60"><a href="#cb44-60" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- off the edge of the screen</span></span>
+<span id="cb44-61"><a href="#cb44-61" aria-hidden="true" tabindex="-1"></a>    ball_pos <span class="op">=</span> math<span class="op">.</span>clamp<span class="op">(</span>ball_pos<span class="op">,</span> min_pos<span class="op">,</span> max_pos<span class="op">)</span></span>
+<span id="cb44-62"><a href="#cb44-62" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb44-63"><a href="#cb44-63" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- update the ball angle</span></span>
+<span id="cb44-64"><a href="#cb44-64" aria-hidden="true" tabindex="-1"></a>    ball_angle <span class="op">=</span> ball_angle <span class="op">+</span> spin <span class="op">*</span> am<span class="op">.</span>delta_time</span>
+<span id="cb44-65"><a href="#cb44-65" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb44-66"><a href="#cb44-66" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- update the ball translate and rotate nodes</span></span>
+<span id="cb44-67"><a href="#cb44-67" aria-hidden="true" tabindex="-1"></a>    scene<span class="st">&quot;ballt&quot;</span><span class="op">.</span>position2d <span class="op">=</span> ball_pos</span>
+<span id="cb44-68"><a href="#cb44-68" aria-hidden="true" tabindex="-1"></a>    scene<span class="st">&quot;ballr&quot;</span><span class="op">.</span>angle <span class="op">=</span> ball_angle</span>
+<span id="cb44-69"><a href="#cb44-69" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb44-70"><a href="#cb44-70" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- apply gravity to the velocity</span></span>
+<span id="cb44-71"><a href="#cb44-71" aria-hidden="true" tabindex="-1"></a>    velocity <span class="op">=</span> velocity <span class="op">+</span> gravity <span class="op">*</span> am<span class="op">.</span>delta_time</span>
+<span id="cb44-72"><a href="#cb44-72" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span><span class="op">)</span></span>
+<span id="cb44-73"><a href="#cb44-73" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb44-74"><a href="#cb44-74" aria-hidden="true" tabindex="-1"></a><span class="co">-- play ocean sound in a loop</span></span>
+<span id="cb44-75"><a href="#cb44-75" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene<span class="op">:</span>action<span class="op">(</span>am<span class="op">.</span>play<span class="op">(</span><span class="st">&quot;ocean.ogg&quot;</span><span class="op">,</span> <span class="kw">true</span><span class="op">))</span></span></code></pre></div>
 <h1 id="math">Math</h1>
-<div class="figure">
-<img src="images/screenshot1.jpg" />
-
-</div>
+<p><img src="images/screenshot1.jpg" /></p>
 <h2 id="vectors">Vectors</h2>
-<p>Amulet has built-in support for 2, 3 or 4 dimensional vectors. Vectors are typically used to represent things like position, direction or velocity in 2 or 3 dimensional space. Representing RGBA colors is another common use of 4 dimensional vectors.</p>
-<p>In Amulet vectors are immutable. This means that once you create a vector, its value cannot be changed. Instead you need to construct a new vector.</p>
+<p>Amulet has built-in support for 2, 3 or 4 dimensional vectors.
+Vectors are typically used to represent things like position, direction
+or velocity in 2 or 3 dimensional space. Representing RGBA colors is
+another common use of 4 dimensional vectors.</p>
+<p>In Amulet vectors are immutable. This means that once you create a
+vector, its value cannot be changed. Instead you need to construct a new
+vector.</p>
 <h3 id="constructing-vectors">Constructing vectors</h3>
-<p>To construct a vector use one of the functions <code>vec2</code>, <code>vec3</code> or <code>vec4</code>. A vector may be constructed by passing its components as separate arguments to one of these functions, for example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> velocity <span class="ot">=</span> vec3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">,</span> <span class="dv">3</span><span class="ot">)</span></code></pre></div>
-<p>Passing a single number to a vector constructor will set all components of the vector to that value. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> origin <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">)</span></code></pre></div>
+<p>To construct a vector use one of the functions <code>vec2</code>,
+<code>vec3</code> or <code>vec4</code>. A vector may be constructed by
+passing its components as separate arguments to one of these functions,
+for example:</p>
+<div class="sourceCode" id="cb45"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb45-1"><a href="#cb45-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> velocity <span class="op">=</span> vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">,</span> <span class="dv">3</span><span class="op">)</span></span></code></pre></div>
+<p>Passing a single number to a vector constructor will set all
+components of the vector to that value. For example:</p>
+<div class="sourceCode" id="cb46"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb46-1"><a href="#cb46-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> origin <span class="op">=</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">)</span></span></code></pre></div>
 <p>sets <code>origin</code> to the value <code>vec2(0, 0)</code>.</p>
-<p>It's also possible to construct a vector from a combination of other vectors and numbers. The new vector's components will be taken from the other vectors in the order they are passed in. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> bottom_left <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">)</span>
-<span class="kw">local</span> top_right <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">10</span><span class="ot">,</span> <span class="dv">100</span><span class="ot">)</span>
-<span class="kw">local</span> rect <span class="ot">=</span> vec4<span class="ot">(</span>bottom_left<span class="ot">,</span> top_right<span class="ot">)</span></code></pre></div>
+<p>It’s also possible to construct a vector from a combination of other
+vectors and numbers. The new vector’s components will be taken from the
+other vectors in the order they are passed in. For example:</p>
+<div class="sourceCode" id="cb47"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb47-1"><a href="#cb47-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> bottom_left <span class="op">=</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">)</span></span>
+<span id="cb47-2"><a href="#cb47-2" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> top_right <span class="op">=</span> vec2<span class="op">(</span><span class="dv">10</span><span class="op">,</span> <span class="dv">100</span><span class="op">)</span></span>
+<span id="cb47-3"><a href="#cb47-3" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> rect <span class="op">=</span> vec4<span class="op">(</span>bottom_left<span class="op">,</span> top_right<span class="op">)</span></span></code></pre></div>
 <p>sets <code>rect</code> to <code>vec4(0, 0, 10, 100)</code></p>
 <h3 id="accessing-vector-components">Accessing vector components</h3>
-<p>There are multiple ways to access the components of a vector. The first component can be accessed using any of the fields <code>x</code>, <code>r</code> or <code>s</code>; the second using any of the fields <code>y</code>, <code>g</code> or <code>t</code>; the third using any of the fields <code>z</code>, <code>b</code> or <code>p</code>; and the fourth using any of the fields <code>w</code>, <code>a</code> or <code>q</code>. Here are some examples:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> color <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0.1</span><span class="ot">,</span> <span class="dv">0.3</span><span class="ot">,</span> <span class="dv">0.7</span><span class="ot">,</span> <span class="dv">0.8</span><span class="ot">)</span>
-<span class="fu">print</span><span class="ot">(</span>color<span class="ot">.</span>r<span class="ot">..</span><span class="st">&quot;, &quot;</span><span class="ot">..</span>color<span class="ot">.</span>g<span class="ot">..</span><span class="st">&quot;, &quot;</span><span class="ot">..</span>color<span class="ot">.</span>b<span class="ot">..</span><span class="st">&quot;, &quot;</span><span class="ot">..</span>color<span class="ot">.</span>a<span class="ot">)</span>
-<span class="kw">local</span> point <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">5</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">)</span>
-<span class="fu">print</span><span class="ot">(</span><span class="st">&quot;x=&quot;</span><span class="ot">..</span>point<span class="ot">.</span>x<span class="ot">..</span><span class="st">&quot;, y=&quot;</span><span class="ot">..</span>point<span class="ot">.</span>y<span class="ot">)</span></code></pre></div>
-<p>A vector's components can also be accessed with 1-based integer indices.</p>
-<p>Vectors support the Lua length operator (<code>#</code>), which returns the number of components of the vector (not its magnitude). This allows for iterating through the components of a vector of unknown size, for example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> v <span class="ot">=</span> vec3<span class="ot">(</span><span class="dv">10</span><span class="ot">,</span> <span class="dv">20</span><span class="ot">,</span> <span class="dv">30</span><span class="ot">)</span>
-<span class="kw">for</span> i <span class="ot">=</span> <span class="dv">1</span><span class="ot">,</span> <span class="ot">#</span>v <span class="kw">do</span>
-    <span class="fu">print</span><span class="ot">(</span>v<span class="ot">[</span>i<span class="ot">])</span>
-<span class="kw">end</span></code></pre></div>
+<p>There are multiple ways to access the components of a vector. The
+first component can be accessed using any of the fields <code>x</code>,
+<code>r</code> or <code>s</code>; the second using any of the fields
+<code>y</code>, <code>g</code> or <code>t</code>; the third using any of
+the fields <code>z</code>, <code>b</code> or <code>p</code>; and the
+fourth using any of the fields <code>w</code>, <code>a</code> or
+<code>q</code>. Here are some examples:</p>
+<div class="sourceCode" id="cb48"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb48-1"><a href="#cb48-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> color <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0.1</span><span class="op">,</span> <span class="dv">0.3</span><span class="op">,</span> <span class="dv">0.7</span><span class="op">,</span> <span class="dv">0.8</span><span class="op">)</span></span>
+<span id="cb48-2"><a href="#cb48-2" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>color<span class="op">.</span>r<span class="op">..</span><span class="st">&quot;, &quot;</span><span class="op">..</span>color<span class="op">.</span>g<span class="op">..</span><span class="st">&quot;, &quot;</span><span class="op">..</span>color<span class="op">.</span>b<span class="op">..</span><span class="st">&quot;, &quot;</span><span class="op">..</span>color<span class="op">.</span>a<span class="op">)</span></span>
+<span id="cb48-3"><a href="#cb48-3" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> point <span class="op">=</span> vec2<span class="op">(</span><span class="dv">5</span><span class="op">,</span> <span class="dv">2</span><span class="op">)</span></span>
+<span id="cb48-4"><a href="#cb48-4" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span><span class="st">&quot;x=&quot;</span><span class="op">..</span>point<span class="op">.</span>x<span class="op">..</span><span class="st">&quot;, y=&quot;</span><span class="op">..</span>point<span class="op">.</span>y<span class="op">)</span></span></code></pre></div>
+<p>A vector’s components can also be accessed with 1-based integer
+indices.</p>
+<p>Vectors support the Lua length operator (<code>#</code>), which
+returns the number of components of the vector (not its magnitude). This
+allows for iterating through the components of a vector of unknown size,
+for example:</p>
+<div class="sourceCode" id="cb49"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb49-1"><a href="#cb49-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> v <span class="op">=</span> vec3<span class="op">(</span><span class="dv">10</span><span class="op">,</span> <span class="dv">20</span><span class="op">,</span> <span class="dv">30</span><span class="op">)</span></span>
+<span id="cb49-2"><a href="#cb49-2" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> i <span class="op">=</span> <span class="dv">1</span><span class="op">,</span> <span class="op">#</span>v <span class="cf">do</span></span>
+<span id="cb49-3"><a href="#cb49-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span>v<span class="op">[</span>i<span class="op">])</span></span>
+<span id="cb49-4"><a href="#cb49-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span></span></code></pre></div>
 <h3 id="swizzle-fields">Swizzle fields</h3>
-<p>Another way to construct vectors is to recombine the components of an existing vector using <em>swizzle fields</em>, which are special fields whose names consist of a combination of any of the component field characters. A new vector containing the named components will be returned. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> dir <span class="ot">=</span> vec3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">,</span> <span class="dv">3</span><span class="ot">)</span>
-<span class="fu">print</span><span class="ot">(</span>dir<span class="ot">.</span>xy<span class="ot">)</span>
-<span class="fu">print</span><span class="ot">(</span>dir<span class="ot">.</span>rggb<span class="ot">)</span>
-<span class="fu">print</span><span class="ot">(</span>dir<span class="ot">.</span>zzys<span class="ot">)</span></code></pre></div>
+<p>Another way to construct vectors is to recombine the components of an
+existing vector using <em>swizzle fields</em>, which are special fields
+whose names consist of a combination of any of the component field
+characters. A new vector containing the named components will be
+returned. For example:</p>
+<div class="sourceCode" id="cb50"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb50-1"><a href="#cb50-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> dir <span class="op">=</span> vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">,</span> <span class="dv">3</span><span class="op">)</span></span>
+<span id="cb50-2"><a href="#cb50-2" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>dir<span class="op">.</span>xy<span class="op">)</span></span>
+<span id="cb50-3"><a href="#cb50-3" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>dir<span class="op">.</span>rggb<span class="op">)</span></span>
+<span id="cb50-4"><a href="#cb50-4" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>dir<span class="op">.</span>zzys<span class="op">)</span></span></code></pre></div>
 <p>Running the above code results in the following output:</p>
 <pre class="console"><code>vec2(1, 2)
 vec4(1, 2, 2, 3)
 vec4(3, 3, 2, 1)</code></pre>
-<p><strong>Note:</strong> You can pass vectors, matrices and quaternions directly to <code>print</code> or other functions that expect strings and they will be formatted appropriately.</p>
+<p><strong>Note:</strong> You can pass vectors, matrices and quaternions
+directly to <code>print</code> or other functions that expect strings
+and they will be formatted appropriately.</p>
 <h3 id="vector-update-syntax">Vector update syntax</h3>
-<p>Although you can't directly set the components of a vector, Amulet provides some syntactic sugar to make it easier to create a new vector from an existing vector that has only some fields modified. Say, for example, you had a 3 dimensional vector, <code>v1</code>, and you wanted to create a new vector, <code>v2</code>, that had the same components as <code>v1</code>, except for the y component, which you'd like to be 10. One way to do this would be to write:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">v2 <span class="ot">=</span> vec3<span class="ot">(</span>v1<span class="ot">.</span>x<span class="ot">,</span> <span class="dv">10</span><span class="ot">,</span> v1<span class="ot">.</span>z<span class="ot">)</span></code></pre></div>
+<p>Although you can’t directly set the components of a vector, Amulet
+provides some syntactic sugar to make it easier to create a new vector
+from an existing vector that has only some fields modified. Say, for
+example, you had a 3 dimensional vector, <code>v1</code>, and you wanted
+to create a new vector, <code>v2</code>, that had the same components as
+<code>v1</code>, except for the y component, which you’d like to be 10.
+One way to do this would be to write:</p>
+<div class="sourceCode" id="cb52"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb52-1"><a href="#cb52-1" aria-hidden="true" tabindex="-1"></a>v2 <span class="op">=</span> vec3<span class="op">(</span>v1<span class="op">.</span>x<span class="op">,</span> <span class="dv">10</span><span class="op">,</span> v1<span class="op">.</span>z<span class="op">)</span></span></code></pre></div>
 <p>but Amulet also allows you to write:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">v2 <span class="ot">=</span> v1<span class="ot">{</span>y <span class="ot">=</span> <span class="dv">10</span><span class="ot">}</span></code></pre></div>
-<p>You can use this syntax to &quot;update&quot; multiple components and it also supports swizzle fields. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> v <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">,</span> <span class="dv">3</span><span class="ot">,</span> <span class="dv">4</span><span class="ot">)</span>
-v <span class="ot">=</span> v<span class="ot">{</span>x <span class="ot">=</span> <span class="dv">5</span><span class="ot">,</span> ba <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">6</span><span class="ot">)}</span></code></pre></div>
+<div class="sourceCode" id="cb53"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb53-1"><a href="#cb53-1" aria-hidden="true" tabindex="-1"></a>v2 <span class="op">=</span> v1<span class="op">{</span>y <span class="op">=</span> <span class="dv">10</span><span class="op">}</span></span></code></pre></div>
+<p>You can use this syntax to “update” multiple components and it also
+supports swizzle fields. For example:</p>
+<div class="sourceCode" id="cb54"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb54-1"><a href="#cb54-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> v <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">,</span> <span class="dv">3</span><span class="op">,</span> <span class="dv">4</span><span class="op">)</span></span>
+<span id="cb54-2"><a href="#cb54-2" aria-hidden="true" tabindex="-1"></a>v <span class="op">=</span> v<span class="op">{</span>x <span class="op">=</span> <span class="dv">5</span><span class="op">,</span> ba <span class="op">=</span> vec2<span class="op">(</span><span class="dv">6</span><span class="op">)}</span></span></code></pre></div>
 <p>This would set <code>v</code> to <code>vec4(5, 2, 6, 6)</code>.</p>
-<p>If the values of a swizzle field are going to be updated to the same value (as with <code>ba</code> above), you can just set the field to the value instead of constructing a vector. So the above could also have been written as:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">v <span class="ot">=</span> v<span class="ot">{</span>x <span class="ot">=</span> <span class="dv">5</span><span class="ot">,</span> ba <span class="ot">=</span> <span class="dv">6</span><span class="ot">}</span></code></pre></div>
+<p>If the values of a swizzle field are going to be updated to the same
+value (as with <code>ba</code> above), you can just set the field to the
+value instead of constructing a vector. So the above could also have
+been written as:</p>
+<div class="sourceCode" id="cb55"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb55-1"><a href="#cb55-1" aria-hidden="true" tabindex="-1"></a>v <span class="op">=</span> v<span class="op">{</span>x <span class="op">=</span> <span class="dv">5</span><span class="op">,</span> ba <span class="op">=</span> <span class="dv">6</span><span class="op">}</span></span></code></pre></div>
 <h3 id="vector-arithmetic">Vector arithmetic</h3>
-<p>You can do arithmetic with vectors using the standard operators <code>+</code>, <code>-</code>, <code>*</code> and <code>/</code>. If both operands are vectors then they should have the same size and the operation is applied in a component-wise fashion, yielding a new vector of the same size. If one operand is a number then the operation is applied to each component of the vector, yielding a new vector of the same size as the vector operand. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="fu">print</span><span class="ot">(</span>vec2<span class="ot">(</span><span class="dv">3</span><span class="ot">,</span> <span class="dv">4</span><span class="ot">)</span> <span class="ot">+</span> <span class="dv">1</span><span class="ot">)</span>
-<span class="fu">print</span><span class="ot">(</span>vec3<span class="ot">(</span><span class="dv">30</span><span class="ot">)</span> <span class="ot">/</span> vec3<span class="ot">(</span><span class="dv">3</span><span class="ot">,</span> <span class="dv">10</span><span class="ot">,</span> <span class="dv">5</span><span class="ot">))</span>
-<span class="fu">print</span><span class="ot">(</span><span class="dv">2</span> <span class="ot">*</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">,</span> <span class="dv">3</span><span class="ot">,</span> <span class="dv">4</span><span class="ot">))</span></code></pre></div>
+<p>You can do arithmetic with vectors using the standard operators
+<code>+</code>, <code>-</code>, <code>*</code> and <code>/</code>. If
+both operands are vectors then they should have the same size and the
+operation is applied in a component-wise fashion, yielding a new vector
+of the same size. If one operand is a number then the operation is
+applied to each component of the vector, yielding a new vector of the
+same size as the vector operand. For example:</p>
+<div class="sourceCode" id="cb56"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb56-1"><a href="#cb56-1" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>vec2<span class="op">(</span><span class="dv">3</span><span class="op">,</span> <span class="dv">4</span><span class="op">)</span> <span class="op">+</span> <span class="dv">1</span><span class="op">)</span></span>
+<span id="cb56-2"><a href="#cb56-2" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>vec3<span class="op">(</span><span class="dv">30</span><span class="op">)</span> <span class="op">/</span> vec3<span class="op">(</span><span class="dv">3</span><span class="op">,</span> <span class="dv">10</span><span class="op">,</span> <span class="dv">5</span><span class="op">))</span></span>
+<span id="cb56-3"><a href="#cb56-3" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span><span class="dv">2</span> <span class="op">*</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">,</span> <span class="dv">3</span><span class="op">,</span> <span class="dv">4</span><span class="op">))</span></span></code></pre></div>
 <p>produces the following output:</p>
 <pre class="console"><code>vec2(4, 5)
 vec3(10, 3, 6)
 vec4(2, 4, 6, 8)</code></pre>
 <p>Vectors can be compared by value with <code>==</code> like this:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">if</span> vec2<span class="ot">(</span>x<span class="ot">,</span>y<span class="ot">)</span> <span class="ot">==</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span><span class="dv">0</span><span class="ot">)</span> <span class="kw">then</span> <span class="ot">...</span></code></pre></div>
-<p>Also, you can concatenate vectors with strings for easy formatting:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> label <span class="ot">=</span> <span class="st">&quot;position: &quot;</span><span class="ot">..</span>vec2<span class="ot">(</span>x<span class="ot">,</span>y<span class="ot">)</span></code></pre></div>
+<div class="sourceCode" id="cb58"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb58-1"><a href="#cb58-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> vec2<span class="op">(</span>x<span class="op">,</span>y<span class="op">)</span> <span class="op">==</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span><span class="dv">0</span><span class="op">)</span> <span class="cf">then</span> <span class="op">...</span></span></code></pre></div>
+<p>Also, you can concatenate vectors with strings for easy
+formatting:</p>
+<div class="sourceCode" id="cb59"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb59-1"><a href="#cb59-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> label <span class="op">=</span> <span class="st">&quot;position: &quot;</span><span class="op">..</span>vec2<span class="op">(</span>x<span class="op">,</span>y<span class="op">)</span></span></code></pre></div>
 <hr />
-<div class="figure">
-<img src="images/screenshot4.jpg" />
-
-</div>
+<p><img src="images/screenshot4.jpg" /></p>
 <h2 id="matrices">Matrices</h2>
-<p>Amulet has built-in support for 2x2, 3x3 and 4x4 matrices. Matrices are typically used to represent transformations in 2 or 3 dimensional space such as rotation, scaling, translation or perspective projection.</p>
+<p>Amulet has built-in support for 2x2, 3x3 and 4x4 matrices. Matrices
+are typically used to represent transformations in 2 or 3 dimensional
+space such as rotation, scaling, translation or perspective
+projection.</p>
 <p>Matrices, like vectors, are immutable.</p>
 <h3 id="constructing-matrices">Constructing matrices</h3>
-<p>Use one of the functions <code>mat2</code>, <code>mat3</code> or <code>mat4</code> to construct a 2x2, 3x3 or 4x4 matrix.</p>
-<p>Passing a single number argument to one of the matrix constructors generates a matrix with all diagonal elements equal to the number and all other elements equal to zero. For example <code>mat3(1)</code> constructs the 3x3 identity matrix:</p>
+<p>Use one of the functions <code>mat2</code>, <code>mat3</code> or
+<code>mat4</code> to construct a 2x2, 3x3 or 4x4 matrix.</p>
+<p>Passing a single number argument to one of the matrix constructors
+generates a matrix with all diagonal elements equal to the number and
+all other elements equal to zero. For example <code>mat3(1)</code>
+constructs the 3x3 identity matrix:</p>
 <div class="math">
 <span class="math display">\[\begin{bmatrix}
     1 &amp; 0 &amp; 0 \\
@@ -1176,10 +1805,14 @@ vec4(2, 4, 6, 8)</code></pre>
     0 &amp; 0 &amp; 1
 \end{bmatrix}\]</span>
 </div>
-<p>You can also pass the individual elements of the matrix as arguments to one of the constructors. These can either be numbers or vectors or a mix of the two. As the constructor arguments are consumed from left to right, the matrix is filled in column by column. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> m <span class="ot">=</span> mat3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">,</span> <span class="dv">3</span><span class="ot">,</span>
-               <span class="dv">4</span><span class="ot">,</span> <span class="dv">5</span><span class="ot">,</span> <span class="dv">6</span><span class="ot">,</span>
-               <span class="dv">7</span><span class="ot">,</span> <span class="dv">8</span><span class="ot">,</span> <span class="dv">9</span><span class="ot">)</span></code></pre></div>
+<p>You can also pass the individual elements of the matrix as arguments
+to one of the constructors. These can either be numbers or vectors or a
+mix of the two. As the constructor arguments are consumed from left to
+right, the matrix is filled in column by column. For example:</p>
+<div class="sourceCode" id="cb60"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb60-1"><a href="#cb60-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> m <span class="op">=</span> mat3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">,</span> <span class="dv">3</span><span class="op">,</span></span>
+<span id="cb60-2"><a href="#cb60-2" aria-hidden="true" tabindex="-1"></a>               <span class="dv">4</span><span class="op">,</span> <span class="dv">5</span><span class="op">,</span> <span class="dv">6</span><span class="op">,</span></span>
+<span id="cb60-3"><a href="#cb60-3" aria-hidden="true" tabindex="-1"></a>               <span class="dv">7</span><span class="op">,</span> <span class="dv">8</span><span class="op">,</span> <span class="dv">9</span><span class="op">)</span></span></code></pre></div>
 <p>sets <code>m</code> to the matrix:</p>
 <div class="math">
 <span class="math display">\[\begin{bmatrix}
@@ -1188,23 +1821,33 @@ vec4(2, 4, 6, 8)</code></pre>
     3 &amp; 6 &amp; 9
 \end{bmatrix}\]</span>
 </div>
-<p>Here's another example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> m <span class="ot">=</span> mat4<span class="ot">(</span>vec3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">,</span> <span class="dv">3</span><span class="ot">),</span> <span class="dv">4</span><span class="ot">,</span>
-               vec4<span class="ot">(</span><span class="dv">5</span><span class="ot">,</span> <span class="dv">6</span><span class="ot">,</span> <span class="dv">7</span><span class="ot">,</span> <span class="dv">8</span><span class="ot">),</span>
-               vec2<span class="ot">(</span><span class="dv">9</span><span class="ot">,</span> <span class="dv">10</span><span class="ot">),</span> vec2<span class="ot">(</span><span class="dv">11</span><span class="ot">,</span> <span class="dv">12</span><span class="ot">),</span>
-               <span class="dv">13</span><span class="ot">,</span> <span class="dv">14</span><span class="ot">,</span> <span class="dv">15</span><span class="ot">,</span> <span class="dv">16</span><span class="ot">)</span></code></pre></div>
+<p>Here’s another example:</p>
+<div class="sourceCode" id="cb61"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb61-1"><a href="#cb61-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> m <span class="op">=</span> mat4<span class="op">(</span>vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">,</span> <span class="dv">3</span><span class="op">),</span> <span class="dv">4</span><span class="op">,</span></span>
+<span id="cb61-2"><a href="#cb61-2" aria-hidden="true" tabindex="-1"></a>               vec4<span class="op">(</span><span class="dv">5</span><span class="op">,</span> <span class="dv">6</span><span class="op">,</span> <span class="dv">7</span><span class="op">,</span> <span class="dv">8</span><span class="op">),</span></span>
+<span id="cb61-3"><a href="#cb61-3" aria-hidden="true" tabindex="-1"></a>               vec2<span class="op">(</span><span class="dv">9</span><span class="op">,</span> <span class="dv">10</span><span class="op">),</span> vec2<span class="op">(</span><span class="dv">11</span><span class="op">,</span> <span class="dv">12</span><span class="op">),</span></span>
+<span id="cb61-4"><a href="#cb61-4" aria-hidden="true" tabindex="-1"></a>               <span class="dv">13</span><span class="op">,</span> <span class="dv">14</span><span class="op">,</span> <span class="dv">15</span><span class="op">,</span> <span class="dv">16</span><span class="op">)</span></span></code></pre></div>
 <p>This sets <code>m</code> to the matrix:</p>
 <div class="math">
 <span class="math display">\[\begin{bmatrix}
-    1 &amp;  5 &amp;  9 &amp; 13 \\ 
-    2 &amp;  6 &amp; 10 &amp; 14 \\ 
-    3 &amp;  7 &amp; 11 &amp; 15 \\ 
+    1 &amp;  5 &amp;  9 &amp; 13 \\
+    2 &amp;  6 &amp; 10 &amp; 14 \\
+    3 &amp;  7 &amp; 11 &amp; 15 \\
     4 &amp;  8 &amp; 12 &amp; 16
 \end{bmatrix}\]</span>
 </div>
-<p><strong>Note</strong>: Matrix constructors are admittedly somewhat confusing, because when you write the matrix constructor in code the columns are layed out horizontally. This is however the convention used in the OpenGL Shader Language (GLSL).</p>
-<p>A matrix can also be constructed by passing an existing matrix to one of the matrix construction functions. If the existing matrix is larger than the new one, the new matrix's elements come from the top-left corner of the existing matrix. Otherwise the top-left corner of the new matrix is filled with the contents of the existing matrix and the rest from the identity matrix. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> m <span class="ot">=</span> mat4<span class="ot">(</span>mat2<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">,</span> <span class="dv">3</span><span class="ot">,</span> <span class="dv">4</span><span class="ot">))</span></code></pre></div>
+<p><strong>Note</strong>: Matrix constructors are admittedly somewhat
+confusing, because when you write the matrix constructor in code the
+columns are layed out horizontally. This is however the convention used
+in the OpenGL Shader Language (GLSL).</p>
+<p>A matrix can also be constructed by passing an existing matrix to one
+of the matrix construction functions. If the existing matrix is larger
+than the new one, the new matrix’s elements come from the top-left
+corner of the existing matrix. Otherwise the top-left corner of the new
+matrix is filled with the contents of the existing matrix and the rest
+from the identity matrix. For example:</p>
+<div class="sourceCode" id="cb62"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb62-1"><a href="#cb62-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> m <span class="op">=</span> mat4<span class="op">(</span>mat2<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">,</span> <span class="dv">3</span><span class="op">,</span> <span class="dv">4</span><span class="op">))</span></span></code></pre></div>
 <p>will set <code>m</code> to the matrix:</p>
 <div class="math">
 <span class="math display">\[\begin{bmatrix}
@@ -1214,19 +1857,28 @@ vec4(2, 4, 6, 8)</code></pre>
     0 &amp; 0 &amp; 0 &amp; 1
 \end{bmatrix}\]</span>
 </div>
-<p>Finally a 3x3 or 4x4 rotation matrix can be constructed from a quaternion by passing the quaternion as the single argument to <code>mat3</code> or <code>mat4</code> (see quaternions).</p>
+<p>Finally a 3x3 or 4x4 rotation matrix can be constructed from a
+quaternion by passing the quaternion as the single argument to
+<code>mat3</code> or <code>mat4</code> (see quaternions).</p>
 <h3 id="accessing-matrix-components">Accessing matrix components</h3>
-<p>The columns of a matrix can be accessed as vectors using 1-based integer indices. The Lua length operator can be used to determine the number of columns. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> matrix <span class="ot">=</span> mat2<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">)</span>
-<span class="kw">for</span> i <span class="ot">=</span> <span class="dv">1</span><span class="ot">,</span> <span class="ot">#</span>matrix <span class="kw">do</span>
-    <span class="fu">print</span><span class="ot">(</span>matrix<span class="ot">[</span>i<span class="ot">])</span>
-<span class="kw">end</span></code></pre></div>
+<p>The columns of a matrix can be accessed as vectors using 1-based
+integer indices. The Lua length operator can be used to determine the
+number of columns. For example:</p>
+<div class="sourceCode" id="cb63"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb63-1"><a href="#cb63-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> matrix <span class="op">=</span> mat2<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">2</span><span class="op">)</span></span>
+<span id="cb63-2"><a href="#cb63-2" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> i <span class="op">=</span> <span class="dv">1</span><span class="op">,</span> <span class="op">#</span>matrix <span class="cf">do</span></span>
+<span id="cb63-3"><a href="#cb63-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span>matrix<span class="op">[</span>i<span class="op">])</span></span>
+<span id="cb63-4"><a href="#cb63-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span></span></code></pre></div>
 <p>This would produce the following output:</p>
 <pre class="console"><code>vec2(1, 0)
 vec2(0, 2)</code></pre>
 <h3 id="matrix-arithmetic">Matrix arithmetic</h3>
-<p>As with vectors the <code>+</code>, <code>-</code>, <code>*</code> and <code>/</code> operators work with matrices too. When one operand is a number, the result is a new matrix of the same size with the operator applied to each element of the matrix. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> m1 <span class="ot">=</span> <span class="dv">2</span> <span class="ot">*</span> mat2<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">,</span> <span class="dv">3</span><span class="ot">,</span> <span class="dv">4</span><span class="ot">)</span></code></pre></div>
+<p>As with vectors the <code>+</code>, <code>-</code>, <code>*</code>
+and <code>/</code> operators work with matrices too. When one operand is
+a number, the result is a new matrix of the same size with the operator
+applied to each element of the matrix. For example:</p>
+<div class="sourceCode" id="cb65"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb65-1"><a href="#cb65-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> m1 <span class="op">=</span> <span class="dv">2</span> <span class="op">*</span> mat2<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">,</span> <span class="dv">3</span><span class="op">,</span> <span class="dv">4</span><span class="op">)</span></span></code></pre></div>
 <p>sets <code>m1</code> to the matrix:</p>
 <div class="math">
 <span class="math display">\[\begin{bmatrix}
@@ -1235,7 +1887,8 @@ vec2(0, 2)</code></pre>
 \end{bmatrix}\]</span>
 </div>
 <p>and:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> m2 <span class="ot">=</span> mat3<span class="ot">(</span><span class="dv">3</span><span class="ot">)</span> <span class="ot">-</span> <span class="dv">1</span></code></pre></div>
+<div class="sourceCode" id="cb66"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb66-1"><a href="#cb66-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> m2 <span class="op">=</span> mat3<span class="op">(</span><span class="dv">3</span><span class="op">)</span> <span class="op">-</span> <span class="dv">1</span></span></code></pre></div>
 <p>sets <code>m2</code> to the matrix:</p>
 <div class="math">
 <span class="math display">\[\begin{bmatrix}
@@ -1244,8 +1897,11 @@ vec2(0, 2)</code></pre>
     -1 &amp; -1 &amp; 2
 \end{bmatrix}\]</span>
 </div>
-<p>When both operands are matrices, the <code>+</code> and <code>-</code> operators work in a similar way to vectors, with the operations applied component-wise. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> m3 <span class="ot">=</span> mat2<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">,</span> <span class="dv">3</span><span class="ot">,</span> <span class="dv">4</span><span class="ot">)</span> <span class="ot">+</span> mat2<span class="ot">(</span><span class="dv">0.1</span><span class="ot">,</span> <span class="dv">0.2</span><span class="ot">,</span> <span class="dv">0.3</span><span class="ot">,</span> <span class="dv">0.4</span><span class="ot">)</span></code></pre></div>
+<p>When both operands are matrices, the <code>+</code> and
+<code>-</code> operators work in a similar way to vectors, with the
+operations applied component-wise. For example:</p>
+<div class="sourceCode" id="cb67"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb67-1"><a href="#cb67-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> m3 <span class="op">=</span> mat2<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">,</span> <span class="dv">3</span><span class="op">,</span> <span class="dv">4</span><span class="op">)</span> <span class="op">+</span> mat2<span class="op">(</span><span class="dv">0.1</span><span class="op">,</span> <span class="dv">0.2</span><span class="op">,</span> <span class="dv">0.3</span><span class="op">,</span> <span class="dv">0.4</span><span class="op">)</span></span></code></pre></div>
 <p>sets <code>m3</code> to the matrix:</p>
 <div class="math">
 <span class="math display">\[\begin{bmatrix}
@@ -1253,733 +1909,1164 @@ vec2(0, 2)</code></pre>
     2.2 &amp; 4.4
 \end{bmatrix}\]</span>
 </div>
-<p>However, when both operands are matrices, the <code>*</code> operator computes the <a href="http://en.wikipedia.org/wiki/Matrix_multiplication">matrix product</a>.</p>
-<p>If the first operand is a vector and the second is a matrix, then the first operand is taken to be a row vector (a matrix with one row) and should have the same number of columns as the matrix. The result is the matrix product of the row vector and the matrix, which is another row vector.</p>
-<p>Similarly if the first argument is a matrix and the second a vector, the vector is taken to be a column vector (a matrix with one column) and the result is the matrix product of the matrix and column vector, which is another column vector.</p>
-<p>The <code>/</code> operator also works when both arguments are matrices and is equivalent to multiplying the first matrix by the inverse of the second.</p>
-<p>Matricies can be compared by value with <code>==</code> like this:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">if</span> m1<span class="ot">*</span>m2 <span class="ot">==</span> mat4<span class="ot">(</span><span class="dv">1</span><span class="ot">)</span> <span class="kw">then</span> <span class="ot">...</span></code></pre></div>
-<div class="figure">
-<img src="images/screenshot2.jpg" />
-
-</div>
+<p>However, when both operands are matrices, the <code>*</code> operator
+computes the <a
+href="http://en.wikipedia.org/wiki/Matrix_multiplication">matrix
+product</a>.</p>
+<p>If the first operand is a vector and the second is a matrix, then the
+first operand is taken to be a row vector (a matrix with one row) and
+should have the same number of columns as the matrix. The result is the
+matrix product of the row vector and the matrix, which is another row
+vector.</p>
+<p>Similarly if the first argument is a matrix and the second a vector,
+the vector is taken to be a column vector (a matrix with one column) and
+the result is the matrix product of the matrix and column vector, which
+is another column vector.</p>
+<p>The <code>/</code> operator also works when both arguments are
+matrices and is equivalent to multiplying the first matrix by the
+inverse of the second.</p>
+<p>Matricies can be compared by value with <code>==</code> like
+this:</p>
+<div class="sourceCode" id="cb68"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb68-1"><a href="#cb68-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> m1<span class="op">*</span>m2 <span class="op">==</span> mat4<span class="op">(</span><span class="dv">1</span><span class="op">)</span> <span class="cf">then</span> <span class="op">...</span></span></code></pre></div>
+<p><img src="images/screenshot2.jpg" /></p>
 <h2 id="quaternions">Quaternions</h2>
-<p><a href="https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation">Quaternions</a> are useful for representing 3D rotations.</p>
+<p><a
+href="https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation">Quaternions</a>
+are useful for representing 3D rotations.</p>
 <p>Like vectors and matrices they are immutable.</p>
 <h3 id="constructing-quaternions">Constructing quaternions</h3>
-<p>The <code>quat</code> function is used to construct quaternions. The simplest way to construct a quaternion is to pass an angle (in radians) and a unit 3D vector representing the axis about which the rotation should occur. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> q <span class="ot">=</span> quat<span class="ot">(</span><span class="fu">math.rad</span><span class="ot">(</span><span class="dv">45</span><span class="ot">),</span> vec3<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">))</span></code></pre></div>
-<p>constructs a quaternion that represents a 45 degree rotation around the z axis. (<code>math.rad</code> converts degrees to radians).</p>
-<p>If the axis argument is omitted then it is taken to be <code>vec3(0, 0, 1)</code>, so the above is equivalent to:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> q <span class="ot">=</span> quat<span class="ot">(</span><span class="fu">math.rad</span><span class="ot">(</span><span class="dv">45</span><span class="ot">))</span></code></pre></div>
+<p>The <code>quat</code> function is used to construct quaternions. The
+simplest way to construct a quaternion is to pass an angle (in radians)
+and a unit 3D vector representing the axis about which the rotation
+should occur. For example:</p>
+<div class="sourceCode" id="cb69"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb69-1"><a href="#cb69-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> q <span class="op">=</span> quat<span class="op">(</span><span class="fu">math.rad</span><span class="op">(</span><span class="dv">45</span><span class="op">),</span> vec3<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">))</span></span></code></pre></div>
+<p>constructs a quaternion that represents a 45 degree rotation around
+the z axis. (<code>math.rad</code> converts degrees to radians).</p>
+<p>If the axis argument is omitted then it is taken to be
+<code>vec3(0, 0, 1)</code>, so the above is equivalent to:</p>
+<div class="sourceCode" id="cb70"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb70-1"><a href="#cb70-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> q <span class="op">=</span> quat<span class="op">(</span><span class="fu">math.rad</span><span class="op">(</span><span class="dv">45</span><span class="op">))</span></span></code></pre></div>
 <p>This is a useful shortcut for 2D rotations in the xy plane.</p>
-<p>A quaternion can also be constructed from Euler angles. Euler angles are rotations around the x, y and z axes, also known as pitch, yaw and roll. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> q <span class="ot">=</span> quat<span class="ot">(</span><span class="fu">math.rad</span><span class="ot">(</span><span class="dv">30</span><span class="ot">),</span> <span class="fu">math.rad</span><span class="ot">(</span><span class="dv">60</span><span class="ot">),</span> <span class="fu">math.rad</span><span class="ot">(</span><span class="dv">20</span><span class="ot">))</span></code></pre></div>
-<p>constructs a quaternion that represents the rotation you'd end up with if you first rotated 30 degrees around the x axis, then 60 degrees around the y axis and finally 20 degrees around the z axis.</p>
-<p>If two unit vector arguments are given, then the quaternion represents the rotation that would be needed to rotate the one vector into into the other. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> q <span class="ot">=</span> quat<span class="ot">(</span>vec3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> vec3<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">))</span></code></pre></div>
-<p>The above quaternion represents a rotation of 90 degrees in the xy plane, since it rotates a vector pointing along the x axis to one pointing along the y axis.</p>
-<p>A quaternion can be constructed from a 3x3 or 4x4 matrix by passing the matrix as the single argument to <code>quat</code>.</p>
-<p>A quaternion can also be converted to a 3x3 or 4x4 matrix by passing it as the single argument to the <code>mat3</code> or <code>mat4</code> functions (see mat-cons).</p>
-<p>Finally a quaternion can be constructed from the coefficients of its real and imaginary parts:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> q <span class="ot">=</span> quat<span class="ot">(</span>w<span class="ot">,</span> x<span class="ot">,</span> y<span class="ot">,</span> z<span class="ot">)</span></code></pre></div>
-<p><code>w</code> is the real part and <code>x</code>, <code>y</code> and <code>z</code> are the coeffients of the imaginary numbers <span class="math inline">\(i\)</span>, <span class="math inline">\(j\)</span> and <span class="math inline">\(k\)</span>.</p>
+<p>A quaternion can also be constructed from Euler angles. Euler angles
+are rotations around the x, y and z axes, also known as pitch, yaw and
+roll. For example:</p>
+<div class="sourceCode" id="cb71"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb71-1"><a href="#cb71-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> q <span class="op">=</span> quat<span class="op">(</span><span class="fu">math.rad</span><span class="op">(</span><span class="dv">30</span><span class="op">),</span> <span class="fu">math.rad</span><span class="op">(</span><span class="dv">60</span><span class="op">),</span> <span class="fu">math.rad</span><span class="op">(</span><span class="dv">20</span><span class="op">))</span></span></code></pre></div>
+<p>constructs a quaternion that represents the rotation you’d end up
+with if you first rotated 30 degrees around the x axis, then 60 degrees
+around the y axis and finally 20 degrees around the z axis.</p>
+<p>If two unit vector arguments are given, then the quaternion
+represents the rotation that would be needed to rotate the one vector
+into into the other. For example:</p>
+<div class="sourceCode" id="cb72"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb72-1"><a href="#cb72-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> q <span class="op">=</span> quat<span class="op">(</span>vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> vec3<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">))</span></span></code></pre></div>
+<p>The above quaternion represents a rotation of 90 degrees in the xy
+plane, since it rotates a vector pointing along the x axis to one
+pointing along the y axis.</p>
+<p>A quaternion can be constructed from a 3x3 or 4x4 matrix by passing
+the matrix as the single argument to <code>quat</code>.</p>
+<p>A quaternion can also be converted to a 3x3 or 4x4 matrix by passing
+it as the single argument to the <code>mat3</code> or <code>mat4</code>
+functions (see mat-cons).</p>
+<p>Finally a quaternion can be constructed from the coefficients of its
+real and imaginary parts:</p>
+<div class="sourceCode" id="cb73"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb73-1"><a href="#cb73-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> q <span class="op">=</span> quat<span class="op">(</span>w<span class="op">,</span> x<span class="op">,</span> y<span class="op">,</span> z<span class="op">)</span></span></code></pre></div>
+<p><code>w</code> is the real part and <code>x</code>, <code>y</code>
+and <code>z</code> are the coeffients of the imaginary numbers <span
+class="math inline">\(i\)</span>, <span class="math inline">\(j\)</span>
+and <span class="math inline">\(k\)</span>.</p>
 <h3 id="quaternion-fields">Quaternion fields</h3>
-<p>The <code>angle</code>, <code>axis</code>, <code>pitch</code>, <code>roll</code>, <code>yaw</code>, <code>w</code>, <code>x</code>, <code>y</code> and <code>z</code> fields can be used to read the corresponding attributes of a quaternion.</p>
-<p><strong>Note</strong>: Quaternions use a normalized internal representation, so the value returned by a field might be different from the value used to construct the quaternion. Though the quaternion as a whole represents the equivalent rotation.</p>
-<p>You may notice this when comparing quaternions with <code>==</code>. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">quat<span class="ot">(</span>vec3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span><span class="dv">0</span><span class="ot">,</span><span class="dv">0</span><span class="ot">),</span> vec3<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span><span class="dv">1</span><span class="ot">,</span><span class="dv">0</span><span class="ot">))</span> <span class="ot">==</span> quat<span class="ot">(</span>vec3<span class="ot">(-</span><span class="dv">1</span><span class="ot">,</span><span class="dv">0</span><span class="ot">,</span><span class="dv">0</span><span class="ot">),</span> vec3<span class="ot">(</span><span class="dv">0</span><span class="ot">,-</span><span class="dv">1</span><span class="ot">,</span><span class="dv">0</span><span class="ot">))</span></code></pre></div>
+<p>The <code>angle</code>, <code>axis</code>, <code>pitch</code>,
+<code>roll</code>, <code>yaw</code>, <code>w</code>, <code>x</code>,
+<code>y</code> and <code>z</code> fields can be used to read the
+corresponding attributes of a quaternion.</p>
+<p><strong>Note</strong>: Quaternions use a normalized internal
+representation, so the value returned by a field might be different from
+the value used to construct the quaternion. Though the quaternion as a
+whole represents the equivalent rotation.</p>
+<p>You may notice this when comparing quaternions with <code>==</code>.
+For example:</p>
+<div class="sourceCode" id="cb74"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb74-1"><a href="#cb74-1" aria-hidden="true" tabindex="-1"></a>quat<span class="op">(</span>vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span><span class="dv">0</span><span class="op">,</span><span class="dv">0</span><span class="op">),</span> vec3<span class="op">(</span><span class="dv">0</span><span class="op">,</span><span class="dv">1</span><span class="op">,</span><span class="dv">0</span><span class="op">))</span> <span class="op">==</span> quat<span class="op">(</span>vec3<span class="op">(-</span><span class="dv">1</span><span class="op">,</span><span class="dv">0</span><span class="op">,</span><span class="dv">0</span><span class="op">),</span> vec3<span class="op">(</span><span class="dv">0</span><span class="op">,-</span><span class="dv">1</span><span class="op">,</span><span class="dv">0</span><span class="op">))</span></span></code></pre></div>
 <p>evaluates to <code>true</code>.</p>
 <h3 id="quaternion-operations">Quaternion operations</h3>
-<p>Quaternions can be multiplied together using the <code>*</code> operator. The result of multiplying 2 quaternions is the rotation that results from applying the first quaternion's rotation followed by the second quaternion's rotation.</p>
-<p>Multiplying a quaternion by a vector rotates the vector. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> v1 <span class="ot">=</span> vec3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">)</span>
-<span class="kw">local</span> q <span class="ot">=</span> quat<span class="ot">(</span><span class="fu">math.rad</span><span class="ot">(</span><span class="dv">90</span><span class="ot">),</span> vec3<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">))</span>
-<span class="kw">local</span> v2 <span class="ot">=</span> q <span class="ot">*</span> v1</code></pre></div>
-<p>would set <code>v2</code> to the vector <code>vec3(0, 1, 0)</code>, which is <code>v1</code> rotated 90 degrees in the xy plain.</p>
-<p>A <code>vec2</code> can be rotated in a similar way (the z component is assumed to be zero and the z component of the result is dropped, yielding another <code>vec2</code>).</p>
+<p>Quaternions can be multiplied together using the <code>*</code>
+operator. The result of multiplying 2 quaternions is the rotation that
+results from applying the first quaternion’s rotation followed by the
+second quaternion’s rotation.</p>
+<p>Multiplying a quaternion by a vector rotates the vector. For
+example:</p>
+<div class="sourceCode" id="cb75"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb75-1"><a href="#cb75-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> v1 <span class="op">=</span> vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb75-2"><a href="#cb75-2" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> q <span class="op">=</span> quat<span class="op">(</span><span class="fu">math.rad</span><span class="op">(</span><span class="dv">90</span><span class="op">),</span> vec3<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">))</span></span>
+<span id="cb75-3"><a href="#cb75-3" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> v2 <span class="op">=</span> q <span class="op">*</span> v1</span></code></pre></div>
+<p>would set <code>v2</code> to the vector <code>vec3(0, 1, 0)</code>,
+which is <code>v1</code> rotated 90 degrees in the xy plain.</p>
+<p>A <code>vec2</code> can be rotated in a similar way (the z component
+is assumed to be zero and the z component of the result is dropped,
+yielding another <code>vec2</code>).</p>
 <h2 id="math-functions">Math functions</h2>
-<p>The following functions supplement the standard Lua math functions.</p>
-<h3 id="math.sign" class="func-def">math.sign(n)</h3>
+<p>The following functions supplement the standard Lua math
+functions.</p>
+<h3 class="func-def" id="math.sign">math.sign(n)</h3>
 <p>Returns +1 if n &gt; 0, -1 if n &lt; 0 and 0 if n == 0.</p>
-<h3 id="math.fract" class="func-def">math.fract(v)</h3>
-<p>Returns the fractional part of <code>v</code>. If <code>v</code> is a vector it returns a vector of the same size with each component being the fractional part of the corresponding component in the original vector.</p>
-<h3 id="math.clamp" class="func-def">math.clamp(v, min, max)</h3>
-<p>Clamps a value <code>v</code> between <code>min</code> and <code>max</code>. <code>v</code>, <code>min</code> and <code>max</code> may be vectors. In this case each component is clamped based on the corresponding components in <code>min</code> and <code>max</code>.</p>
-<h3 id="math.randvec2" class="func-def">math.randvec2()</h3>
-<p>Returns a <code>vec2</code> with all components set to a random number between 0 and 1.</p>
-<h3 id="math.randvec3" class="func-def">math.randvec3()</h3>
-<p>Returns a <code>vec3</code> with all components set to a random number between 0 and 1.</p>
-<h3 id="math.randvec4" class="func-def">math.randvec4()</h3>
-<p>Returns a <code>vec4</code> with all components set to a random number between 0 and 1.</p>
-<h3 id="math.dotvector1-vector2" class="func-def">math.dot(vector1, vector2)</h3>
-<p>Returns the dot product of two vectors. The vectors must have the same size.</p>
-<h3 id="math.crossvector1-vector2" class="func-def">math.cross(vector1, vector2)</h3>
+<h3 class="func-def" id="math.fract">math.fract(v)</h3>
+<p>Returns the fractional part of <code>v</code>. If <code>v</code> is a
+vector it returns a vector of the same size with each component being
+the fractional part of the corresponding component in the original
+vector.</p>
+<h3 class="func-def" id="math.clamp">math.clamp(v, min, max)</h3>
+<p>Clamps a value <code>v</code> between <code>min</code> and
+<code>max</code>. <code>v</code>, <code>min</code> and <code>max</code>
+may be vectors. In this case each component is clamped based on the
+corresponding components in <code>min</code> and <code>max</code>.</p>
+<h3 class="func-def" id="math.randvec2">math.randvec2()</h3>
+<p>Returns a <code>vec2</code> with all components set to a random
+number between 0 and 1.</p>
+<h3 class="func-def" id="math.randvec3">math.randvec3()</h3>
+<p>Returns a <code>vec3</code> with all components set to a random
+number between 0 and 1.</p>
+<h3 class="func-def" id="math.randvec4">math.randvec4()</h3>
+<p>Returns a <code>vec4</code> with all components set to a random
+number between 0 and 1.</p>
+<h3 class="func-def" id="math.dotvector1-vector2">math.dot(vector1,
+vector2)</h3>
+<p>Returns the dot product of two vectors. The vectors must have the
+same size.</p>
+<h3 class="func-def" id="math.crossvector1-vector2">math.cross(vector1,
+vector2)</h3>
 <p>Returns the cross product of two 3 dimensional vectors.</p>
-<h3 id="math.normalizevector" class="func-def">math.normalize(vector)</h3>
-<p>Returns the normalized form of a vector (i.e. the vector that points in the same direction, but whose length is 1). If the given vector has zero length, then a vector of the same size is returned whose first component is 1 and whose remaining components are 0.</p>
-<h3 id="math.lengthvector" class="func-def">math.length(vector)</h3>
+<h3 class="func-def"
+id="math.normalizevector">math.normalize(vector)</h3>
+<p>Returns the normalized form of a vector (i.e. the vector that points
+in the same direction, but whose length is 1). If the given vector has
+zero length, then a vector of the same size is returned whose first
+component is 1 and whose remaining components are 0.</p>
+<h3 class="func-def" id="math.lengthvector">math.length(vector)</h3>
 <p>Returns the length of a vector.</p>
-<h3 id="math.distance" class="func-def">math.distance(vector1, vector2)</h3>
+<h3 class="func-def" id="math.distance">math.distance(vector1,
+vector2)</h3>
 <p>Returns the distance between two vectors.</p>
-<h3 id="math.inversematrix" class="func-def">math.inverse(matrix)</h3>
+<h3 class="func-def" id="math.inversematrix">math.inverse(matrix)</h3>
 <p>Returns the inverse of a matrix.</p>
-<h3 id="math.lookateye-center-up" class="func-def">math.lookat(eye, center, up)</h3>
-<p>Creates a 4x4 view matrix at <code>eye</code>, looking in the direction of <code>center</code> with the y axis of the camera pointing in the same direction as <code>up</code>.</p>
-<h3 id="math.perspectivefovy-aspect-near-far" class="func-def">math.perspective(fovy, aspect, near, far)</h3>
+<h3 class="func-def" id="math.lookateye-center-up">math.lookat(eye,
+center, up)</h3>
+<p>Creates a 4x4 view matrix at <code>eye</code>, looking in the
+direction of <code>center</code> with the y axis of the camera pointing
+in the same direction as <code>up</code>.</p>
+<h3 class="func-def"
+id="math.perspectivefovy-aspect-near-far">math.perspective(fovy, aspect,
+near, far)</h3>
 <p>Creates a 4x4 matrix for a symmetric perspective-view frustum.</p>
 <ul>
-<li><code>fovy</code> is the field of view in the y plain, in radians.</li>
-<li><code>aspect</code> is typically the window width divided by its height.</li>
-<li><code>near</code> and <code>far</code> are the distances of the near and far clipping plains from the camera (these should be positive).</li>
+<li><code>fovy</code> is the field of view in the y plain, in
+radians.</li>
+<li><code>aspect</code> is typically the window width divided by its
+height.</li>
+<li><code>near</code> and <code>far</code> are the distances of the near
+and far clipping plains from the camera (these should be positive).</li>
 </ul>
-<h3 id="math.ortho" class="func-def">math.ortho(left, right, bottom, top [, near, far])</h3>
-<p>Creates a 4x4 orthographic projection matrix. <code>near</code> and <code>far</code> are the distance from the viewer of the near and far clipping plains (negative means behind the viewer). Their default values are <code>-1</code> and <code>1</code>.</p>
-<h3 id="math.oblique" class="func-def">math.oblique(angle, zscale, left, right, bottom, top [, near, far])</h3>
-<p>Creates a 4x4 oblique projection matrix. <code>near</code> and <code>far</code> are the distance from the viewer of the near and far clipping plains (negative means behind the viewer). Their default values are <code>-1</code> and <code>1</code>.</p>
-<h3 id="math.translate4" class="func-def">math.translate4(position)</h3>
+<h3 class="func-def" id="math.ortho">math.ortho(left, right, bottom, top
+[, near, far])</h3>
+<p>Creates a 4x4 orthographic projection matrix. <code>near</code> and
+<code>far</code> are the distance from the viewer of the near and far
+clipping plains (negative means behind the viewer). Their default values
+are <code>-1</code> and <code>1</code>.</p>
+<h3 class="func-def" id="math.oblique">math.oblique(angle, zscale, left,
+right, bottom, top [, near, far])</h3>
+<p>Creates a 4x4 oblique projection matrix. <code>near</code> and
+<code>far</code> are the distance from the viewer of the near and far
+clipping plains (negative means behind the viewer). Their default values
+are <code>-1</code> and <code>1</code>.</p>
+<h3 class="func-def" id="math.translate4">math.translate4(position)</h3>
 <p>Creates a 4x4 translation matrix.</p>
-<p><code>position</code> may be either 2 or 3 numbers (the x, y and z components) or a <code>vec2</code> or <code>vec3</code>.</p>
+<p><code>position</code> may be either 2 or 3 numbers (the x, y and z
+components) or a <code>vec2</code> or <code>vec3</code>.</p>
 <p>If the z component is omitted it is assumed to be 0.</p>
-<h3 id="math.scale4" class="func-def">math.scale4(scaling)</h3>
+<h3 class="func-def" id="math.scale4">math.scale4(scaling)</h3>
 <p>Creates a 4x4 scale matrix.</p>
-<p><code>scaling</code> may be 1, 2 or 3 numbers or a <code>vec2</code> or <code>vec3</code>. If 1 number is provided it is assume to be the x and y components of the scaling and the z scaling is assumed to be 1. If 2 numbers or a <code>vec2</code> is provided, they are the scaling for the x and y components and z is assumed to be 1.</p>
-<h3 id="math.scale4" class="func-def">math.rotate4(rotation)</h3>
+<p><code>scaling</code> may be 1, 2 or 3 numbers or a <code>vec2</code>
+or <code>vec3</code>. If 1 number is provided it is assume to be the x
+and y components of the scaling and the z scaling is assumed to be 1. If
+2 numbers or a <code>vec2</code> is provided, they are the scaling for
+the x and y components and z is assumed to be 1.</p>
+<h3 class="func-def" id="math.scale4">math.rotate4(rotation)</h3>
 <p>Creates a 4x4 rotation matrix.</p>
-<p><code>rotation</code> can be either a quaternion, or an angle (in radians) followed by an optional <code>vec3</code> axis. If the axis is omitted it is assumed to be <code>vec3(0, 0, 1)</code> so the rotation becomes a 2D rotation in the xy plane about the z axis.</p>
-<h3 id="math.perlin" class="func-def">math.perlin(pos [, period])</h3>
-<p>Generate perlin noise. <code>pos</code> can be a 2, 3, or 4 dimensional vector, or a number. If the second argument is supplied then the noise will be periodic with the given period. <code>period</code> should be of the same type as <code>pos</code> and its components should be integers greater than 1.</p>
+<p><code>rotation</code> can be either a quaternion, or an angle (in
+radians) followed by an optional <code>vec3</code> axis. If the axis is
+omitted it is assumed to be <code>vec3(0, 0, 1)</code> so the rotation
+becomes a 2D rotation in the xy plane about the z axis.</p>
+<h3 class="func-def" id="math.perlin">math.perlin(pos [, period])</h3>
+<p>Generate perlin noise. <code>pos</code> can be a 2, 3, or 4
+dimensional vector, or a number. If the second argument is supplied then
+the noise will be periodic with the given period. <code>period</code>
+should be of the same type as <code>pos</code> and its components should
+be integers greater than 1.</p>
 <p>The returned value is between -1 and 1.</p>
-<h3 id="math.simplex" class="func-def">math.simplex(pos)</h3>
-<p>Generate simplex noise. <code>pos</code> can be a 2, 3, or 4 dimensional vector, or a number.</p>
+<h3 class="func-def" id="math.simplex">math.simplex(pos)</h3>
+<p>Generate simplex noise. <code>pos</code> can be a 2, 3, or 4
+dimensional vector, or a number.</p>
 <p>The returned value is between -1 and 1.</p>
-<h3 id="math.mix" class="func-def">math.mix(from, to, t)</h3>
-<p>Returns the linear interpolation between <code>from</code> and <code>to</code> determined by <code>t</code>. <code>from</code> and <code>to</code> can be numbers or vectors, and must be the same type. <code>t</code> should be a number between 0 and 1. <code>from</code> and <code>to</code> can also be quaternions. In this case <code>math.mix</code> returns the spherical linear interpolation of the two quaternions.</p>
-<h3 id="math.slerp" class="func-def">math.slerp(from, to, t)</h3>
-<p>Returns the spherical linear interpolation of the two quaternions <code>from</code> and <code>to</code>. <code>t</code> should be a number between 0 and 1. Unlike (<code>math.mix</code>)[#math.mix] this interpolation takes the shortest path.</p>
+<h3 class="func-def" id="math.mix">math.mix(from, to, t)</h3>
+<p>Returns the linear interpolation between <code>from</code> and
+<code>to</code> determined by <code>t</code>. <code>from</code> and
+<code>to</code> can be numbers or vectors, and must be the same type.
+<code>t</code> should be a number between 0 and 1. <code>from</code> and
+<code>to</code> can also be quaternions. In this case
+<code>math.mix</code> returns the spherical linear interpolation of the
+two quaternions.</p>
+<h3 class="func-def" id="math.slerp">math.slerp(from, to, t)</h3>
+<p>Returns the spherical linear interpolation of the two quaternions
+<code>from</code> and <code>to</code>. <code>t</code> should be a number
+between 0 and 1. Unlike (<code>math.mix</code>)[#math.mix] this
+interpolation takes the shortest path.</p>
 <hr />
-<div class="figure">
-<img src="images/screenshot5.jpg" />
-
-</div>
+<p><img src="images/screenshot5.jpg" /></p>
 <h1 id="buffers-and-views">Buffers and views</h1>
-<p>Buffers are contiguous blocks of memory. They are used for storing images, audio and vertex data, or anything else you like.</p>
-<p>You can't access a buffer's memory directly. Instead you access a buffer through a <em>view</em>. Views provide a typed array-like interface to the buffer.</p>
+<p>Buffers are contiguous blocks of memory. They are used for storing
+images, audio and vertex data, or anything else you like.</p>
+<p>You can’t access a buffer’s memory directly. Instead you access a
+buffer through a <em>view</em>. Views provide a typed array-like
+interface to the buffer.</p>
 <h2 id="buffers">Buffers</h2>
-<h3 id="am.buffer" class="func-def">am.buffer(size)</h3>
+<h3 class="func-def" id="am.buffer">am.buffer(size)</h3>
 <p>Returns a new buffer of the given size in bytes.</p>
-<p>The buffer's memory will be zeroed.</p>
-<p>The <code>#</code> operator can be used to retrieve the size of a buffer in bytes.</p>
+<p>The buffer’s memory will be zeroed.</p>
+<p>The <code>#</code> operator can be used to retrieve the size of a
+buffer in bytes.</p>
 <p>Fields:</p>
 <ul>
-<li><p><code>usage</code>: A hint to the graphics driver telling it how this buffer will be used when it's used for vertex attribute data or element indices. Can be one of <code>&quot;static&quot;</code> (the data won't change often), <code>&quot;dynamic&quot;</code> (the data will change frequenty), or <code>&quot;stream&quot;</code> (the data will only be used a few times). The default is <code>&quot;static&quot;</code>.</p></li>
-<li><p><code>dataptr</code>: Returns a pointer to the buffer as a Lua <code>lightuserdata</code> value. The intended use for this is to manipulate the buffer using the <a href="http://luajit.org/ext_ffi.html">LuaJIT FFI library</a>. Readonly.</p></li>
+<li><p><code>usage</code>: A hint to the graphics driver telling it how
+this buffer will be used when it’s used for vertex attribute data or
+element indices. Can be one of <code>"static"</code> (the data won’t
+change often), <code>"dynamic"</code> (the data will change frequenty),
+or <code>"stream"</code> (the data will only be used a few times). The
+default is <code>"static"</code>.</p></li>
+<li><p><code>dataptr</code>: Returns a pointer to the buffer as a Lua
+<code>lightuserdata</code> value. The intended use for this is to
+manipulate the buffer using the <a
+href="http://luajit.org/ext_ffi.html">LuaJIT FFI library</a>.
+Readonly.</p></li>
 </ul>
 <p>Methods:</p>
 <ul>
-<li><code>mark_dirty()</code>: Mark the buffer dirty. This should be called if you update the buffer using the <code>dataptr</code> field. This will cause data to be copied to any textures or vbos that depend on the buffer when next they are drawn. Note that you don't need to call this method if you're not using <code>dataptr</code> to update the buffer, for example if you're updating it through a view - in that case the buffer will automatically be marked dirty.</li>
+<li><code>mark_dirty()</code>: Mark the buffer dirty. This should be
+called if you update the buffer using the <code>dataptr</code> field.
+This will cause data to be copied to any textures or vbos that depend on
+the buffer when next they are drawn. Note that you don’t need to call
+this method if you’re not using <code>dataptr</code> to update the
+buffer, for example if you’re updating it through a view - in that case
+the buffer will automatically be marked dirty.</li>
 </ul>
-<h3 id="am.load_buffer" class="func-def">am.load_buffer(filename)</h3>
-<p>Loads the given file and returns a buffer containing the file's data, or <code>nil</code> if the file wasn't found.</p>
-<h3 id="am.base64_encode" class="func-def">am.base64_encode(buffer)</h3>
+<h3 class="func-def" id="am.load_buffer">am.load_buffer(filename)</h3>
+<p>Loads the given file and returns a buffer containing the file’s data,
+or <code>nil</code> if the file wasn’t found.</p>
+<h3 class="func-def" id="am.base64_encode">am.base64_encode(buffer)</h3>
 <p>Returns a base64 encoding of a buffer as a string.</p>
-<h3 id="am.base64_decode" class="func-def">am.base64_decode(string)</h3>
+<h3 class="func-def" id="am.base64_decode">am.base64_decode(string)</h3>
 <p>Converts a base64 string to a buffer.</p>
 <h2 id="views">Views</h2>
-<h3 id="buffer:view" class="func-def">buffer:view(type [, offset [, stride [, count]]])</h3>
+<h3 class="func-def" id="buffer:view">buffer:view(type [, offset [,
+stride [, count]]])</h3>
 <p>Returns a view into <code>buffer</code>.</p>
 <p><code>type</code> can be one of the following:</p>
 <table>
 <thead>
 <tr class="header">
-<th align="left">type</th>
-<th align="right">size (bytes)</th>
-<th align="left">Lua value range</th>
-<th align="left">internal range</th>
-<th align="left">endianess</th>
+<th style="text-align: left;">type</th>
+<th style="text-align: right;">size (bytes)</th>
+<th style="text-align: left;">Lua value range</th>
+<th style="text-align: left;">internal range</th>
+<th style="text-align: left;">endianess</th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td align="left"><code>&quot;float&quot;</code></td>
-<td align="right">4</td>
-<td align="left">approx -3.4e38 to 3.4e38</td>
-<td align="left">same</td>
-<td align="left">native</td>
+<td style="text-align: left;"><code>"float"</code></td>
+<td style="text-align: right;">4</td>
+<td style="text-align: left;">approx -3.4e38 to 3.4e38</td>
+<td style="text-align: left;">same</td>
+<td style="text-align: left;">native</td>
 </tr>
 <tr class="even">
-<td align="left"><code>&quot;vec2&quot;</code></td>
-<td align="right">8</td>
-<td align="left">any <code>vec2</code></td>
-<td align="left">same</td>
-<td align="left">native</td>
+<td style="text-align: left;"><code>"vec2"</code></td>
+<td style="text-align: right;">8</td>
+<td style="text-align: left;">any <code>vec2</code></td>
+<td style="text-align: left;">same</td>
+<td style="text-align: left;">native</td>
 </tr>
 <tr class="odd">
-<td align="left"><code>&quot;vec3&quot;</code></td>
-<td align="right">12</td>
-<td align="left">any <code>vec3</code></td>
-<td align="left">same</td>
-<td align="left">native</td>
+<td style="text-align: left;"><code>"vec3"</code></td>
+<td style="text-align: right;">12</td>
+<td style="text-align: left;">any <code>vec3</code></td>
+<td style="text-align: left;">same</td>
+<td style="text-align: left;">native</td>
 </tr>
 <tr class="even">
-<td align="left"><code>&quot;vec4&quot;</code></td>
-<td align="right">16</td>
-<td align="left">any <code>vec4</code></td>
-<td align="left">same</td>
-<td align="left">native</td>
+<td style="text-align: left;"><code>"vec4"</code></td>
+<td style="text-align: right;">16</td>
+<td style="text-align: left;">any <code>vec4</code></td>
+<td style="text-align: left;">same</td>
+<td style="text-align: left;">native</td>
 </tr>
 <tr class="odd">
-<td align="left"><code>&quot;byte&quot;</code></td>
-<td align="right">1</td>
-<td align="left">-128 to 127</td>
-<td align="left">same</td>
-<td align="left">N/A</td>
+<td style="text-align: left;"><code>"byte"</code></td>
+<td style="text-align: right;">1</td>
+<td style="text-align: left;">-128 to 127</td>
+<td style="text-align: left;">same</td>
+<td style="text-align: left;">N/A</td>
 </tr>
 <tr class="even">
-<td align="left"><code>&quot;ubyte&quot;</code></td>
-<td align="right">1</td>
-<td align="left">0 to 255</td>
-<td align="left">same</td>
-<td align="left">N/A</td>
+<td style="text-align: left;"><code>"ubyte"</code></td>
+<td style="text-align: right;">1</td>
+<td style="text-align: left;">0 to 255</td>
+<td style="text-align: left;">same</td>
+<td style="text-align: left;">N/A</td>
 </tr>
 <tr class="odd">
-<td align="left"><code>&quot;byte_norm&quot;</code></td>
-<td align="right">1</td>
-<td align="left">-1.0 to 1.0</td>
-<td align="left">-127 to 127</td>
-<td align="left">N/A</td>
+<td style="text-align: left;"><code>"byte_norm"</code></td>
+<td style="text-align: right;">1</td>
+<td style="text-align: left;">-1.0 to 1.0</td>
+<td style="text-align: left;">-127 to 127</td>
+<td style="text-align: left;">N/A</td>
 </tr>
 <tr class="even">
-<td align="left"><code>&quot;ubyte_norm&quot;</code></td>
-<td align="right">1</td>
-<td align="left">0.0 to 1.0</td>
-<td align="left">0 to 255</td>
-<td align="left">N/A</td>
+<td style="text-align: left;"><code>"ubyte_norm"</code></td>
+<td style="text-align: right;">1</td>
+<td style="text-align: left;">0.0 to 1.0</td>
+<td style="text-align: left;">0 to 255</td>
+<td style="text-align: left;">N/A</td>
 </tr>
 <tr class="odd">
-<td align="left"><code>&quot;short&quot;</code></td>
-<td align="right">2</td>
-<td align="left">-32768 to 32767</td>
-<td align="left">same</td>
-<td align="left">native</td>
+<td style="text-align: left;"><code>"short"</code></td>
+<td style="text-align: right;">2</td>
+<td style="text-align: left;">-32768 to 32767</td>
+<td style="text-align: left;">same</td>
+<td style="text-align: left;">native</td>
 </tr>
 <tr class="even">
-<td align="left"><code>&quot;ushort&quot;</code></td>
-<td align="right">2</td>
-<td align="left">0 to 65535</td>
-<td align="left">same</td>
-<td align="left">native</td>
+<td style="text-align: left;"><code>"ushort"</code></td>
+<td style="text-align: right;">2</td>
+<td style="text-align: left;">0 to 65535</td>
+<td style="text-align: left;">same</td>
+<td style="text-align: left;">native</td>
 </tr>
 <tr class="odd">
-<td align="left"><code>&quot;short_norm&quot;</code></td>
-<td align="right">2</td>
-<td align="left">-1.0 to 1.0</td>
-<td align="left">-32767 to 32767</td>
-<td align="left">native</td>
+<td style="text-align: left;"><code>"short_norm"</code></td>
+<td style="text-align: right;">2</td>
+<td style="text-align: left;">-1.0 to 1.0</td>
+<td style="text-align: left;">-32767 to 32767</td>
+<td style="text-align: left;">native</td>
 </tr>
 <tr class="even">
-<td align="left"><code>&quot;ushort_norm&quot;</code></td>
-<td align="right">2</td>
-<td align="left">0.0 to 1.0</td>
-<td align="left">0 to 65535</td>
-<td align="left">native</td>
+<td style="text-align: left;"><code>"ushort_norm"</code></td>
+<td style="text-align: right;">2</td>
+<td style="text-align: left;">0.0 to 1.0</td>
+<td style="text-align: left;">0 to 65535</td>
+<td style="text-align: left;">native</td>
 </tr>
 <tr class="odd">
-<td align="left"><code>&quot;ushort_elem&quot;</code></td>
-<td align="right">2</td>
-<td align="left">1 to 65536</td>
-<td align="left">0 to 65535</td>
-<td align="left">native</td>
+<td style="text-align: left;"><code>"ushort_elem"</code></td>
+<td style="text-align: right;">2</td>
+<td style="text-align: left;">1 to 65536</td>
+<td style="text-align: left;">0 to 65535</td>
+<td style="text-align: left;">native</td>
 </tr>
 <tr class="even">
-<td align="left"><code>&quot;int&quot;</code></td>
-<td align="right">4</td>
-<td align="left">-2147483648 to 2147483647</td>
-<td align="left">same</td>
-<td align="left">native</td>
+<td style="text-align: left;"><code>"int"</code></td>
+<td style="text-align: right;">4</td>
+<td style="text-align: left;">-2147483648 to 2147483647</td>
+<td style="text-align: left;">same</td>
+<td style="text-align: left;">native</td>
 </tr>
 <tr class="odd">
-<td align="left"><code>&quot;uint&quot;</code></td>
-<td align="right">4</td>
-<td align="left">0 to 4294967295</td>
-<td align="left">same</td>
-<td align="left">native</td>
+<td style="text-align: left;"><code>"uint"</code></td>
+<td style="text-align: right;">4</td>
+<td style="text-align: left;">0 to 4294967295</td>
+<td style="text-align: left;">same</td>
+<td style="text-align: left;">native</td>
 </tr>
 <tr class="even">
-<td align="left"><code>&quot;uint_elem&quot;</code></td>
-<td align="right">4</td>
-<td align="left">1 to 4294967296</td>
-<td align="left">0 to 4294967295</td>
-<td align="left">native</td>
+<td style="text-align: left;"><code>"uint_elem"</code></td>
+<td style="text-align: right;">4</td>
+<td style="text-align: left;">1 to 4294967296</td>
+<td style="text-align: left;">0 to 4294967295</td>
+<td style="text-align: left;">native</td>
 </tr>
 </tbody>
 </table>
-<p>The <code>_norm</code> types map Lua numbers in the range -1 to 1 (or 0 to 1 for unsigned types) to integer values in the buffer.</p>
-<p>The <code>_elem</code> types are specifically for element array buffers and offset the Lua numbers by 1 to conform to the Lua convention of array indices starting at 1.</p>
-<p>All view types currently use the native platform endianess, which happens to be little-endian on all currently supported platforms.</p>
-<p>The <code>offset</code> argument is the byte offset of the first element of the view. The default is 0.</p>
-<p>The <code>stride</code> argument is the distance between consecutive values in the view, in bytes. The default is the size of the view type.</p>
-<p>The <code>count</code> argument determines the number of elements in the view. The underlying buffer must be large enough to accommodate the elements with the given stride. The default is the maximum supported by the buffer with the given stride.</p>
-<p>You can read and write to views as if they were Lua arrays (as with Lua arrays, indices start at 1). For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> buf <span class="ot">=</span> am<span class="ot">.</span>buffer<span class="ot">(</span><span class="dv">12</span><span class="ot">)</span>
-<span class="kw">local</span> view <span class="ot">=</span> buf:view<span class="ot">(</span><span class="st">&quot;float&quot;</span><span class="ot">)</span>
-view<span class="ot">[</span><span class="dv">1</span><span class="ot">]</span> <span class="ot">=</span> <span class="dv">1.5</span> 
-view<span class="ot">[</span><span class="dv">2</span><span class="ot">]</span> <span class="ot">=</span> view<span class="ot">[</span><span class="dv">1</span><span class="ot">]</span> <span class="ot">+</span> <span class="dv">2</span></code></pre></div>
-<p>Attempting to read an index less than 1 or larger than the number of elements will return nil.</p>
-<p>You can retrieve the number of elements in a view using the <code>#</code> operator.</p>
+<p>The <code>_norm</code> types map Lua numbers in the range -1 to 1 (or
+0 to 1 for unsigned types) to integer values in the buffer.</p>
+<p>The <code>_elem</code> types are specifically for element array
+buffers and offset the Lua numbers by 1 to conform to the Lua convention
+of array indices starting at 1.</p>
+<p>All view types currently use the native platform endianess, which
+happens to be little-endian on all currently supported platforms.</p>
+<p>The <code>offset</code> argument is the byte offset of the first
+element of the view. The default is 0.</p>
+<p>The <code>stride</code> argument is the distance between consecutive
+values in the view, in bytes. The default is the size of the view
+type.</p>
+<p>The <code>count</code> argument determines the number of elements in
+the view. The underlying buffer must be large enough to accommodate the
+elements with the given stride. The default is the maximum supported by
+the buffer with the given stride.</p>
+<p>You can read and write to views as if they were Lua arrays (as with
+Lua arrays, indices start at 1). For example:</p>
+<div class="sourceCode" id="cb76"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb76-1"><a href="#cb76-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> buf <span class="op">=</span> am<span class="op">.</span>buffer<span class="op">(</span><span class="dv">12</span><span class="op">)</span></span>
+<span id="cb76-2"><a href="#cb76-2" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> view <span class="op">=</span> buf<span class="op">:</span>view<span class="op">(</span><span class="st">&quot;float&quot;</span><span class="op">)</span></span>
+<span id="cb76-3"><a href="#cb76-3" aria-hidden="true" tabindex="-1"></a>view<span class="op">[</span><span class="dv">1</span><span class="op">]</span> <span class="op">=</span> <span class="dv">1.5</span> </span>
+<span id="cb76-4"><a href="#cb76-4" aria-hidden="true" tabindex="-1"></a>view<span class="op">[</span><span class="dv">2</span><span class="op">]</span> <span class="op">=</span> view<span class="op">[</span><span class="dv">1</span><span class="op">]</span> <span class="op">+</span> <span class="dv">2</span></span></code></pre></div>
+<p>Attempting to read an index less than 1 or larger than the number of
+elements will return nil.</p>
+<p>You can retrieve the number of elements in a view using the
+<code>#</code> operator.</p>
 <h2 id="view-fields">View fields</h2>
-<h3 id="view.buffer" class="field-def">view.buffer</h3>
+<h3 class="field-def" id="view.buffer">view.buffer</h3>
 <p>The buffer associated with the view.</p>
 <p>Readonly.</p>
 <h2 id="view-methods">View methods</h2>
-<h3 id="view:slice" class="method-def">view:slice(n [, count [, stride_multiplier]])</h3>
-<p>Returns a new view with the same type as <code>view</code> that references the same buffer, but which starts at the <code>n</code>th element of <code>view</code> and continues for <code>count</code> elements. If <code>count</code> is omitted or nil it covers all the elements of <code>view</code> after and including the <code>n</code>th. <code>stride_multiplier</code> can be used to increase the stride of the view and thereby skip elements. It must be a positive integer and defaults to 1 (no skipping).</p>
-<h3 id="view:set" class="method-def">view:set(val [, start [, count]])</h3>
-<p>Bulk sets values in a view. This is faster than setting them one at a time.</p>
-<p>If <code>val</code> is a number or vector then this sets all elements of <code>view</code> to <code>val</code>.</p>
-<p>If <code>val</code> is a table then the elements are set to their corresponding values from the table.</p>
-<p>As a special case, if <code>val</code> is a table of numbers and the view's type is a vector, then the elements of the table will be used to set the components of the vectors in the view. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> verts <span class="ot">=</span> am<span class="ot">.</span>buffer<span class="ot">(</span><span class="dv">24</span><span class="ot">)</span>:view<span class="ot">(</span><span class="st">&quot;vec3&quot;</span><span class="ot">)</span>
-verts:set<span class="ot">{</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">,</span> <span class="dv">3</span><span class="ot">,</span> <span class="dv">4</span><span class="ot">,</span> <span class="dv">5</span><span class="ot">,</span> <span class="dv">6</span><span class="ot">}</span>
-<span class="fu">print</span><span class="ot">(</span>verts<span class="ot">[</span><span class="dv">1</span><span class="ot">])</span> <span class="do">-- vec3(1, 2, 3)</span>
-<span class="fu">print</span><span class="ot">(</span>verts<span class="ot">[</span><span class="dv">2</span><span class="ot">])</span> <span class="do">-- vec3(4, 5, 6)</span></code></pre></div>
-<p>Finally if <code>val</code> is another view then the elements are set to the corresponding values from that view. The views may be of different types as long as they are &quot;compatible&quot;. The types are converted as if each element were set using the Lua code <code>view1[i] = view2[i]</code>. This means you can't set a number view to a vector view or vice versa.</p>
-<p>If <code>start</code> is given then only elements at that index and beyond will be set. The default value for <code>start</code> is <code>1</code>.</p>
-<p>If <code>count</code> is given then at most that many elements will be set.</p>
-<h3 id="am.float_array" class="func-def">am.float_array(table)</h3>
-<p>Returns a <code>float</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.byte_array" class="func-def">am.byte_array(table)</h3>
-<p>Returns a <code>byte</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.ubyte_array" class="func-def">am.ubyte_array(table)</h3>
-<p>Returns a <code>ubyte</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.byte_norm_array" class="func-def">am.byte_norm_array(table)</h3>
-<p>Returns a <code>byte_norm</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.ubyte_norm_array" class="func-def">am.ubyte_norm_array(table)</h3>
-<p>Returns a <code>ubyte_norm</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.short_array" class="func-def">am.short_array(table)</h3>
-<p>Returns a <code>short</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.ushort_array" class="func-def">am.ushort_array(table)</h3>
-<p>Returns a <code>ushort</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.short_norm_array" class="func-def">am.short_norm_array(table)</h3>
-<p>Returns a <code>short_norm</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.ushort_norm_array" class="func-def">am.ushort_norm_array(table)</h3>
-<p>Returns a <code>ushort_norm</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.int_array" class="func-def">am.int_array(table)</h3>
-<p>Returns an <code>int</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.uint_array" class="func-def">am.uint_array(table)</h3>
-<p>Returns a <code>uint</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.int_norm_array" class="func-def">am.int_norm_array(table)</h3>
-<p>Returns an <code>int_norm</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.uint_norm_array" class="func-def">am.uint_norm_array(table)</h3>
-<p>Returns a <code>uint_norm</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.ushort_elem_array" class="func-def">am.ushort_elem_array(table)</h3>
-<p>Returns a <code>ushort_elem</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.uint_elem_array" class="func-def">am.uint_elem_array(table)</h3>
-<p>Returns a <code>uint_elem</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<h3 id="am.vec2_array" class="func-def">am.vec2_array(table)</h3>
-<p>Returns a <code>vec2</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<p>The table may contain either <code>vec2</code>s or numbers (though not a mix). If the table contains numbers they are used for the vector components and the resulting view will have half the number of elements as there are numbers in the table.</p>
-<h3 id="am.vec3_array" class="func-def">am.vec3_array(table)</h3>
-<p>Returns a <code>vec3</code> view to a newly created buffer and fills it with the values in the given table.</p>
-<p>The table may contain either <code>vec3</code>s or numbers (though not a mix). If the table contains numbers they are used for the vector components and the resulting view will have a third the number of elements as there are numbers in the table.</p>
-<h3 id="am.vec4_array" class="func-def">am.vec4_array(table)</h3>
-<p>Returns a <code>vec4</code> view to a newly created buffer containing the values in the given table.</p>
-<p>The table may contain either <code>vec4</code>s or numbers (though not a mix). If the table contains numbers they are used for the vector components and the resulting view will have a quarter the number of elements as there are numbers in the table.</p>
-<h3 id="am.struct_array" class="func-def">am.struct_array(size, spec)</h3>
-<p>Returns a table of views of the given <code>size</code> as defined by <code>spec</code>. <code>spec</code> is a sequence of view name (a string) and view type (also a string) pairs. The returned table can be passed directly to the <a href="#am.bind"><code>am.bind</code></a> function. The views all use the same underlying buffer.</p>
+<h3 class="method-def" id="view:slice">view:slice(n [, count [,
+stride_multiplier]])</h3>
+<p>Returns a new view with the same type as <code>view</code> that
+references the same buffer, but which starts at the <code>n</code>th
+element of <code>view</code> and continues for <code>count</code>
+elements. If <code>count</code> is omitted or nil it covers all the
+elements of <code>view</code> after and including the <code>n</code>th.
+<code>stride_multiplier</code> can be used to increase the stride of the
+view and thereby skip elements. It must be a positive integer and
+defaults to 1 (no skipping).</p>
+<h3 class="method-def" id="view:set">view:set(val [, start [,
+count]])</h3>
+<p>Bulk sets values in a view. This is faster than setting them one at a
+time.</p>
+<p>If <code>val</code> is a number or vector then this sets all elements
+of <code>view</code> to <code>val</code>.</p>
+<p>If <code>val</code> is a table then the elements are set to their
+corresponding values from the table.</p>
+<p>As a special case, if <code>val</code> is a table of numbers and the
+view’s type is a vector, then the elements of the table will be used to
+set the components of the vectors in the view. For example:</p>
+<div class="sourceCode" id="cb77"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb77-1"><a href="#cb77-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> verts <span class="op">=</span> am<span class="op">.</span>buffer<span class="op">(</span><span class="dv">24</span><span class="op">):</span>view<span class="op">(</span><span class="st">&quot;vec3&quot;</span><span class="op">)</span></span>
+<span id="cb77-2"><a href="#cb77-2" aria-hidden="true" tabindex="-1"></a>verts<span class="op">:</span>set<span class="op">{</span><span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">,</span> <span class="dv">3</span><span class="op">,</span> <span class="dv">4</span><span class="op">,</span> <span class="dv">5</span><span class="op">,</span> <span class="dv">6</span><span class="op">}</span></span>
+<span id="cb77-3"><a href="#cb77-3" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>verts<span class="op">[</span><span class="dv">1</span><span class="op">])</span> <span class="co">-- vec3(1, 2, 3)</span></span>
+<span id="cb77-4"><a href="#cb77-4" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>verts<span class="op">[</span><span class="dv">2</span><span class="op">])</span> <span class="co">-- vec3(4, 5, 6)</span></span></code></pre></div>
+<p>Finally if <code>val</code> is another view then the elements are set
+to the corresponding values from that view. The views may be of
+different types as long as they are “compatible”. The types are
+converted as if each element were set using the Lua code
+<code>view1[i] = view2[i]</code>. This means you can’t set a number view
+to a vector view or vice versa.</p>
+<p>If <code>start</code> is given then only elements at that index and
+beyond will be set. The default value for <code>start</code> is
+<code>1</code>.</p>
+<p>If <code>count</code> is given then at most that many elements will
+be set.</p>
+<h3 class="func-def" id="am.float_array">am.float_array(table)</h3>
+<p>Returns a <code>float</code> view to a newly created buffer and fills
+it with the values in the given table.</p>
+<h3 class="func-def" id="am.byte_array">am.byte_array(table)</h3>
+<p>Returns a <code>byte</code> view to a newly created buffer and fills
+it with the values in the given table.</p>
+<h3 class="func-def" id="am.ubyte_array">am.ubyte_array(table)</h3>
+<p>Returns a <code>ubyte</code> view to a newly created buffer and fills
+it with the values in the given table.</p>
+<h3 class="func-def"
+id="am.byte_norm_array">am.byte_norm_array(table)</h3>
+<p>Returns a <code>byte_norm</code> view to a newly created buffer and
+fills it with the values in the given table.</p>
+<h3 class="func-def"
+id="am.ubyte_norm_array">am.ubyte_norm_array(table)</h3>
+<p>Returns a <code>ubyte_norm</code> view to a newly created buffer and
+fills it with the values in the given table.</p>
+<h3 class="func-def" id="am.short_array">am.short_array(table)</h3>
+<p>Returns a <code>short</code> view to a newly created buffer and fills
+it with the values in the given table.</p>
+<h3 class="func-def" id="am.ushort_array">am.ushort_array(table)</h3>
+<p>Returns a <code>ushort</code> view to a newly created buffer and
+fills it with the values in the given table.</p>
+<h3 class="func-def"
+id="am.short_norm_array">am.short_norm_array(table)</h3>
+<p>Returns a <code>short_norm</code> view to a newly created buffer and
+fills it with the values in the given table.</p>
+<h3 class="func-def"
+id="am.ushort_norm_array">am.ushort_norm_array(table)</h3>
+<p>Returns a <code>ushort_norm</code> view to a newly created buffer and
+fills it with the values in the given table.</p>
+<h3 class="func-def" id="am.int_array">am.int_array(table)</h3>
+<p>Returns an <code>int</code> view to a newly created buffer and fills
+it with the values in the given table.</p>
+<h3 class="func-def" id="am.uint_array">am.uint_array(table)</h3>
+<p>Returns a <code>uint</code> view to a newly created buffer and fills
+it with the values in the given table.</p>
+<h3 class="func-def"
+id="am.int_norm_array">am.int_norm_array(table)</h3>
+<p>Returns an <code>int_norm</code> view to a newly created buffer and
+fills it with the values in the given table.</p>
+<h3 class="func-def"
+id="am.uint_norm_array">am.uint_norm_array(table)</h3>
+<p>Returns a <code>uint_norm</code> view to a newly created buffer and
+fills it with the values in the given table.</p>
+<h3 class="func-def"
+id="am.ushort_elem_array">am.ushort_elem_array(table)</h3>
+<p>Returns a <code>ushort_elem</code> view to a newly created buffer and
+fills it with the values in the given table.</p>
+<h3 class="func-def"
+id="am.uint_elem_array">am.uint_elem_array(table)</h3>
+<p>Returns a <code>uint_elem</code> view to a newly created buffer and
+fills it with the values in the given table.</p>
+<h3 class="func-def" id="am.vec2_array">am.vec2_array(table)</h3>
+<p>Returns a <code>vec2</code> view to a newly created buffer and fills
+it with the values in the given table.</p>
+<p>The table may contain either <code>vec2</code>s or numbers (though
+not a mix). If the table contains numbers they are used for the vector
+components and the resulting view will have half the number of elements
+as there are numbers in the table.</p>
+<h3 class="func-def" id="am.vec3_array">am.vec3_array(table)</h3>
+<p>Returns a <code>vec3</code> view to a newly created buffer and fills
+it with the values in the given table.</p>
+<p>The table may contain either <code>vec3</code>s or numbers (though
+not a mix). If the table contains numbers they are used for the vector
+components and the resulting view will have a third the number of
+elements as there are numbers in the table.</p>
+<h3 class="func-def" id="am.vec4_array">am.vec4_array(table)</h3>
+<p>Returns a <code>vec4</code> view to a newly created buffer containing
+the values in the given table.</p>
+<p>The table may contain either <code>vec4</code>s or numbers (though
+not a mix). If the table contains numbers they are used for the vector
+components and the resulting view will have a quarter the number of
+elements as there are numbers in the table.</p>
+<h3 class="func-def" id="am.struct_array">am.struct_array(size,
+spec)</h3>
+<p>Returns a table of views of the given <code>size</code> as defined by
+<code>spec</code>. <code>spec</code> is a sequence of view name (a
+string) and view type (also a string) pairs. The returned table can be
+passed directly to the <a href="#am.bind"><code>am.bind</code></a>
+function. The views all use the same underlying buffer.</p>
 <p>For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> arr <span class="ot">=</span> am<span class="ot">.</span>struct_array<span class="ot">(</span><span class="dv">3</span><span class="ot">,</span> <span class="ot">{</span><span class="st">&quot;vert&quot;</span><span class="ot">,</span> <span class="st">&quot;vec2&quot;</span><span class="ot">,</span> <span class="st">&quot;color&quot;</span><span class="ot">,</span> <span class="st">&quot;vec4&quot;</span><span class="ot">})</span>
-arr<span class="ot">.</span>vert:set<span class="ot">{</span>vec2<span class="ot">(-</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> vec2<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)}</span> 
-arr<span class="ot">.</span>color:set<span class="ot">(</span>vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0.5</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">))</span></code></pre></div>
-<div class="figure">
-<img src="images/screenshot3.jpg" />
-
-</div>
+<div class="sourceCode" id="cb78"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb78-1"><a href="#cb78-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> arr <span class="op">=</span> am<span class="op">.</span>struct_array<span class="op">(</span><span class="dv">3</span><span class="op">,</span> <span class="op">{</span><span class="st">&quot;vert&quot;</span><span class="op">,</span> <span class="st">&quot;vec2&quot;</span><span class="op">,</span> <span class="st">&quot;color&quot;</span><span class="op">,</span> <span class="st">&quot;vec4&quot;</span><span class="op">})</span></span>
+<span id="cb78-2"><a href="#cb78-2" aria-hidden="true" tabindex="-1"></a>arr<span class="op">.</span>vert<span class="op">:</span>set<span class="op">{</span>vec2<span class="op">(-</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> vec2<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">)}</span> </span>
+<span id="cb78-3"><a href="#cb78-3" aria-hidden="true" tabindex="-1"></a>arr<span class="op">.</span>color<span class="op">:</span>set<span class="op">(</span>vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0.5</span><span class="op">,</span> <span class="dv">1</span><span class="op">))</span></span></code></pre></div>
+<p><img src="images/screenshot3.jpg" /></p>
 <h1 id="windows-and-input">Windows and input</h1>
 <h2 id="creating-a-window-1">Creating a window</h2>
-<h3 id="am.window" class="func-def">am.window(settings)</h3>
-<p>Creates a new window and returns a handle to it. <code>settings</code> is a table with any of the following fields:</p>
+<h3 class="func-def" id="am.window">am.window(settings)</h3>
+<p>Creates a new window and returns a handle to it.
+<code>settings</code> is a table with any of the following fields:</p>
 <ul>
-<li><p><strong><code>mode</code></strong>: Either <code>&quot;windowed&quot;</code> or <code>&quot;fullscreen&quot;</code>. A fullscreen window will have the same resolution as the user's desktop. The default is <code>&quot;windowed&quot;</code>. Not all platforms support windowed mode (e.g. iOS). On these platforms this setting is ignored.</p></li>
-<li><p><strong><code>width</code></strong> and <strong><code>height</code></strong>: These define the window's <em>default coordinate system</em>. If letterboxing is enabled then this is (<code>-width/2</code>, <code>-height/2</code>) in the bottom-left corner and (<code>width/2</code>, <code>height/2</code>) in the top-right corner. If letterboxing is disabled, then the coordinate system will extend in the horizontal or vertical directions to ensure an area of at least <code>width</code>×<code>height</code> is visible in the center of the window. In either case the centre coordinate will always be (0, 0). The default size is 640×480. Mouse and touch positions as well as rendering will be in this coordinate system unless a custom projection matrix is defined (see below). These also define the physical size of the window in windowed mode, unless the <code>physical_size</code> property is given (see below).</p></li>
-<li><p><strong><code>physical_size</code></strong>: The initial physical size of the window in windowed mode (a <code>vec2</code>). This is in &quot;screen units&quot; which usually correspond to pixels, but not always. For example on a retina Mac display where <code>highdpi</code> is enabled there are 2 pixels per screen unit. If this property is omitted then the <code>width</code> and <code>height</code> properties will be used for the physical window size. Note that this property has no effect on the coordinate system used by the window. Note also that this property only has an effect where the platform supports different sized windows. E.g. on iOS windows always fill the screen, so this property is ignored.</p></li>
+<li><p><strong><code>mode</code></strong>: Either
+<code>"windowed"</code> or <code>"fullscreen"</code>. A fullscreen
+window will have the same resolution as the user’s desktop. The default
+is <code>"windowed"</code>. Not all platforms support windowed mode
+(e.g. iOS). On these platforms this setting is ignored.</p></li>
+<li><p><strong><code>width</code></strong> and
+<strong><code>height</code></strong>: These define the window’s
+<em>default coordinate system</em>. If letterboxing is enabled then this
+is (<code>-width/2</code>, <code>-height/2</code>) in the bottom-left
+corner and (<code>width/2</code>, <code>height/2</code>) in the
+top-right corner. If letterboxing is disabled, then the coordinate
+system will extend in the horizontal or vertical directions to ensure an
+area of at least <code>width</code>×<code>height</code> is visible in
+the center of the window. In either case the centre coordinate will
+always be (0, 0). The default size is 640×480. Mouse and touch positions
+as well as rendering will be in this coordinate system unless a custom
+projection matrix is defined (see below). These also define the physical
+size of the window in windowed mode, unless the
+<code>physical_size</code> property is given (see below).</p></li>
+<li><p><strong><code>physical_size</code></strong>: The initial physical
+size of the window in windowed mode (a <code>vec2</code>). This is in
+“screen units” which usually correspond to pixels, but not always. For
+example on a retina Mac display where <code>highdpi</code> is enabled
+there are 2 pixels per screen unit. If this property is omitted then the
+<code>width</code> and <code>height</code> properties will be used for
+the physical window size. Note that this property has no effect on the
+coordinate system used by the window. Note also that this property only
+has an effect where the platform supports different sized windows. E.g.
+on iOS windows always fill the screen, so this property is
+ignored.</p></li>
 <li><p><strong><code>title</code></strong>: The window title.</p></li>
-<li><p><strong><code>resizable</code></strong>: Whether the window can be resized by the user (<code>true</code> or <code>false</code>, default <code>true</code>).</p></li>
-<li><p><strong><code>borderless</code></strong>: Whether the window has a title bar and border (<code>true</code> or <code>false</code>, default <code>false</code>).</p></li>
-<li><p><strong><code>highdpi</code></strong>: Whether to use high DPI resolution if available (<code>true</code> or <code>false</code>, default <code>false</code>).</p></li>
-<li><p><strong><code>depth_buffer</code></strong>: Whether the window has a depth buffer (<code>true</code> or <code>false</code>, default <code>false</code>).</p></li>
-<li><p><strong><code>stencil_buffer</code></strong>: Whether the window has a stencil buffer (<code>true</code> or <code>false</code>, default <code>false</code>).</p></li>
-<li><p><strong><code>stencil_clear_value</code></strong>: The value to clear the stencil buffer with before drawing each frame (an integer between 0 and 255). The default is 0.</p></li>
-<li><p><strong><code>lock_pointer</code></strong>: <code>true</code> or <code>false</code>. When pointer lock is enabled the cursor will be hidden and mouse movement will be set to &quot;relative&quot; mode. In this mode the mouse is tracked infinitely in all directions, i.e. as if there is no edge of the screen to stop the mouse cursor. This is useful for implementing first-person style mouse-look. The default is <code>false</code>.</p></li>
-<li><p><strong><code>show_cursor</code></strong>: Whether to show the mouse cursor (<code>true</code> or <code>false</code>, default <code>true</code>).</p></li>
-<li><p><strong><code>clear_color</code></strong>: The color (a <code>vec4</code>) used to clear the window each frame before drawing. The default clear color is black (<code>vec4(0, 0, 0, 1)</code>).</p></li>
-<li><p><strong><code>letterbox</code></strong>: <code>true</code> or <code>false</code>. Indicates whether the original aspect ratio (as determined by the <code>width</code> and <code>height</code> settings of the window) should be maintained after a resize by adding black horizontal or vertical bars to the sides of the window. The default is <code>true</code>.</p></li>
-<li><p><strong><code>msaa_samples</code></strong>: The number of samples to use for multisample anti-aliasing. This must be a power of 2. Use zero (the default) for no anti-aliasing.</p></li>
-<li><p><strong><code>projection</code></strong>: A custom projection matrix (a <code>mat4</code>) to be used for the window's coordinate system. If supplied, this matrix is used when transforming mouse or touch event coordinates and is set as the projection matrix for rendering, but does not affect the <code>left</code>, <code>right</code>, <code>top</code>, <code>bottom</code>, <code>width</code> and <code>height</code> fields of the window.</p></li>
+<li><p><strong><code>resizable</code></strong>: Whether the window can
+be resized by the user (<code>true</code> or <code>false</code>, default
+<code>true</code>).</p></li>
+<li><p><strong><code>borderless</code></strong>: Whether the window has
+a title bar and border (<code>true</code> or <code>false</code>, default
+<code>false</code>).</p></li>
+<li><p><strong><code>highdpi</code></strong>: Whether to use high DPI
+resolution if available (<code>true</code> or <code>false</code>,
+default <code>false</code>).</p></li>
+<li><p><strong><code>depth_buffer</code></strong>: Whether the window
+has a depth buffer (<code>true</code> or <code>false</code>, default
+<code>false</code>).</p></li>
+<li><p><strong><code>stencil_buffer</code></strong>: Whether the window
+has a stencil buffer (<code>true</code> or <code>false</code>, default
+<code>false</code>).</p></li>
+<li><p><strong><code>stencil_clear_value</code></strong>: The value to
+clear the stencil buffer with before drawing each frame (an integer
+between 0 and 255). The default is 0.</p></li>
+<li><p><strong><code>lock_pointer</code></strong>: <code>true</code> or
+<code>false</code>. When pointer lock is enabled the cursor will be
+hidden and mouse movement will be set to “relative” mode. In this mode
+the mouse is tracked infinitely in all directions, i.e. as if there is
+no edge of the screen to stop the mouse cursor. This is useful for
+implementing first-person style mouse-look. The default is
+<code>false</code>.</p></li>
+<li><p><strong><code>show_cursor</code></strong>: Whether to show the
+mouse cursor (<code>true</code> or <code>false</code>, default
+<code>true</code>).</p></li>
+<li><p><strong><code>clear_color</code></strong>: The color (a
+<code>vec4</code>) used to clear the window each frame before drawing.
+The default clear color is black
+(<code>vec4(0, 0, 0, 1)</code>).</p></li>
+<li><p><strong><code>letterbox</code></strong>: <code>true</code> or
+<code>false</code>. Indicates whether the original aspect ratio (as
+determined by the <code>width</code> and <code>height</code> settings of
+the window) should be maintained after a resize by adding black
+horizontal or vertical bars to the sides of the window. The default is
+<code>true</code>.</p></li>
+<li><p><strong><code>msaa_samples</code></strong>: The number of samples
+to use for multisample anti-aliasing. This must be a power of 2. Use
+zero (the default) for no anti-aliasing.</p></li>
+<li><p><strong><code>projection</code></strong>: A custom projection
+matrix (a <code>mat4</code>) to be used for the window’s coordinate
+system. If supplied, this matrix is used when transforming mouse or
+touch event coordinates and is set as the projection matrix for
+rendering, but does not affect the <code>left</code>,
+<code>right</code>, <code>top</code>, <code>bottom</code>,
+<code>width</code> and <code>height</code> fields of the
+window.</p></li>
 </ul>
 <h2 id="window-fields">Window fields</h2>
-<h3 id="window.left" class="func-def">window.left</h3>
-<p>The x coordinate of the left edge of the window in the window's default coordinate system.</p>
+<h3 class="func-def" id="window.left">window.left</h3>
+<p>The x coordinate of the left edge of the window in the window’s
+default coordinate system.</p>
 <p>Readonly.</p>
-<h3 id="window.right" class="func-def">window.right</h3>
-<p>The x coordinate of the right edge of the window, in the window's default coordinate system.</p>
+<h3 class="func-def" id="window.right">window.right</h3>
+<p>The x coordinate of the right edge of the window, in the window’s
+default coordinate system.</p>
 <p>Readonly.</p>
-<h3 id="window.bottom" class="func-def">window.bottom</h3>
-<p>The y coordinate of the bottom edge of the window, in the window's default coordinate system.</p>
+<h3 class="func-def" id="window.bottom">window.bottom</h3>
+<p>The y coordinate of the bottom edge of the window, in the window’s
+default coordinate system.</p>
 <p>Readonly.</p>
-<h3 id="window.top" class="func-def">window.top</h3>
-<p>The y coordinate of the top edge of the window, in the window's default coordinate system.</p>
+<h3 class="func-def" id="window.top">window.top</h3>
+<p>The y coordinate of the top edge of the window, in the window’s
+default coordinate system.</p>
 <p>Readonly.</p>
-<h3 id="window.width" class="func-def">window.width</h3>
-<p>The width of the window in the window's default coordinate system. This will always be equal to the <code>width</code> setting supplied when the window was created if the <code>letterbox</code> setting is enabled. Otherwise it may be larger, but it will never be smaller than the <code>width</code> setting.</p>
+<h3 class="func-def" id="window.width">window.width</h3>
+<p>The width of the window in the window’s default coordinate system.
+This will always be equal to the <code>width</code> setting supplied
+when the window was created if the <code>letterbox</code> setting is
+enabled. Otherwise it may be larger, but it will never be smaller than
+the <code>width</code> setting.</p>
 <p>Readonly.</p>
-<h3 id="window.height" class="field-def">window.height</h3>
-<p>The height of the window in the window's default coordinate space. This will always be equal to the <code>height</code> setting supplied when the window was created if the <code>letterbox</code> setting is enabled. Otherwise it may be larger, but it will never be smaller than the <code>height</code> setting.</p>
+<h3 class="field-def" id="window.height">window.height</h3>
+<p>The height of the window in the window’s default coordinate space.
+This will always be equal to the <code>height</code> setting supplied
+when the window was created if the <code>letterbox</code> setting is
+enabled. Otherwise it may be larger, but it will never be smaller than
+the <code>height</code> setting.</p>
 <p>Readonly.</p>
-<h3 id="window.pixel_width" class="field-def">window.pixel_width</h3>
+<h3 class="field-def" id="window.pixel_width">window.pixel_width</h3>
 <p>The real width of the window in pixels.</p>
 <p>Readonly.</p>
-<h3 id="window.pixel_height" class="field-def">window.pixel_height</h3>
+<h3 class="field-def" id="window.pixel_height">window.pixel_height</h3>
 <p>The real height of the window in pixels</p>
 <p>Readonly.</p>
-<h3 id="window.safe_left" class="func-def">window.safe_left</h3>
-<p>The x coordinate of the left edge of the window's safe area in the window's default coordinate system.</p>
-<p>This should be used to position elements that you don't want obscured by e.g. the iPhone X notch.</p>
+<h3 class="func-def" id="window.safe_left">window.safe_left</h3>
+<p>The x coordinate of the left edge of the window’s safe area in the
+window’s default coordinate system.</p>
+<p>This should be used to position elements that you don’t want obscured
+by e.g. the iPhone X notch.</p>
 <p>Readonly.</p>
-<h3 id="window.safe_right" class="func-def">window.safe_right</h3>
-<p>The x coordinate of the right edge of the window's safe area, in the window's default coordinate system.</p>
-<p>This should be used to position elements that you don't want obscured by e.g. the iPhone X notch.</p>
+<h3 class="func-def" id="window.safe_right">window.safe_right</h3>
+<p>The x coordinate of the right edge of the window’s safe area, in the
+window’s default coordinate system.</p>
+<p>This should be used to position elements that you don’t want obscured
+by e.g. the iPhone X notch.</p>
 <p>Readonly.</p>
-<h3 id="window.safe_bottom" class="func-def">window.safe_bottom</h3>
-<p>The y coordinate of the bottom edge of the window's safe area, in the window's default coordinate system.</p>
-<p>This should be used to position elements that you don't want obscured by e.g. the iPhone X notch.</p>
+<h3 class="func-def" id="window.safe_bottom">window.safe_bottom</h3>
+<p>The y coordinate of the bottom edge of the window’s safe area, in the
+window’s default coordinate system.</p>
+<p>This should be used to position elements that you don’t want obscured
+by e.g. the iPhone X notch.</p>
 <p>Readonly.</p>
-<h3 id="window.safe_top" class="func-def">window.safe_top</h3>
-<p>The y coordinate of the top edge of the window's safe area, in the window's default coordinate system.</p>
-<p>This should be used to position elements that you don't want obscured by e.g. the iPhone X notch.</p>
+<h3 class="func-def" id="window.safe_top">window.safe_top</h3>
+<p>The y coordinate of the top edge of the window’s safe area, in the
+window’s default coordinate system.</p>
+<p>This should be used to position elements that you don’t want obscured
+by e.g. the iPhone X notch.</p>
 <p>Readonly.</p>
-<h3 id="window.mode" class="field-def">window.mode</h3>
+<h3 class="field-def" id="window.mode">window.mode</h3>
 <p>See <a href="#am.window">window settings</a>.</p>
 <p>Updatable.</p>
-<h3 id="window.clear_color" class="field-def">window.clear_color</h3>
+<h3 class="field-def" id="window.clear_color">window.clear_color</h3>
 <p>See <a href="#am.window">window settings</a>.</p>
 <p>Updatable.</p>
-<h3 id="window.stencil_clear_value" class="field-def">window.stencil_clear_value</h3>
+<h3 class="field-def"
+id="window.stencil_clear_value">window.stencil_clear_value</h3>
 <p>See <a href="#am.window">window settings</a>.</p>
 <p>Updatable.</p>
-<h3 id="window.letterbox" class="field-def">window.letterbox</h3>
+<h3 class="field-def" id="window.letterbox">window.letterbox</h3>
 <p>See <a href="#am.window">window settings</a>.</p>
 <p>Updatable.</p>
-<h3 id="window.lock_pointer" class="field-def">window.lock_pointer</h3>
+<h3 class="field-def" id="window.lock_pointer">window.lock_pointer</h3>
 <p>See <a href="#am.window">window settings</a>.</p>
 <p>Updatable.</p>
-<h3 id="window.show_cursor" class="field-def">window.show_cursor</h3>
+<h3 class="field-def" id="window.show_cursor">window.show_cursor</h3>
 <p>See <a href="#am.window">window settings</a>.</p>
 <p>Updatable.</p>
-<h3 id="window.scene" class="field-def">window.scene</h3>
-<p>The <a href="#scenes">scene node</a> currently attached to the window. This scene will be rendered to the window each frame.</p>
+<h3 class="field-def" id="window.scene">window.scene</h3>
+<p>The <a href="#scenes">scene node</a> currently attached to the
+window. This scene will be rendered to the window each frame.</p>
 <p>Updatable.</p>
-<h3 id="window.projection" class="field-def">window.projection</h3>
+<h3 class="field-def" id="window.projection">window.projection</h3>
 <p>See <a href="#am.window">window settings</a>.</p>
 <p>Updatable.</p>
 <h2 id="closing-a-window">Closing a window</h2>
-<h3 id="windowclose" class="method-def">window:close()</h3>
-<p>Closes the window and quits the application if this was the only window.</p>
-<h2 id="detecting-when-a-window-resizes">Detecting when a window resizes</h2>
-<h3 id="windowresized" class="method-def">window:resized()</h3>
-<p>Returns true if the window's size changed since the last frame.</p>
+<h3 class="method-def" id="windowclose">window:close()</h3>
+<p>Closes the window and quits the application if this was the only
+window.</p>
+<h2 id="detecting-when-a-window-resizes">Detecting when a window
+resizes</h2>
+<h3 class="method-def" id="windowresized">window:resized()</h3>
+<p>Returns true if the window’s size changed since the last frame.</p>
 <h2 id="detecting-key-presses">Detecting key presses</h2>
-<p>The following functions detect physical key states and are not affected by the keyboard layout preferences selected in the OS (except when targetting HTML).</p>
+<p>The following functions detect physical key states and are not
+affected by the keyboard layout preferences selected in the OS (except
+when targetting HTML).</p>
 <p>Keys are represented by one of the following strings:</p>
 <ul>
-<li><code>&quot;a&quot;</code></li>
-<li><code>&quot;b&quot;</code></li>
-<li><code>&quot;c&quot;</code></li>
-<li><code>&quot;d&quot;</code></li>
-<li><code>&quot;e&quot;</code></li>
-<li><code>&quot;f&quot;</code></li>
-<li><code>&quot;g&quot;</code></li>
-<li><code>&quot;h&quot;</code></li>
-<li><code>&quot;i&quot;</code></li>
-<li><code>&quot;j&quot;</code></li>
-<li><code>&quot;k&quot;</code></li>
-<li><code>&quot;l&quot;</code></li>
-<li><code>&quot;m&quot;</code></li>
-<li><code>&quot;n&quot;</code></li>
-<li><code>&quot;o&quot;</code></li>
-<li><code>&quot;p&quot;</code></li>
-<li><code>&quot;q&quot;</code></li>
-<li><code>&quot;r&quot;</code></li>
-<li><code>&quot;s&quot;</code></li>
-<li><code>&quot;t&quot;</code></li>
-<li><code>&quot;u&quot;</code></li>
-<li><code>&quot;v&quot;</code></li>
-<li><code>&quot;w&quot;</code></li>
-<li><code>&quot;x&quot;</code></li>
-<li><code>&quot;y&quot;</code></li>
-<li><code>&quot;z&quot;</code></li>
-<li><code>&quot;1&quot;</code></li>
-<li><code>&quot;2&quot;</code></li>
-<li><code>&quot;3&quot;</code></li>
-<li><code>&quot;4&quot;</code></li>
-<li><code>&quot;5&quot;</code></li>
-<li><code>&quot;6&quot;</code></li>
-<li><code>&quot;7&quot;</code></li>
-<li><code>&quot;8&quot;</code></li>
-<li><code>&quot;9&quot;</code></li>
-<li><code>&quot;0&quot;</code></li>
-<li><code>&quot;enter&quot;</code></li>
-<li><code>&quot;escape&quot;</code></li>
-<li><code>&quot;backspace&quot;</code></li>
-<li><code>&quot;tab&quot;</code></li>
-<li><code>&quot;space&quot;</code></li>
-<li><code>&quot;minus&quot;</code></li>
-<li><code>&quot;equals&quot;</code></li>
-<li><code>&quot;leftbracket&quot;</code></li>
-<li><code>&quot;rightbracket&quot;</code></li>
-<li><code>&quot;backslash&quot;</code></li>
-<li><code>&quot;semicolon&quot;</code></li>
-<li><code>&quot;quote&quot;</code></li>
-<li><code>&quot;backquote&quot;</code></li>
-<li><code>&quot;comma&quot;</code></li>
-<li><code>&quot;period&quot;</code></li>
-<li><code>&quot;slash&quot;</code></li>
-<li><code>&quot;capslock&quot;</code></li>
-<li><code>&quot;f1&quot;</code></li>
-<li><code>&quot;f2&quot;</code></li>
-<li><code>&quot;f3&quot;</code></li>
-<li><code>&quot;f4&quot;</code></li>
-<li><code>&quot;f5&quot;</code></li>
-<li><code>&quot;f6&quot;</code></li>
-<li><code>&quot;f7&quot;</code></li>
-<li><code>&quot;f8&quot;</code></li>
-<li><code>&quot;f9&quot;</code></li>
-<li><code>&quot;f10&quot;</code></li>
-<li><code>&quot;f11&quot;</code></li>
-<li><code>&quot;f12&quot;</code></li>
-<li><code>&quot;printscreen&quot;</code></li>
-<li><code>&quot;scrolllock&quot;</code></li>
-<li><code>&quot;pause&quot;</code></li>
-<li><code>&quot;insert&quot;</code></li>
-<li><code>&quot;home&quot;</code></li>
-<li><code>&quot;pageup&quot;</code></li>
-<li><code>&quot;delete&quot;</code></li>
-<li><code>&quot;end&quot;</code></li>
-<li><code>&quot;pagedown&quot;</code></li>
-<li><code>&quot;right&quot;</code></li>
-<li><code>&quot;left&quot;</code></li>
-<li><code>&quot;down&quot;</code></li>
-<li><code>&quot;up&quot;</code></li>
-<li><code>&quot;numlock&quot;</code></li>
-<li><code>&quot;kp_divide&quot;</code></li>
-<li><code>&quot;kp_multiply&quot;</code></li>
-<li><code>&quot;kp_minus&quot;</code></li>
-<li><code>&quot;kp_plus&quot;</code></li>
-<li><code>&quot;kp_enter&quot;</code></li>
-<li><code>&quot;kp_1&quot;</code></li>
-<li><code>&quot;kp_2&quot;</code></li>
-<li><code>&quot;kp_3&quot;</code></li>
-<li><code>&quot;kp_4&quot;</code></li>
-<li><code>&quot;kp_5&quot;</code></li>
-<li><code>&quot;kp_6&quot;</code></li>
-<li><code>&quot;kp_7&quot;</code></li>
-<li><code>&quot;kp_8&quot;</code></li>
-<li><code>&quot;kp_9&quot;</code></li>
-<li><code>&quot;kp_0&quot;</code></li>
-<li><code>&quot;kp_period&quot;</code></li>
-<li><code>&quot;lctrl&quot;</code></li>
-<li><code>&quot;lshift&quot;</code></li>
-<li><code>&quot;lalt&quot;</code></li>
-<li><code>&quot;lgui&quot;</code></li>
-<li><code>&quot;rctrl&quot;</code></li>
-<li><code>&quot;rshift&quot;</code></li>
-<li><code>&quot;ralt&quot;</code></li>
-<li><code>&quot;rgui&quot;</code></li>
+<li><code>"a"</code></li>
+<li><code>"b"</code></li>
+<li><code>"c"</code></li>
+<li><code>"d"</code></li>
+<li><code>"e"</code></li>
+<li><code>"f"</code></li>
+<li><code>"g"</code></li>
+<li><code>"h"</code></li>
+<li><code>"i"</code></li>
+<li><code>"j"</code></li>
+<li><code>"k"</code></li>
+<li><code>"l"</code></li>
+<li><code>"m"</code></li>
+<li><code>"n"</code></li>
+<li><code>"o"</code></li>
+<li><code>"p"</code></li>
+<li><code>"q"</code></li>
+<li><code>"r"</code></li>
+<li><code>"s"</code></li>
+<li><code>"t"</code></li>
+<li><code>"u"</code></li>
+<li><code>"v"</code></li>
+<li><code>"w"</code></li>
+<li><code>"x"</code></li>
+<li><code>"y"</code></li>
+<li><code>"z"</code></li>
+<li><code>"1"</code></li>
+<li><code>"2"</code></li>
+<li><code>"3"</code></li>
+<li><code>"4"</code></li>
+<li><code>"5"</code></li>
+<li><code>"6"</code></li>
+<li><code>"7"</code></li>
+<li><code>"8"</code></li>
+<li><code>"9"</code></li>
+<li><code>"0"</code></li>
+<li><code>"enter"</code></li>
+<li><code>"escape"</code></li>
+<li><code>"backspace"</code></li>
+<li><code>"tab"</code></li>
+<li><code>"space"</code></li>
+<li><code>"minus"</code></li>
+<li><code>"equals"</code></li>
+<li><code>"leftbracket"</code></li>
+<li><code>"rightbracket"</code></li>
+<li><code>"backslash"</code></li>
+<li><code>"semicolon"</code></li>
+<li><code>"quote"</code></li>
+<li><code>"backquote"</code></li>
+<li><code>"comma"</code></li>
+<li><code>"period"</code></li>
+<li><code>"slash"</code></li>
+<li><code>"capslock"</code></li>
+<li><code>"f1"</code></li>
+<li><code>"f2"</code></li>
+<li><code>"f3"</code></li>
+<li><code>"f4"</code></li>
+<li><code>"f5"</code></li>
+<li><code>"f6"</code></li>
+<li><code>"f7"</code></li>
+<li><code>"f8"</code></li>
+<li><code>"f9"</code></li>
+<li><code>"f10"</code></li>
+<li><code>"f11"</code></li>
+<li><code>"f12"</code></li>
+<li><code>"printscreen"</code></li>
+<li><code>"scrolllock"</code></li>
+<li><code>"pause"</code></li>
+<li><code>"insert"</code></li>
+<li><code>"home"</code></li>
+<li><code>"pageup"</code></li>
+<li><code>"delete"</code></li>
+<li><code>"end"</code></li>
+<li><code>"pagedown"</code></li>
+<li><code>"right"</code></li>
+<li><code>"left"</code></li>
+<li><code>"down"</code></li>
+<li><code>"up"</code></li>
+<li><code>"numlock"</code></li>
+<li><code>"kp_divide"</code></li>
+<li><code>"kp_multiply"</code></li>
+<li><code>"kp_minus"</code></li>
+<li><code>"kp_plus"</code></li>
+<li><code>"kp_enter"</code></li>
+<li><code>"kp_1"</code></li>
+<li><code>"kp_2"</code></li>
+<li><code>"kp_3"</code></li>
+<li><code>"kp_4"</code></li>
+<li><code>"kp_5"</code></li>
+<li><code>"kp_6"</code></li>
+<li><code>"kp_7"</code></li>
+<li><code>"kp_8"</code></li>
+<li><code>"kp_9"</code></li>
+<li><code>"kp_0"</code></li>
+<li><code>"kp_period"</code></li>
+<li><code>"lctrl"</code></li>
+<li><code>"lshift"</code></li>
+<li><code>"lalt"</code></li>
+<li><code>"lgui"</code></li>
+<li><code>"rctrl"</code></li>
+<li><code>"rshift"</code></li>
+<li><code>"ralt"</code></li>
+<li><code>"rgui"</code></li>
 </ul>
-<p>Keys not listed above are represented as a hash followed by the scancode, for example <code>&quot;#101&quot;</code>.</p>
-<h3 id="key_down" class="method-def">window:key_down(key)</h3>
-<p>Returns true if the given key was down at the start of the current frame.</p>
-<h3 id="windowkeys_down" class="method-def">window:keys_down()</h3>
-<p>Returns an array of the keys that were down at the start of the current frame.</p>
-<h3 id="windowkey_pressedkey" class="method-def">window:key_pressed(key)</h3>
-<p>Returns true if the given key's state changed from up to down since the last frame.</p>
-<p>Note that if <code>key_pressed</code> returns true for a particular key, then <code>key_down</code> will also return <code>true</code>. Also if <code>key_pressed</code> returns <code>true</code> for a particular key then <code>key_released</code> will return <code>false</code> for the same key. (If necessary, Amulet will postpone key release events to the next frame to ensure this.)</p>
-<h3 id="windowkeys_pressed" class="method-def">window:keys_pressed()</h3>
-<p>Returns an array of all the keys whose state changed from up to down since the last frame.</p>
-<h3 id="windowkey_releasedkey" class="method-def">window:key_released(key)</h3>
-<p>Returns true if the given key's state changed from down to up since the last frame.</p>
-<p>Note that if <code>key_released</code> returns true for a particular key, then <code>key_down</code> will return <code>false</code>. Also if <code>key_released</code> returns <code>true</code> for a particular key then <code>key_pressed</code> will return <code>false</code>. (If necessary, Amulet will postpone key press events to the next frame to ensure this.)</p>
-<h3 id="windowkeys_released" class="method-def">window:keys_released()</h3>
-<p>Returns an array of all the keys whose state changed from down to up since the last frame.</p>
+<p>Keys not listed above are represented as a hash followed by the
+scancode, for example <code>"#101"</code>.</p>
+<h3 class="method-def" id="key_down">window:key_down(key)</h3>
+<p>Returns true if the given key was down at the start of the current
+frame.</p>
+<h3 class="method-def" id="windowkeys_down">window:keys_down()</h3>
+<p>Returns an array of the keys that were down at the start of the
+current frame.</p>
+<h3 class="method-def"
+id="windowkey_pressedkey">window:key_pressed(key)</h3>
+<p>Returns true if the given key’s state changed from up to down since
+the last frame.</p>
+<p>Note that if <code>key_pressed</code> returns true for a particular
+key, then <code>key_down</code> will also return <code>true</code>. Also
+if <code>key_pressed</code> returns <code>true</code> for a particular
+key then <code>key_released</code> will return <code>false</code> for
+the same key. (If necessary, Amulet will postpone key release events to
+the next frame to ensure this.)</p>
+<h3 class="method-def"
+id="windowkeys_pressed">window:keys_pressed()</h3>
+<p>Returns an array of all the keys whose state changed from up to down
+since the last frame.</p>
+<h3 class="method-def"
+id="windowkey_releasedkey">window:key_released(key)</h3>
+<p>Returns true if the given key’s state changed from down to up since
+the last frame.</p>
+<p>Note that if <code>key_released</code> returns true for a particular
+key, then <code>key_down</code> will return <code>false</code>. Also if
+<code>key_released</code> returns <code>true</code> for a particular key
+then <code>key_pressed</code> will return <code>false</code>. (If
+necessary, Amulet will postpone key press events to the next frame to
+ensure this.)</p>
+<h3 class="method-def"
+id="windowkeys_released">window:keys_released()</h3>
+<p>Returns an array of all the keys whose state changed from down to up
+since the last frame.</p>
 <h2 id="detecting-mouse-events">Detecting mouse events</h2>
-<h3 id="windowmouse_position" class="method-def">window:mouse_position()</h3>
-<p>Returns the position of the mouse cursor, as a <code>vec2</code>, in the window's coordinate system.</p>
-<h3 id="windowmouse_norm_position" class="method-def">window:mouse_norm_position()</h3>
-<p>Returns the position of the mouse cursor in normalized device coordinates, as a <code>vec2</code>.</p>
-<h3 id="windowmouse_pixel_position" class="method-def">window:mouse_pixel_position()</h3>
-<p>Returns the position of the mouse cursor in pixels where the bottom left corner of the window has coordinate (0, 0), as a <code>vec2</code>.</p>
-<h3 id="windowmouse_delta" class="func-def">window:mouse_delta()</h3>
-<p>Returns the change in mouse position since the last frame, in the window's coordinate system (a <code>vec2</code>).</p>
-<h3 id="windowmouse_norm_delta" class="method-def">window:mouse_norm_delta()</h3>
-<p>Returns the change in mouse position since the last frame, in normalized device coordinates (a <code>vec2</code>).</p>
-<h3 id="windowmouse_pixel_delta" class="method-def">window:mouse_pixel_delta()</h3>
-<p>Returns the change in mouse position since the last frame, in pixels (a <code>vec2</code>).</p>
-<h3 id="windowmouse_downbutton" class="method-def">window:mouse_down(button)</h3>
-<p>Returns <code>true</code> if the given button was down at the start of the frame. <code>button</code> may be <code>&quot;left&quot;</code>, <code>&quot;right&quot;</code> or <code>&quot;middle&quot;</code>.</p>
-<h3 id="windowmouse_pressedbutton" class="method-def">window:mouse_pressed(button)</h3>
-<p>Returns <code>true</code> if the given mouse button's state changed from up to down since the last frame. <code>button</code> may be <code>&quot;left&quot;</code>, <code>&quot;right&quot;</code> or <code>&quot;middle&quot;</code>.</p>
-<p>Note that if <code>mouse_pressed</code> returns <code>true</code> for a particular button then <code>mouse_down</code> will also return <code>true</code>. Also if <code>mouse_pressed</code> returns <code>true</code> for a particular button then <code>mouse_released</code> will return <code>false</code>. (If necessary, Amulet will postpone button release events to the next frame to ensure this.)</p>
-<h3 id="windowmouse_releasedbutton" class="method-def">window:mouse_released(button)</h3>
-<p>Returns true if the given mouse button's state changed from down to up since the last frame. <code>button</code> may be <code>&quot;left&quot;</code>, <code>&quot;right&quot;</code> or <code>&quot;middle&quot;</code>.</p>
-<p>Note that if <code>mouse_released</code> returns <code>true</code> for a particular button then <code>mouse_down</code> will return <code>false</code>. Also if <code>mouse_released</code> returns <code>true</code> for a particular button then <code>mouse_pressed</code> will return <code>false</code>. (If necessary, Amulet will postpone button press events to the next frame to ensure this.)</p>
-<h3 id="windowmouse_wheel" class="method-def">window:mouse_wheel()</h3>
+<h3 class="method-def"
+id="windowmouse_position">window:mouse_position()</h3>
+<p>Returns the position of the mouse cursor, as a <code>vec2</code>, in
+the window’s coordinate system.</p>
+<h3 class="method-def"
+id="windowmouse_norm_position">window:mouse_norm_position()</h3>
+<p>Returns the position of the mouse cursor in normalized device
+coordinates, as a <code>vec2</code>.</p>
+<h3 class="method-def"
+id="windowmouse_pixel_position">window:mouse_pixel_position()</h3>
+<p>Returns the position of the mouse cursor in pixels where the bottom
+left corner of the window has coordinate (0, 0), as a
+<code>vec2</code>.</p>
+<h3 class="func-def" id="windowmouse_delta">window:mouse_delta()</h3>
+<p>Returns the change in mouse position since the last frame, in the
+window’s coordinate system (a <code>vec2</code>).</p>
+<h3 class="method-def"
+id="windowmouse_norm_delta">window:mouse_norm_delta()</h3>
+<p>Returns the change in mouse position since the last frame, in
+normalized device coordinates (a <code>vec2</code>).</p>
+<h3 class="method-def"
+id="windowmouse_pixel_delta">window:mouse_pixel_delta()</h3>
+<p>Returns the change in mouse position since the last frame, in pixels
+(a <code>vec2</code>).</p>
+<h3 class="method-def"
+id="windowmouse_downbutton">window:mouse_down(button)</h3>
+<p>Returns <code>true</code> if the given button was down at the start
+of the frame. <code>button</code> may be <code>"left"</code>,
+<code>"right"</code> or <code>"middle"</code>.</p>
+<h3 class="method-def"
+id="windowmouse_pressedbutton">window:mouse_pressed(button)</h3>
+<p>Returns <code>true</code> if the given mouse button’s state changed
+from up to down since the last frame. <code>button</code> may be
+<code>"left"</code>, <code>"right"</code> or <code>"middle"</code>.</p>
+<p>Note that if <code>mouse_pressed</code> returns <code>true</code> for
+a particular button then <code>mouse_down</code> will also return
+<code>true</code>. Also if <code>mouse_pressed</code> returns
+<code>true</code> for a particular button then
+<code>mouse_released</code> will return <code>false</code>. (If
+necessary, Amulet will postpone button release events to the next frame
+to ensure this.)</p>
+<h3 class="method-def"
+id="windowmouse_releasedbutton">window:mouse_released(button)</h3>
+<p>Returns true if the given mouse button’s state changed from down to
+up since the last frame. <code>button</code> may be <code>"left"</code>,
+<code>"right"</code> or <code>"middle"</code>.</p>
+<p>Note that if <code>mouse_released</code> returns <code>true</code>
+for a particular button then <code>mouse_down</code> will return
+<code>false</code>. Also if <code>mouse_released</code> returns
+<code>true</code> for a particular button then
+<code>mouse_pressed</code> will return <code>false</code>. (If
+necessary, Amulet will postpone button press events to the next frame to
+ensure this.)</p>
+<h3 class="method-def" id="windowmouse_wheel">window:mouse_wheel()</h3>
 <p>Returns the mouse scroll wheel position (a <code>vec2</code>).</p>
-<h3 id="windowmouse_wheel_delta" class="method-def">window:mouse_wheel_delta()</h3>
-<p>Returns the change in mouse scroll wheel position since the last frame (a <code>vec2</code>).</p>
+<h3 class="method-def"
+id="windowmouse_wheel_delta">window:mouse_wheel_delta()</h3>
+<p>Returns the change in mouse scroll wheel position since the last
+frame (a <code>vec2</code>).</p>
 <h2 id="detecting-touch-events">Detecting touch events</h2>
-<h3 id="touches_began" class="method-def">window:touches_began()</h3>
+<h3 class="method-def" id="touches_began">window:touches_began()</h3>
 <p>Returns an array of the touches that began since the last frame.</p>
-<p>Each touch is an integer and each time a new touch occurs the lowest available integer greater than or equal to 1 is assigned to the touch.</p>
-<p>If there are no other active touches then the next touch will always be 1, so if your interface only expects a single touch at a time, you can just use 1 for all touch functions that take a touch argument and any additional touches will be ignored.</p>
-<h3 id="windowtouches_ended" class="method-def">window:touches_ended()</h3>
+<p>Each touch is an integer and each time a new touch occurs the lowest
+available integer greater than or equal to 1 is assigned to the
+touch.</p>
+<p>If there are no other active touches then the next touch will always
+be 1, so if your interface only expects a single touch at a time, you
+can just use 1 for all touch functions that take a touch argument and
+any additional touches will be ignored.</p>
+<h3 class="method-def"
+id="windowtouches_ended">window:touches_ended()</h3>
 <p>Returns an array of the touches that ended since the last frame.</p>
-<p>See <a href="#touches_began"><code>window:touches_began</code></a> for more info about the returned touches.</p>
-<h3 id="windowactive_touches" class="method-def">window:active_touches()</h3>
+<p>See <a href="#touches_began"><code>window:touches_began</code></a>
+for more info about the returned touches.</p>
+<h3 class="method-def"
+id="windowactive_touches">window:active_touches()</h3>
 <p>Returns an array of the currently active touches.</p>
-<p>See <a href="#touches_began"><code>window:touches_began</code></a> for more info about the returned touches.</p>
-<h3 id="windowtouch_begantouch" class="method-def">window:touch_began([touch])</h3>
+<p>See <a href="#touches_began"><code>window:touches_began</code></a>
+for more info about the returned touches.</p>
+<h3 class="method-def"
+id="windowtouch_begantouch">window:touch_began([touch])</h3>
 <p>Returns true if the specific touch began since the last frame.</p>
 <p>The default value for <code>touch</code> is <code>1</code>.</p>
-<p>See <a href="#touches_began"><code>window:touches_began</code></a> for additional notes on the <code>touch</code> argument.</p>
-<h3 id="windowtouch_endedtouch" class="method-def">window:touch_ended([touch])</h3>
+<p>See <a href="#touches_began"><code>window:touches_began</code></a>
+for additional notes on the <code>touch</code> argument.</p>
+<h3 class="method-def"
+id="windowtouch_endedtouch">window:touch_ended([touch])</h3>
 <p>Returns true if the specific touch ended since the last frame.</p>
 <p>The default value for <code>touch</code> is <code>1</code>.</p>
-<p>See <a href="#touches_began"><code>window:touches_began</code></a> for additional notes on the <code>touch</code> argument.</p>
-<h3 id="window:touch_active" class="method-def">window:touch_active([touch])</h3>
+<p>See <a href="#touches_began"><code>window:touches_began</code></a>
+for additional notes on the <code>touch</code> argument.</p>
+<h3 class="method-def"
+id="window:touch_active">window:touch_active([touch])</h3>
 <p>Returns true if the specific touch is active.</p>
 <p>The default value for <code>touch</code> is <code>1</code>.</p>
-<p>See <a href="#touches_began"><code>window:touches_began</code></a> for additional notes on the <code>touch</code> argument.</p>
-<h3 id="windowtouch_positiontouch" class="method-def">window:touch_position([touch])</h3>
-<p>Returns the last touch position in the window's coordinate system (a <code>vec2</code>).</p>
+<p>See <a href="#touches_began"><code>window:touches_began</code></a>
+for additional notes on the <code>touch</code> argument.</p>
+<h3 class="method-def"
+id="windowtouch_positiontouch">window:touch_position([touch])</h3>
+<p>Returns the last touch position in the window’s coordinate system (a
+<code>vec2</code>).</p>
 <p>The default value for <code>touch</code> is <code>1</code>.</p>
-<p>See <a href="#touches_began"><code>window:touches_began</code></a> for additional notes on the <code>touch</code> argument.</p>
-<h3 id="windowtouch_norm_positiontouch" class="method-def">window:touch_norm_position([touch])</h3>
-<p>Returns the last touch position in normalized device coordinates (a <code>vec2</code>).</p>
+<p>See <a href="#touches_began"><code>window:touches_began</code></a>
+for additional notes on the <code>touch</code> argument.</p>
+<h3 class="method-def"
+id="windowtouch_norm_positiontouch">window:touch_norm_position([touch])</h3>
+<p>Returns the last touch position in normalized device coordinates (a
+<code>vec2</code>).</p>
 <p>The default value for <code>touch</code> is <code>1</code>.</p>
-<p>See <a href="#touches_began"><code>window:touches_began</code></a> for additional notes on the <code>touch</code> argument.</p>
-<h3 id="windowtouch_pixel_positiontouch" class="method-def">window:touch_pixel_position([touch])</h3>
-<p>Returns the last touch position in pixels, where the bottom left corner of the window is (0, 0) (a <code>vec2</code>).</p>
+<p>See <a href="#touches_began"><code>window:touches_began</code></a>
+for additional notes on the <code>touch</code> argument.</p>
+<h3 class="method-def"
+id="windowtouch_pixel_positiontouch">window:touch_pixel_position([touch])</h3>
+<p>Returns the last touch position in pixels, where the bottom left
+corner of the window is (0, 0) (a <code>vec2</code>).</p>
 <p>The default value for <code>touch</code> is <code>1</code>.</p>
-<p>See <a href="#touches_began"><code>window:touches_began</code></a> for additional notes on the <code>touch</code> argument.</p>
-<h3 id="windowtouch_deltatouch" class="method-def">window:touch_delta([touch])</h3>
-<p>Returns the change in touch position since the last frame in the window's coordinate system (a <code>vec2</code>).</p>
+<p>See <a href="#touches_began"><code>window:touches_began</code></a>
+for additional notes on the <code>touch</code> argument.</p>
+<h3 class="method-def"
+id="windowtouch_deltatouch">window:touch_delta([touch])</h3>
+<p>Returns the change in touch position since the last frame in the
+window’s coordinate system (a <code>vec2</code>).</p>
 <p>The default value for <code>touch</code> is <code>1</code>.</p>
-<p>See <a href="#touches_began"><code>window:touches_began</code></a> for additional notes on the <code>touch</code> argument.</p>
-<h3 id="windowtouch_norm_deltatouch" class="method-def">window:touch_norm_delta([touch])</h3>
-<p>Returns the change in touch position since the last frame in normalized device coordinates (a <code>vec2</code>).</p>
+<p>See <a href="#touches_began"><code>window:touches_began</code></a>
+for additional notes on the <code>touch</code> argument.</p>
+<h3 class="method-def"
+id="windowtouch_norm_deltatouch">window:touch_norm_delta([touch])</h3>
+<p>Returns the change in touch position since the last frame in
+normalized device coordinates (a <code>vec2</code>).</p>
 <p>The default value for <code>touch</code> is <code>1</code>.</p>
-<p>See <a href="#touches_began"><code>window:touches_began</code></a> for additional notes on the <code>touch</code> argument.</p>
-<h3 id="windowtouch_pixel_deltatouch" class="method-def">window:touch_pixel_delta([touch])</h3>
-<p>Returns the change in touch position since the last frame in pixels (a <code>vec2</code>).</p>
+<p>See <a href="#touches_began"><code>window:touches_began</code></a>
+for additional notes on the <code>touch</code> argument.</p>
+<h3 class="method-def"
+id="windowtouch_pixel_deltatouch">window:touch_pixel_delta([touch])</h3>
+<p>Returns the change in touch position since the last frame in pixels
+(a <code>vec2</code>).</p>
 <p>The default value for <code>touch</code> is <code>1</code>.</p>
-<p>See <a href="#touches_began"><code>window:touches_began</code></a> for additional notes on the <code>touch</code> argument.</p>
-<h3 id="window:touch_force" class="method-def">window:touch_force([touch])</h3>
-<p>Returns the force of the touch where 0 means no force and 1 is &quot;average&quot; force. Harder presses will result in values larger than 1.</p>
+<p>See <a href="#touches_began"><code>window:touches_began</code></a>
+for additional notes on the <code>touch</code> argument.</p>
+<h3 class="method-def"
+id="window:touch_force">window:touch_force([touch])</h3>
+<p>Returns the force of the touch where 0 means no force and 1 is
+“average” force. Harder presses will result in values larger than 1.</p>
 <p>The default value for <code>touch</code> is <code>1</code>.</p>
-<p>See <a href="#touches_began"><code>window:touches_began</code></a> for additional notes on the <code>touch</code> argument.</p>
-<h3 id="window:touch_force_available" class="method-def">window:touch_force_available()</h3>
+<p>See <a href="#touches_began"><code>window:touches_began</code></a>
+for additional notes on the <code>touch</code> argument.</p>
+<h3 class="method-def"
+id="window:touch_force_available">window:touch_force_available()</h3>
 <p>Returns true if touch force is supported on the device.</p>
-<div class="figure">
-<img src="images/screenshot8.jpg" />
-
-</div>
+<p><img src="images/screenshot8.jpg" /></p>
 <h1 id="scenes">Scenes</h1>
-<p>Scene graphs are how you draw graphics in Amulet. <em>Scene nodes</em> are connected together to form a graph which is attached to a window (via the window's <a href="#window.scene"><code>scene</code></a> field). The window will then render the scene graph each frame.</p>
-<p>Scene nodes correspond to graphics commands. They either change the rendering state in some way, for example by applying a transformation or changing the blend mode, or execute a draw command, which renders something to the screen.</p>
-<p>Each scene node has a list of children, which are rendered in depth-first, left-to-right order.</p>
-<p>A scene node may be the child of multiple other scene nodes, so in general a scene node does not have a unique parent. Cycles are also allowed and are handled by imposing a limit to the number of times a node can be recursively rendered.</p>
+<p>Scene graphs are how you draw graphics in Amulet. <em>Scene
+nodes</em> are connected together to form a graph which is attached to a
+window (via the window’s <a href="#window.scene"><code>scene</code></a>
+field). The window will then render the scene graph each frame.</p>
+<p>Scene nodes correspond to graphics commands. They either change the
+rendering state in some way, for example by applying a transformation or
+changing the blend mode, or execute a draw command, which renders
+something to the screen.</p>
+<p>Each scene node has a list of children, which are rendered in
+depth-first, left-to-right order.</p>
+<p>A scene node may be the child of multiple other scene nodes, so in
+general a scene node does not have a unique parent. Cycles are also
+allowed and are handled by imposing a limit to the number of times a
+node can be recursively rendered.</p>
 <h2 id="scene-graph-syntax">Scene graph construction syntax</h2>
-<p>Special syntax is provided for constructing scene graphs from nodes. The expression:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">node1 <span class="ot">^</span> node2</code></pre></div>
-<p>adds <code>node2</code> as a child of <code>node1</code> and returns <code>node1</code>. The resulting scene graph looks like this:</p>
-<div class="figure">
-<img src="graphs/scene4.png" />
-
-</div>
+<p>Special syntax is provided for constructing scene graphs from nodes.
+The expression:</p>
+<div class="sourceCode" id="cb79"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb79-1"><a href="#cb79-1" aria-hidden="true" tabindex="-1"></a>node1 <span class="op">^</span> node2</span></code></pre></div>
+<p>adds <code>node2</code> as a child of <code>node1</code> and returns
+<code>node1</code>. The resulting scene graph looks like this:</p>
+<p><img src="graphs/scene4.png" /></p>
 <p>The expression:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">node1 <span class="ot">^</span> <span class="ot">{</span> node2<span class="ot">,</span> node3 <span class="ot">}</span></code></pre></div>
-<p>adds both <code>node2</code> and <code>node3</code> as children of <code>node1</code> and returns <code>node1</code>:</p>
-<div class="figure">
-<img src="graphs/scene5.png" />
-
-</div>
+<div class="sourceCode" id="cb80"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb80-1"><a href="#cb80-1" aria-hidden="true" tabindex="-1"></a>node1 <span class="op">^</span> <span class="op">{</span> node2<span class="op">,</span> node3 <span class="op">}</span></span></code></pre></div>
+<p>adds both <code>node2</code> and <code>node3</code> as children of
+<code>node1</code> and returns <code>node1</code>:</p>
+<p><img src="graphs/scene5.png" /></p>
 <p>The expression:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">node1 <span class="ot">^</span> <span class="ot">{</span> node2<span class="ot">,</span> node3 <span class="ot">}</span> <span class="ot">^</span> node4</code></pre></div>
-<p>does the same as the previous expression, except <code>node4</code> is added as a child of both <code>node2</code> and <code>node3</code>:</p>
-<div class="figure">
-<img src="graphs/scene6.png" />
-
-</div>
-<p>If <code>node2</code> or <code>node3</code> were graphs with multiple nodes, then <code>node4</code> would be added to the leaf nodes of those graphs.</p>
+<div class="sourceCode" id="cb81"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb81-1"><a href="#cb81-1" aria-hidden="true" tabindex="-1"></a>node1 <span class="op">^</span> <span class="op">{</span> node2<span class="op">,</span> node3 <span class="op">}</span> <span class="op">^</span> node4</span></code></pre></div>
+<p>does the same as the previous expression, except <code>node4</code>
+is added as a child of both <code>node2</code> and
+<code>node3</code>:</p>
+<p><img src="graphs/scene6.png" /></p>
+<p>If <code>node2</code> or <code>node3</code> were graphs with multiple
+nodes, then <code>node4</code> would be added to the leaf nodes of those
+graphs.</p>
 <p>Here is a more complex example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">node1 
-    <span class="ot">^</span> node2
-    <span class="ot">^</span> <span class="ot">{</span>
-        node3
-        <span class="ot">^</span> node4
-        <span class="ot">,</span>
-        node5
-        <span class="ot">^</span> <span class="ot">{</span>node6<span class="ot">,</span> node7<span class="ot">,</span> node8<span class="ot">}</span>
-    <span class="ot">}</span>
-    <span class="ot">^</span> node9
-    <span class="ot">^</span> node10</code></pre></div>
+<div class="sourceCode" id="cb82"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb82-1"><a href="#cb82-1" aria-hidden="true" tabindex="-1"></a>node1 </span>
+<span id="cb82-2"><a href="#cb82-2" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> node2</span>
+<span id="cb82-3"><a href="#cb82-3" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> <span class="op">{</span></span>
+<span id="cb82-4"><a href="#cb82-4" aria-hidden="true" tabindex="-1"></a>        node3</span>
+<span id="cb82-5"><a href="#cb82-5" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> node4</span>
+<span id="cb82-6"><a href="#cb82-6" aria-hidden="true" tabindex="-1"></a>        <span class="op">,</span></span>
+<span id="cb82-7"><a href="#cb82-7" aria-hidden="true" tabindex="-1"></a>        node5</span>
+<span id="cb82-8"><a href="#cb82-8" aria-hidden="true" tabindex="-1"></a>        <span class="op">^</span> <span class="op">{</span>node6<span class="op">,</span> node7<span class="op">,</span> node8<span class="op">}</span></span>
+<span id="cb82-9"><a href="#cb82-9" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb82-10"><a href="#cb82-10" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> node9</span>
+<span id="cb82-11"><a href="#cb82-11" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> node10</span></code></pre></div>
 <p>The above expression results in the following graph:</p>
-<div class="figure">
-<img src="graphs/scene7.png" />
-
-</div>
-<h2 id="scene-node-common-fields-and-methods">Scene node common fields and methods</h2>
+<p><img src="graphs/scene7.png" /></p>
+<h2 id="scene-node-common-fields-and-methods">Scene node common fields
+and methods</h2>
 <p>The following fields and methods are common to all scene nodes.</p>
-<h3 id="node.hidden" class="func-def">node.hidden</h3>
-<p>Determines whether the node and its children are rendered. The default is <code>false</code>, meaning that the node is rendered.</p>
+<h3 class="func-def" id="node.hidden">node.hidden</h3>
+<p>Determines whether the node and its children are rendered. The
+default is <code>false</code>, meaning that the node is rendered.</p>
 <p>Updatable.</p>
-<h3 id="node.paused" class="func-def">node.paused</h3>
-<p>Determines whether the node and its children's <a href="#node:action">actions</a> are executed. The default is <code>false</code>, meaning the actions are executed.</p>
-<p>Note that a descendant node's actions might still be executed if it is has another, non-paused, parent.</p>
+<h3 class="func-def" id="node.paused">node.paused</h3>
+<p>Determines whether the node and its children’s <a
+href="#node:action">actions</a> are executed. The default is
+<code>false</code>, meaning the actions are executed.</p>
+<p>Note that a descendant node’s actions might still be executed if it
+is has another, non-paused, parent.</p>
 <p>Updatable.</p>
-<h3 id="node.num_children" class="func-def">node.num_children</h3>
-<p>Returns the node's child count.</p>
+<h3 class="func-def" id="node.num_children">node.num_children</h3>
+<p>Returns the node’s child count.</p>
 <p>Readonly.</p>
-<h3 id="node.recursion_limit" class="func-def">node.recursion_limit</h3>
-<p>This determines the number of times the node will be rendered recursively when part of a cycle in the scene graph. The default is 8.</p>
+<h3 class="func-def" id="node.recursion_limit">node.recursion_limit</h3>
+<p>This determines the number of times the node will be rendered
+recursively when part of a cycle in the scene graph. The default is
+8.</p>
 <p>Updatable.</p>
-<h3 id="node:tag" class="method-def">node:tag(tagname)</h3>
-<p>Adds a tag to a node and returns the node. <code>tagname</code> should be a string.</p>
-<p>Note that most scene nodes receive a default tag name when they are created. See the documentation of the different nodes below for what these default tags are.</p>
-<p>No more than 65535 unique tag names may be created in a single application.</p>
-<h3 id="node:untag" class="method-def">node:untag(tagname)</h3>
+<h3 class="method-def" id="node:tag">node:tag(tagname)</h3>
+<p>Adds a tag to a node and returns the node. <code>tagname</code>
+should be a string.</p>
+<p>Note that most scene nodes receive a default tag name when they are
+created. See the documentation of the different nodes below for what
+these default tags are.</p>
+<p>No more than 65535 unique tag names may be created in a single
+application.</p>
+<h3 class="method-def" id="node:untag">node:untag(tagname)</h3>
 <p>Removes a tag from a node and returns the node.</p>
-<h3 id="node:all" class="method-def">node:all(tagname [, recurse])</h3>
-<p>Searches <code>node</code> and all its descendants for any nodes with the tag <code>tagname</code> and returns them as a table.</p>
-<p>The <code>recurse</code> boolean argument determines if <code>all</code> recursively searches the descendents of matched nodes. The default value is <code>false</code>.</p>
-<p>The returned table has a metatable that allows setting a field on all nodes by setting the corresponding field on the table. So for example to set the color of all sprite nodes that are descendents of a parent node, one might do the following:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">parent_node:all<span class="st">&quot;sprite&quot;</span><span class="ot">.</span>color <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)</span></code></pre></div>
-<h3 id="node:tagsearch" class="method-def">node(tagname)</h3>
-<p>Searches <code>node</code> and its descendants for <code>tagname</code> and returns the first matching node found, or <code>nil</code> if no matching nodes were found. The search is depth-first left-to-right.</p>
-<p>The found node's parent is also returned as a second value, unless the found node was the root of the given subgraph.</p>
-<h3 id="node:action" class="method-def">node:action([id,] action)</h3>
+<h3 class="method-def" id="node:all">node:all(tagname [, recurse])</h3>
+<p>Searches <code>node</code> and all its descendants for any nodes with
+the tag <code>tagname</code> and returns them as a table.</p>
+<p>The <code>recurse</code> boolean argument determines if
+<code>all</code> recursively searches the descendents of matched nodes.
+The default value is <code>false</code>.</p>
+<p>The returned table has a metatable that allows setting a field on all
+nodes by setting the corresponding field on the table. So for example to
+set the color of all sprite nodes that are descendents of a parent node,
+one might do the following:</p>
+<div class="sourceCode" id="cb83"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb83-1"><a href="#cb83-1" aria-hidden="true" tabindex="-1"></a>parent_node<span class="op">:</span>all<span class="st">&quot;sprite&quot;</span><span class="op">.</span>color <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">)</span></span></code></pre></div>
+<h3 class="method-def" id="node:tagsearch">node(tagname)</h3>
+<p>Searches <code>node</code> and its descendants for
+<code>tagname</code> and returns the first matching node found, or
+<code>nil</code> if no matching nodes were found. The search is
+depth-first left-to-right.</p>
+<p>The found node’s parent is also returned as a second value, unless
+the found node was the root of the given subgraph.</p>
+<h3 class="method-def" id="node:action">node:action([id,] action)</h3>
 <p>Attaches an action to a node and returns the node.</p>
 <p><code>action</code> may be a function or a coroutine.</p>
-<p>The action function will be called exactly once per frame as long as the node is part of a scene graph that is attached to a window. If a coroutine is used, it will be run until it yields or finishes. The action will be run for the first time on the frame after it was attached to the node.</p>
-<p>The action function may accept a single argument which is the node to which it is attached. If a coroutine is used, then the node is returned by <code>coroutine.yield()</code>.</p>
-<p>If the action function returns <code>true</code> then the action will be removed from the node and not run again. Similarly if a coroutine yields <code>true</code> or finishes.</p>
-<p>Each action has an ID. If the <code>id</code> argument is omitted, then its ID is the <code>action</code> argument itself. If present, <code>id</code> may be a value of any type besides nil, a function or coroutine (typically it's a string).</p>
-<p>Multiple actions may be attached to a scene node, but they must all have unique ids. If you attempt to attach an action with an ID that is already used by another action on the same node, then the other action will be removed before the new one is attached.</p>
-<p>The order that actions are run is determined by the node's position in the scene graph. Each node is visited in depth-first, left-to-right order and the actions on each node are run in the order they were added to the node. Each action is never run more than once per frame, even if the node occurs multiple times in the graph or is part of a cycle. For example, given the following scene graph:</p>
-<div class="figure">
-<img src="graphs/scene8.png" />
-
-</div>
+<p>The action function will be called exactly once per frame as long as
+the node is part of a scene graph that is attached to a window. If a
+coroutine is used, it will be run until it yields or finishes. The
+action will be run for the first time on the frame after it was attached
+to the node.</p>
+<p>The action function may accept a single argument which is the node to
+which it is attached. If a coroutine is used, then the node is returned
+by <code>coroutine.yield()</code>.</p>
+<p>If the action function returns <code>true</code> then the action will
+be removed from the node and not run again. Similarly if a coroutine
+yields <code>true</code> or finishes.</p>
+<p>Each action has an ID. If the <code>id</code> argument is omitted,
+then its ID is the <code>action</code> argument itself. If present,
+<code>id</code> may be a value of any type besides nil, a function or
+coroutine (typically it’s a string).</p>
+<p>Multiple actions may be attached to a scene node, but they must all
+have unique ids. If you attempt to attach an action with an ID that is
+already used by another action on the same node, then the other action
+will be removed before the new one is attached.</p>
+<p>The order that actions are run is determined by the node’s position
+in the scene graph. Each node is visited in depth-first, left-to-right
+order and the actions on each node are run in the order they were added
+to the node. Each action is never run more than once per frame, even if
+the node occurs multiple times in the graph or is part of a cycle. For
+example, given the following scene graph:</p>
+<p><img src="graphs/scene8.png" /></p>
 <p>The nodes will be visited in this order:</p>
 <ul>
 <li><code>node1</code></li>
@@ -1990,103 +3077,160 @@ arr<span class="ot">.</span>color:set<span class="ot">(</span>vec4<span class="o
 <li><code>node6</code></li>
 <li><code>node3</code></li>
 </ul>
-<p>Note that the action execution order is determined before the first action runs each frame and is not affected by any modifications to the scene graph made by actions running during the frame. Any modifications to the scene graph will only affect the order of actions in subsequent frames.</p>
-<h3 id="node:late_action" class="method-def">node:late_action([id,] action)</h3>
-<p>Attach a <em>late action</em> to a scene node. Late actions are the same as normal actions, except they are run after all normal actions are finished.</p>
+<p>Note that the action execution order is determined before the first
+action runs each frame and is not affected by any modifications to the
+scene graph made by actions running during the frame. Any modifications
+to the scene graph will only affect the order of actions in subsequent
+frames.</p>
+<h3 class="method-def" id="node:late_action">node:late_action([id,]
+action)</h3>
+<p>Attach a <em>late action</em> to a scene node. Late actions are the
+same as normal actions, except they are run after all normal actions are
+finished.</p>
 <p>See also <a href="#node:action">node:action</a>.</p>
-<h3 id="node:cancel" class="method-def">node:cancel(id)</h3>
+<h3 class="method-def" id="node:cancel">node:cancel(id)</h3>
 <p>Cancels an action.</p>
-<h3 id="node:update" class="method-def">node:update()</h3>
-<p>Executes actions on a node and its descendants. Actions are still only run once per frame, so if the give node's actions have already been run, they won't run again.</p>
-<p>Use this method to execute actions on nodes that are not attached to the window, for example nodes that are being manually rendered into a framebuffer.</p>
-<h3 id="nodeappendchild" class="func-def">node:append(child)</h3>
-<p>Appends <code>child</code> to the end of <code>node</code>'s child list and returns <code>node</code>.</p>
-<h3 id="nodeprependchild" class="func-def">node:prepend(child)</h3>
-<p>Adds <code>child</code> to the start of <code>node</code>'s child list and returns <code>node</code>.</p>
-<h3 id="noderemovechild" class="func-def">node:remove(child)</h3>
-<p>Removes the first occurrence of <code>child</code> from <code>node</code>'s child list and returns <code>node</code>.</p>
-<h3 id="noderemovetagname" class="func-def">node:remove(tagname)</h3>
-<p>Searches for a node with tag <code>tagname</code> in the descendants of <code>node</code> and removes the first one it finds. Then returns <code>node</code>.</p>
-<h3 id="noderemove_all" class="func-def">node:remove_all()</h3>
-<p>Removes all of <code>node</code>'s children and returns <code>node</code>.</p>
-<h3 id="nodereplacechild-replacement" class="func-def">node:replace(child, replacement)</h3>
-<p>Replaces the first occurrence of <code>child</code> with <code>replacement</code> in <code>node</code>'s child list and returns <code>node</code>.</p>
-<h3 id="nodereplacetagname-replacement" class="func-def">node:replace(tagname, replacement)</h3>
-<p>Searches for a node with tag <code>tagname</code> in the descendants of <code>node</code> and replaces the first one it finds with <code>replacement</code>. Then returns <code>node</code>.</p>
-<h3 id="nodechildn" class="func-def">node:child(n)</h3>
-<p>Returns the nth child of <code>node</code> (or <code>nil</code> if there is no such child).</p>
-<h3 id="nodechild_pairs" class="func-def">node:child_pairs()</h3>
-<p>Returns an iterator over all <code>node</code>'s children. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">for</span> i<span class="ot">,</span> child <span class="kw">in</span> node:child_pairs<span class="ot">()</span> <span class="kw">do</span>
-    <span class="do">-- do something with child</span>
-<span class="kw">end</span></code></pre></div>
+<h3 class="method-def" id="node:update">node:update()</h3>
+<p>Executes actions on a node and its descendants. Actions are still
+only run once per frame, so if the give node’s actions have already been
+run, they won’t run again.</p>
+<p>Use this method to execute actions on nodes that are not attached to
+the window, for example nodes that are being manually rendered into a
+framebuffer.</p>
+<h3 class="func-def" id="nodeappendchild">node:append(child)</h3>
+<p>Appends <code>child</code> to the end of <code>node</code>’s child
+list and returns <code>node</code>.</p>
+<h3 class="func-def" id="nodeprependchild">node:prepend(child)</h3>
+<p>Adds <code>child</code> to the start of <code>node</code>’s child
+list and returns <code>node</code>.</p>
+<h3 class="func-def" id="noderemovechild">node:remove(child)</h3>
+<p>Removes the first occurrence of <code>child</code> from
+<code>node</code>’s child list and returns <code>node</code>.</p>
+<h3 class="func-def" id="noderemovetagname">node:remove(tagname)</h3>
+<p>Searches for a node with tag <code>tagname</code> in the descendants
+of <code>node</code> and removes the first one it finds. Then returns
+<code>node</code>.</p>
+<h3 class="func-def" id="noderemove_all">node:remove_all()</h3>
+<p>Removes all of <code>node</code>’s children and returns
+<code>node</code>.</p>
+<h3 class="func-def"
+id="nodereplacechild-replacement">node:replace(child, replacement)</h3>
+<p>Replaces the first occurrence of <code>child</code> with
+<code>replacement</code> in <code>node</code>’s child list and returns
+<code>node</code>.</p>
+<h3 class="func-def"
+id="nodereplacetagname-replacement">node:replace(tagname,
+replacement)</h3>
+<p>Searches for a node with tag <code>tagname</code> in the descendants
+of <code>node</code> and replaces the first one it finds with
+<code>replacement</code>. Then returns <code>node</code>.</p>
+<h3 class="func-def" id="nodechildn">node:child(n)</h3>
+<p>Returns the nth child of <code>node</code> (or <code>nil</code> if
+there is no such child).</p>
+<h3 class="func-def" id="nodechild_pairs">node:child_pairs()</h3>
+<p>Returns an iterator over all <code>node</code>’s children. For
+example:</p>
+<div class="sourceCode" id="cb84"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb84-1"><a href="#cb84-1" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> i<span class="op">,</span> child <span class="kw">in</span> node<span class="op">:</span>child_pairs<span class="op">()</span> <span class="cf">do</span></span>
+<span id="cb84-2"><a href="#cb84-2" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- do something with child</span></span>
+<span id="cb84-3"><a href="#cb84-3" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span></span></code></pre></div>
 <h2 id="basic-nodes">Basic nodes</h2>
-<h3 id="am.groupchildren" class="func-def">am.group(children)</h3>
-<p>Group nodes are only for grouping child nodes under a common parent. They have no other effect. The children can be passed in as a table.</p>
-<p>Default tag: <code>&quot;group&quot;</code>.</p>
+<h3 class="func-def" id="am.groupchildren">am.group(children)</h3>
+<p>Group nodes are only for grouping child nodes under a common parent.
+They have no other effect. The children can be passed in as a table.</p>
+<p>Default tag: <code>"group"</code>.</p>
 <p>Example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> group_node <span class="ot">=</span> am<span class="ot">.</span>group<span class="ot">{</span>node1<span class="ot">,</span> node2<span class="ot">,</span> node3<span class="ot">}</span></code></pre></div>
-<h3 id="am.text" class="func-def">am.text([font, ] string [, color] [, halign [, valign]])</h3>
+<div class="sourceCode" id="cb85"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb85-1"><a href="#cb85-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> group_node <span class="op">=</span> am<span class="op">.</span>group<span class="op">{</span>node1<span class="op">,</span> node2<span class="op">,</span> node3<span class="op">}</span></span></code></pre></div>
+<h3 class="func-def" id="am.text">am.text([font, ] string [, color] [,
+halign [, valign]])</h3>
 <p>Renders some text.</p>
-<p><code>font</code> is an object generated using the <a href="#spritepack">sprite packing tool</a>. If omitted, the default font will be used, which is a monospace font of size 16px.</p>
-<p><code>color</code> should be a <code>vec4</code>. The default color is white.</p>
-<p><code>halign</code> and <code>valign</code> specify horizontal and vertical alignment. The allowed values for <code>halign</code> are <code>&quot;left&quot;</code>, <code>&quot;right&quot;</code> and <code>&quot;center&quot;</code>. The allowed values for <code>valign</code> are <code>&quot;bottom&quot;</code>, <code>&quot;top&quot;</code> and <code>&quot;center&quot;</code>. The default in both cases is <code>&quot;center&quot;</code>.</p>
+<p><code>font</code> is an object generated using the <a
+href="#spritepack">sprite packing tool</a>. If omitted, the default font
+will be used, which is a monospace font of size 16px.</p>
+<p><code>color</code> should be a <code>vec4</code>. The default color
+is white.</p>
+<p><code>halign</code> and <code>valign</code> specify horizontal and
+vertical alignment. The allowed values for <code>halign</code> are
+<code>"left"</code>, <code>"right"</code> and <code>"center"</code>. The
+allowed values for <code>valign</code> are <code>"bottom"</code>,
+<code>"top"</code> and <code>"center"</code>. The default in both cases
+is <code>"center"</code>.</p>
 <p>Fields:</p>
 <ul>
 <li><code>text</code>: The text to display. Updatable.</li>
 <li><code>color</code>: The color of the text. Updatable.</li>
-<li><code>width</code>: The width of the displayed text in pixels. Readonly.</li>
-<li><code>height</code>: The height of the displayed text in pixels. Readonly.</li>
+<li><code>width</code>: The width of the displayed text in pixels.
+Readonly.</li>
+<li><code>height</code>: The height of the displayed text in pixels.
+Readonly.</li>
 </ul>
-<p>Default tag: <code>&quot;text&quot;</code>.</p>
-<h3 id="am.sprite" class="func-def">am.sprite(source [, color] [, halign [, valign]])</h3>
+<p>Default tag: <code>"text"</code>.</p>
+<h3 class="func-def" id="am.sprite">am.sprite(source [, color] [, halign
+[, valign]])</h3>
 <p>Renders a sprite (an image).</p>
-<p><code>source</code> can be either a filename, an ASCII art string or a <em>sprite spec</em>.</p>
-<p>When <code>source</code> is a filename, that file is loaded and displayed as the sprite. Currently only <code>.png</code> and <code>.jpg</code> files are supported. Note that loaded files are cached, so each file will only be loaded once.</p>
-<p><code>source</code> may also be an ASCII art string. This is a string with at least one newline character. Each row in the string represents a row of pixels. Here's an example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> face <span class="ot">=</span> <span class="st">[[</span>
-<span class="st">..YYYYY..</span>
-<span class="st">.Y.....Y.</span>
-<span class="st">Y..B.B..Y</span>
-<span class="st">Y.......Y</span>
-<span class="st">Y.R...R.Y</span>
-<span class="st">Y..RRR..Y</span>
-<span class="st">.Y.....Y.</span>
-<span class="st">..YYYYY..</span>
-<span class="st">]]</span>
-am<span class="ot">.</span>window<span class="ot">{}.</span>scene <span class="ot">=</span> am<span class="ot">.</span>scale<span class="ot">(</span><span class="dv">20</span><span class="ot">)</span> <span class="ot">^</span> am<span class="ot">.</span>sprite<span class="ot">(</span>face<span class="ot">)</span></code></pre></div>
+<p><code>source</code> can be either a filename, an ASCII art string or
+a <em>sprite spec</em>.</p>
+<p>When <code>source</code> is a filename, that file is loaded and
+displayed as the sprite. Currently only <code>.png</code> and
+<code>.jpg</code> files are supported. Note that loaded files are
+cached, so each file will only be loaded once.</p>
+<p><code>source</code> may also be an ASCII art string. This is a string
+with at least one newline character. Each row in the string represents a
+row of pixels. Here’s an example:</p>
+<div class="sourceCode" id="cb86"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb86-1"><a href="#cb86-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> face <span class="op">=</span> <span class="vs">[[</span></span>
+<span id="cb86-2"><a href="#cb86-2" aria-hidden="true" tabindex="-1"></a><span class="vs">..YYYYY..</span></span>
+<span id="cb86-3"><a href="#cb86-3" aria-hidden="true" tabindex="-1"></a><span class="vs">.Y.....Y.</span></span>
+<span id="cb86-4"><a href="#cb86-4" aria-hidden="true" tabindex="-1"></a><span class="vs">Y..B.B..Y</span></span>
+<span id="cb86-5"><a href="#cb86-5" aria-hidden="true" tabindex="-1"></a><span class="vs">Y.......Y</span></span>
+<span id="cb86-6"><a href="#cb86-6" aria-hidden="true" tabindex="-1"></a><span class="vs">Y.R...R.Y</span></span>
+<span id="cb86-7"><a href="#cb86-7" aria-hidden="true" tabindex="-1"></a><span class="vs">Y..RRR..Y</span></span>
+<span id="cb86-8"><a href="#cb86-8" aria-hidden="true" tabindex="-1"></a><span class="vs">.Y.....Y.</span></span>
+<span id="cb86-9"><a href="#cb86-9" aria-hidden="true" tabindex="-1"></a><span class="vs">..YYYYY..</span></span>
+<span id="cb86-10"><a href="#cb86-10" aria-hidden="true" tabindex="-1"></a><span class="vs">]]</span></span>
+<span id="cb86-11"><a href="#cb86-11" aria-hidden="true" tabindex="-1"></a>am<span class="op">.</span>window<span class="op">{}.</span>scene <span class="op">=</span> am<span class="op">.</span>scale<span class="op">(</span><span class="dv">20</span><span class="op">)</span> <span class="op">^</span> am<span class="op">.</span>sprite<span class="op">(</span>face<span class="op">)</span></span></code></pre></div>
 <p>The resulting image looks like this:</p>
-<div class="figure">
+<figure>
 <img src="images/face.png" alt="face" />
-<p class="caption">face</p>
-</div>
-<p>The mapping from characters to colors is determined by the <code>am.ascii_color_map</code> table. By default this is defined as:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">am<span class="ot">.</span>ascii_color_map <span class="ot">=</span> <span class="ot">{</span>
-    W <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>          <span class="do">-- full white</span>
-    w <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0.75</span><span class="ot">,</span> <span class="dv">0.75</span><span class="ot">,</span> <span class="dv">0.75</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span> <span class="do">-- silver</span>
-    K <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>          <span class="do">-- full black</span>
-    k <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0.5</span><span class="ot">,</span> <span class="dv">0.5</span><span class="ot">,</span> <span class="dv">0.5</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>    <span class="do">-- dark grey</span>
-    R <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>          <span class="do">-- full red</span>
-    r <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0.5</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>        <span class="do">-- half red (maroon)</span>
-    Y <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>          <span class="do">-- full yellow</span>
-    y <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0.5</span><span class="ot">,</span> <span class="dv">0.5</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>      <span class="do">-- half yellow (olive)</span>
-    G <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>          <span class="do">-- full green</span>
-    g <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0.5</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>        <span class="do">-- half green</span>
-    C <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>          <span class="do">-- full cyan</span>
-    c <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0.5</span><span class="ot">,</span> <span class="dv">0.5</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>      <span class="do">-- half cyan (teal)</span>
-    B <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>          <span class="do">-- full blue</span>
-    b <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0.5</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>        <span class="do">-- half blue (navy)</span>
-    M <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>          <span class="do">-- full magenta</span>
-    m <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0.5</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0.5</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>      <span class="do">-- half magenta</span>
-    O <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0.5</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>        <span class="do">-- full orange</span>
-    o <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0.5</span><span class="ot">,</span> <span class="dv">0.25</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>     <span class="do">-- half orange (brown)</span>
-<span class="ot">}</span></code></pre></div>
-<p>but you can modify it as you please (though this must be done before creating a sprite).</p>
-<p>Any characters not in the color map will come out as transparent pixels, except for space characters which are ignored.</p>
-<p>The third kind of source is a <em>sprite spec</em>. Sprite specs are usually generated using the <a href="#spritepack">sprite packing tool</a>, though you can create them manually as well if you like.</p>
-<p>You can define your own sprite spec by supplying a table with all of the following fields:</p>
+<figcaption aria-hidden="true">face</figcaption>
+</figure>
+<p>The mapping from characters to colors is determined by the
+<code>am.ascii_color_map</code> table. By default this is defined
+as:</p>
+<div class="sourceCode" id="cb87"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb87-1"><a href="#cb87-1" aria-hidden="true" tabindex="-1"></a>am<span class="op">.</span>ascii_color_map <span class="op">=</span> <span class="op">{</span></span>
+<span id="cb87-2"><a href="#cb87-2" aria-hidden="true" tabindex="-1"></a>    <span class="cn">W</span> <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>          <span class="co">-- full white</span></span>
+<span id="cb87-3"><a href="#cb87-3" aria-hidden="true" tabindex="-1"></a>    w <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0.75</span><span class="op">,</span> <span class="dv">0.75</span><span class="op">,</span> <span class="dv">0.75</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span> <span class="co">-- silver</span></span>
+<span id="cb87-4"><a href="#cb87-4" aria-hidden="true" tabindex="-1"></a>    <span class="cn">K</span> <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>          <span class="co">-- full black</span></span>
+<span id="cb87-5"><a href="#cb87-5" aria-hidden="true" tabindex="-1"></a>    k <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0.5</span><span class="op">,</span> <span class="dv">0.5</span><span class="op">,</span> <span class="dv">0.5</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>    <span class="co">-- dark grey</span></span>
+<span id="cb87-6"><a href="#cb87-6" aria-hidden="true" tabindex="-1"></a>    <span class="cn">R</span> <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>          <span class="co">-- full red</span></span>
+<span id="cb87-7"><a href="#cb87-7" aria-hidden="true" tabindex="-1"></a>    r <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0.5</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>        <span class="co">-- half red (maroon)</span></span>
+<span id="cb87-8"><a href="#cb87-8" aria-hidden="true" tabindex="-1"></a>    <span class="cn">Y</span> <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>          <span class="co">-- full yellow</span></span>
+<span id="cb87-9"><a href="#cb87-9" aria-hidden="true" tabindex="-1"></a>    y <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0.5</span><span class="op">,</span> <span class="dv">0.5</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>      <span class="co">-- half yellow (olive)</span></span>
+<span id="cb87-10"><a href="#cb87-10" aria-hidden="true" tabindex="-1"></a>    <span class="cn">G</span> <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>          <span class="co">-- full green</span></span>
+<span id="cb87-11"><a href="#cb87-11" aria-hidden="true" tabindex="-1"></a>    g <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0.5</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>        <span class="co">-- half green</span></span>
+<span id="cb87-12"><a href="#cb87-12" aria-hidden="true" tabindex="-1"></a>    <span class="cn">C</span> <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>          <span class="co">-- full cyan</span></span>
+<span id="cb87-13"><a href="#cb87-13" aria-hidden="true" tabindex="-1"></a>    c <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0.5</span><span class="op">,</span> <span class="dv">0.5</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>      <span class="co">-- half cyan (teal)</span></span>
+<span id="cb87-14"><a href="#cb87-14" aria-hidden="true" tabindex="-1"></a>    <span class="cn">B</span> <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>          <span class="co">-- full blue</span></span>
+<span id="cb87-15"><a href="#cb87-15" aria-hidden="true" tabindex="-1"></a>    b <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0.5</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>        <span class="co">-- half blue (navy)</span></span>
+<span id="cb87-16"><a href="#cb87-16" aria-hidden="true" tabindex="-1"></a>    <span class="cn">M</span> <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>          <span class="co">-- full magenta</span></span>
+<span id="cb87-17"><a href="#cb87-17" aria-hidden="true" tabindex="-1"></a>    m <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0.5</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0.5</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>      <span class="co">-- half magenta</span></span>
+<span id="cb87-18"><a href="#cb87-18" aria-hidden="true" tabindex="-1"></a>    <span class="cn">O</span> <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0.5</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>        <span class="co">-- full orange</span></span>
+<span id="cb87-19"><a href="#cb87-19" aria-hidden="true" tabindex="-1"></a>    o <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0.5</span><span class="op">,</span> <span class="dv">0.25</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span>     <span class="co">-- half orange (brown)</span></span>
+<span id="cb87-20"><a href="#cb87-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>but you can modify it as you please (though this must be done before
+creating a sprite).</p>
+<p>Any characters not in the color map will come out as transparent
+pixels, except for space characters which are ignored.</p>
+<p>The third kind of source is a <em>sprite spec</em>. Sprite specs are
+usually generated using the <a href="#spritepack">sprite packing
+tool</a>, though you can create them manually as well if you like.</p>
+<p>You can define your own sprite spec by supplying a table with all of
+the following fields:</p>
 <ul>
-<li><code>texture</code>: the <a href="#am.texture2d">texture</a> containing the sprite.</li>
+<li><code>texture</code>: the <a href="#am.texture2d">texture</a>
+containing the sprite.</li>
 <li><code>s1</code>: the left texture coordinate (0 to 1)</li>
 <li><code>t1</code>: the bottom texture coordinate (0 to 1)</li>
 <li><code>s2</code>: the right texture coordinate (0 to 1)</li>
@@ -2098,47 +3242,79 @@ am<span class="ot">.</span>window<span class="ot">{}.</span>scene <span class="o
 <li><code>width</code>: the width of the sprite (in pixels)</li>
 <li><code>height</code>: the height of the sprite (in pixels)</li>
 </ul>
-<p>Typically <code>x1</code> and <code>y1</code> would both be zero and <code>x2</code> and <code>y2</code> would be equal to <code>width</code> and <code>height</code>, though they may be different when transparents pixels are removed from the edges of sprites when packing them. The <code>width</code> and <code>height</code> fields are used for adjusting sprite position based on the requested alignment.</p>
-<p>The <code>color</code> argument is a <code>vec4</code> that applies a tinting color to the sprite. The default is white (no tinting).</p>
-<p>The <code>halign</code> and <code>valign</code> arguments determine the alignment of the sprite. The allowed values for <code>halign</code> are <code>&quot;left&quot;</code>, <code>&quot;right&quot;</code> and <code>&quot;center&quot;</code>. The allowed values for <code>valign</code> are <code>&quot;bottom&quot;</code>, <code>&quot;top&quot;</code> and <code>&quot;center&quot;</code>. The default in both cases is <code>&quot;center&quot;</code>.</p>
+<p>Typically <code>x1</code> and <code>y1</code> would both be zero and
+<code>x2</code> and <code>y2</code> would be equal to <code>width</code>
+and <code>height</code>, though they may be different when transparents
+pixels are removed from the edges of sprites when packing them. The
+<code>width</code> and <code>height</code> fields are used for adjusting
+sprite position based on the requested alignment.</p>
+<p>The <code>color</code> argument is a <code>vec4</code> that applies a
+tinting color to the sprite. The default is white (no tinting).</p>
+<p>The <code>halign</code> and <code>valign</code> arguments determine
+the alignment of the sprite. The allowed values for <code>halign</code>
+are <code>"left"</code>, <code>"right"</code> and <code>"center"</code>.
+The allowed values for <code>valign</code> are <code>"bottom"</code>,
+<code>"top"</code> and <code>"center"</code>. The default in both cases
+is <code>"center"</code>.</p>
 <p>Fields:</p>
 <ul>
-<li><code>source</code>: The sprite source (filename, ascii art string or sprite spec). Updatable.</li>
-<li><code>color</code>: The sprite tint color as a <code>vec4</code>. Updatable.</li>
+<li><code>source</code>: The sprite source (filename, ascii art string
+or sprite spec). Updatable.</li>
+<li><code>color</code>: The sprite tint color as a <code>vec4</code>.
+Updatable.</li>
 <li><code>width</code>: The width of the sprite in pixels.</li>
 <li><code>height</code>: The height of the sprite in pixels.</li>
-<li><code>spec</code>: The sprite spec table, from which you can retrieve the texture, texture coordinates and vertices. This is available even if the sprite wasn't created with a sprite spec. Readonly.</li>
+<li><code>spec</code>: The sprite spec table, from which you can
+retrieve the texture, texture coordinates and vertices. This is
+available even if the sprite wasn’t created with a sprite spec.
+Readonly.</li>
 </ul>
-<p>Default tag: <code>&quot;sprite&quot;</code>.</p>
-<h3 id="am.rect" class="func-def">am.rect(x1, y1, x2, y2 [, color])</h3>
-<p>Draws a rectangle from (<code>x1</code>, <code>y1</code>) to (<code>x2</code>, <code>y2</code>).</p>
-<p><code>color</code> should be a <code>vec4</code> and defaults to white.</p>
+<p>Default tag: <code>"sprite"</code>.</p>
+<h3 class="func-def" id="am.rect">am.rect(x1, y1, x2, y2 [, color])</h3>
+<p>Draws a rectangle from (<code>x1</code>, <code>y1</code>) to
+(<code>x2</code>, <code>y2</code>).</p>
+<p><code>color</code> should be a <code>vec4</code> and defaults to
+white.</p>
 <p>Fields:</p>
 <ul>
-<li><code>x1</code>: The left coordinate of the rectangle. Updatable.</li>
-<li><code>y1</code>: The bottom coordinate of the rectangle. Updatable.</li>
-<li><code>x2</code>: The right coordinate of the rectangle. Updatable.</li>
-<li><code>y2</code>: The top coordinate of the rectangle. Updatable.</li>
-<li><code>color</code>: The color of the rectangle as a <code>vec4</code>. Updatable.</li>
+<li><code>x1</code>: The left coordinate of the rectangle.
+Updatable.</li>
+<li><code>y1</code>: The bottom coordinate of the rectangle.
+Updatable.</li>
+<li><code>x2</code>: The right coordinate of the rectangle.
+Updatable.</li>
+<li><code>y2</code>: The top coordinate of the rectangle.
+Updatable.</li>
+<li><code>color</code>: The color of the rectangle as a
+<code>vec4</code>. Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;rect&quot;</code>.</p>
-<h3 id="am.circle" class="func-def">am.circle(center, radius [, color [, sides]])</h3>
+<p>Default tag: <code>"rect"</code>.</p>
+<h3 class="func-def" id="am.circle">am.circle(center, radius [, color [,
+sides]])</h3>
 <p>Draws a circle or regular polygon.</p>
 <p><code>center</code> should be a <code>vec2</code>.</p>
-<p><code>color</code> should be a <code>vec4</code>. The default is white.</p>
-<p><code>sides</code> is the number of sides to use when rendering the circle. The default is 255. You can change this to make other regular polygons. For example change it to 6 to draw a hexagon.</p>
+<p><code>color</code> should be a <code>vec4</code>. The default is
+white.</p>
+<p><code>sides</code> is the number of sides to use when rendering the
+circle. The default is 255. You can change this to make other regular
+polygons. For example change it to 6 to draw a hexagon.</p>
 <p>Fields:</p>
 <ul>
-<li><code>center</code>: The circle center as a <code>vec2</code>. Updatable.</li>
+<li><code>center</code>: The circle center as a <code>vec2</code>.
+Updatable.</li>
 <li><code>radius</code>: The circle radius. Updatable.</li>
-<li><code>color</code>: The circle color as a <code>vec4</code>. Updatable.</li>
+<li><code>color</code>: The circle color as a <code>vec4</code>.
+Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;circle&quot;</code>.</p>
-<h3 id="am.line" class="func-def">am.line(point1, point2 [, thickness [, color]])</h3>
+<p>Default tag: <code>"circle"</code>.</p>
+<h3 class="func-def" id="am.line">am.line(point1, point2 [, thickness [,
+color]])</h3>
 <p>Draws a line from <code>point1</code> to <code>point2</code>.</p>
-<p><code>point1</code> and <code>point1</code> should be <code>vec2</code>s.</p>
+<p><code>point1</code> and <code>point1</code> should be
+<code>vec2</code>s.</p>
 <p><code>thickness</code> should be a number. The default is 1.</p>
-<p><code>color</code> should be a <code>vec4</code>. The default is white.</p>
+<p><code>color</code> should be a <code>vec4</code>. The default is
+white.</p>
 <p>Fields:</p>
 <ul>
 <li><code>point1</code>: Updatable.</li>
@@ -2146,238 +3322,331 @@ am<span class="ot">.</span>window<span class="ot">{}.</span>scene <span class="o
 <li><code>thickness</code>: Updatable.</li>
 <li><code>color</code>: Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;line&quot;</code>.</p>
-<h3 id="am.particles2d" class="func-def">am.particles2d(settings)</h3>
+<p>Default tag: <code>"line"</code>.</p>
+<h3 class="func-def" id="am.particles2d">am.particles2d(settings)</h3>
 <p>Renders a simple 2D particle system.</p>
-<p><code>settings</code> should be a table with any of the following fields:</p>
+<p><code>settings</code> should be a table with any of the following
+fields:</p>
 <ul>
-<li><code>source_pos</code>: The position where the particles emit from (<code>vec2</code>)</li>
-<li><code>source_pos_var</code>: The source position variation (<code>vec2</code>)</li>
-<li><code>start_size</code>: The start size of the particles (number)</li>
+<li><code>source_pos</code>: The position where the particles emit from
+(<code>vec2</code>)</li>
+<li><code>source_pos_var</code>: The source position variation
+(<code>vec2</code>)</li>
+<li><code>start_size</code>: The start size of the particles
+(number)</li>
 <li><code>start_size_var</code>: The start size variation (number)</li>
 <li><code>end_size</code>: The end size of the particles (number)</li>
 <li><code>end_size_var</code>: The end size variation (number)</li>
 <li><code>angle</code>: The angle the particles emit at (radians)</li>
-<li><code>angle_var</code>: The variation in the angle the particles emit at (radians)</li>
+<li><code>angle_var</code>: The variation in the angle the particles
+emit at (radians)</li>
 <li><code>speed</code>: The speed of the particles (number)</li>
-<li><code>speed_var</code>: The variation in the speed of the particles (number)</li>
+<li><code>speed_var</code>: The variation in the speed of the particles
+(number)</li>
 <li><code>life</code>: The lifetime of the particles (seconds)</li>
-<li><code>life_var</code>: The variation in lifetime of the particles (seconds)</li>
-<li><code>start_color</code>: The start color of the particles (<code>vec4</code>)</li>
-<li><code>start_color_var</code>: The variation in the start color of the particles (<code>vec4</code>)</li>
-<li><code>end_color</code>: The end color of the particles (<code>vec4</code>)</li>
-<li><code>end_color_var</code>: The variation in the end color of the particles (<code>vec4</code>)</li>
-<li><code>emission_rate</code>: The number of particles to emit per second</li>
+<li><code>life_var</code>: The variation in lifetime of the particles
+(seconds)</li>
+<li><code>start_color</code>: The start color of the particles
+(<code>vec4</code>)</li>
+<li><code>start_color_var</code>: The variation in the start color of
+the particles (<code>vec4</code>)</li>
+<li><code>end_color</code>: The end color of the particles
+(<code>vec4</code>)</li>
+<li><code>end_color_var</code>: The variation in the end color of the
+particles (<code>vec4</code>)</li>
+<li><code>emission_rate</code>: The number of particles to emit per
+second</li>
 <li><code>start_particles</code>: The initial number of particles</li>
 <li><code>max_particles</code>: The maximum number of particles</li>
-<li><code>gravity</code>: Gravity to apply to the particles (<code>vec2</code>)</li>
+<li><code>gravity</code>: Gravity to apply to the particles
+(<code>vec2</code>)</li>
 <li><code>damping</code>: Slows down particles if greater than zero</li>
-<li><code>sprite_source</code>: The particle sprite source (see <a href="#am.sprite">am.sprite</a>). If this is omitted the particles will be colored squares.</li>
-<li><code>warmup_time</code>: Simulate running the particle system for this number of seconds before showing it for the first time.</li>
+<li><code>sprite_source</code>: The particle sprite source (see <a
+href="#am.sprite">am.sprite</a>). If this is omitted the particles will
+be colored squares.</li>
+<li><code>warmup_time</code>: Simulate running the particle system for
+this number of seconds before showing it for the first time.</li>
 </ul>
-<p>In the table the <code>_var</code> fields are an amount that is added to and subtracted from the corresponding field (the one without the <code>_var</code> suffix) to get the range of values from which one is randomly chosen. For example if <code>source_pos</code> is <code>vec2(1, 0)</code> and <code>source_pos_var</code> is <code>vec2(3, 2)</code>, then source positions will be chosen in the range <code>vec2(-2, -2)</code> to <code>vec2(4, 2)</code>.</p>
-<p>All of the sprite settings are exposed as updatable fields on the particles node.</p>
-<p>Note that no blending is applied to the particles, so if you want alpha on your particles, then you need to add a <a href="#am.blend"><code>am.blend</code></a> node. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> node <span class="ot">=</span> am<span class="ot">.</span>blend<span class="ot">(</span><span class="st">&quot;add_alpha&quot;</span><span class="ot">)</span>
-    <span class="ot">^</span> am<span class="ot">.</span>particles2d<span class="ot">{</span>
-        source_pos <span class="ot">=</span> win:mouse_position<span class="ot">(),</span>
-        source_pos_var <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">20</span><span class="ot">),</span>
-        max_particles <span class="ot">=</span> <span class="dv">1000</span><span class="ot">,</span>
-        emission_rate <span class="ot">=</span> <span class="dv">500</span><span class="ot">,</span>
-        start_particles <span class="ot">=</span> <span class="dv">0</span><span class="ot">,</span>
-        life <span class="ot">=</span> <span class="dv">0.4</span><span class="ot">,</span>
-        life_var <span class="ot">=</span> <span class="dv">0.1</span><span class="ot">,</span>
-        angle <span class="ot">=</span> <span class="fu">math.rad</span><span class="ot">(</span><span class="dv">90</span><span class="ot">),</span>
-        angle_var <span class="ot">=</span> <span class="fu">math.rad</span><span class="ot">(</span><span class="dv">180</span><span class="ot">),</span>
-        speed <span class="ot">=</span> <span class="dv">200</span><span class="ot">,</span>
-        start_color <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0.3</span><span class="ot">,</span> <span class="dv">0.01</span><span class="ot">,</span> <span class="dv">0.5</span><span class="ot">),</span>
-        start_color_var <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0.1</span><span class="ot">,</span> <span class="dv">0.05</span><span class="ot">,</span> <span class="dv">0.0</span><span class="ot">,</span> <span class="dv">0.1</span><span class="ot">),</span>
-        end_color <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0.5</span><span class="ot">,</span> <span class="dv">0.8</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>
-        end_color_var <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0.1</span><span class="ot">),</span>
-        start_size <span class="ot">=</span> <span class="dv">30</span><span class="ot">,</span>
-        start_size_var <span class="ot">=</span> <span class="dv">10</span><span class="ot">,</span>
-        end_size <span class="ot">=</span> <span class="dv">2</span><span class="ot">,</span>
-        end_size_var <span class="ot">=</span> <span class="dv">2</span><span class="ot">,</span>
-        gravity <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">2000</span><span class="ot">),</span>
-    <span class="ot">}</span></code></pre></div>
+<p>In the table the <code>_var</code> fields are an amount that is added
+to and subtracted from the corresponding field (the one without the
+<code>_var</code> suffix) to get the range of values from which one is
+randomly chosen. For example if <code>source_pos</code> is
+<code>vec2(1, 0)</code> and <code>source_pos_var</code> is
+<code>vec2(3, 2)</code>, then source positions will be chosen in the
+range <code>vec2(-2, -2)</code> to <code>vec2(4, 2)</code>.</p>
+<p>All of the sprite settings are exposed as updatable fields on the
+particles node.</p>
+<p>Note that no blending is applied to the particles, so if you want
+alpha on your particles, then you need to add a <a
+href="#am.blend"><code>am.blend</code></a> node. For example:</p>
+<div class="sourceCode" id="cb88"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb88-1"><a href="#cb88-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> node <span class="op">=</span> am<span class="op">.</span>blend<span class="op">(</span><span class="st">&quot;add_alpha&quot;</span><span class="op">)</span></span>
+<span id="cb88-2"><a href="#cb88-2" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> am<span class="op">.</span>particles2d<span class="op">{</span></span>
+<span id="cb88-3"><a href="#cb88-3" aria-hidden="true" tabindex="-1"></a>        source_pos <span class="op">=</span> win<span class="op">:</span>mouse_position<span class="op">(),</span></span>
+<span id="cb88-4"><a href="#cb88-4" aria-hidden="true" tabindex="-1"></a>        source_pos_var <span class="op">=</span> vec2<span class="op">(</span><span class="dv">20</span><span class="op">),</span></span>
+<span id="cb88-5"><a href="#cb88-5" aria-hidden="true" tabindex="-1"></a>        max_particles <span class="op">=</span> <span class="dv">1000</span><span class="op">,</span></span>
+<span id="cb88-6"><a href="#cb88-6" aria-hidden="true" tabindex="-1"></a>        emission_rate <span class="op">=</span> <span class="dv">500</span><span class="op">,</span></span>
+<span id="cb88-7"><a href="#cb88-7" aria-hidden="true" tabindex="-1"></a>        start_particles <span class="op">=</span> <span class="dv">0</span><span class="op">,</span></span>
+<span id="cb88-8"><a href="#cb88-8" aria-hidden="true" tabindex="-1"></a>        life <span class="op">=</span> <span class="dv">0.4</span><span class="op">,</span></span>
+<span id="cb88-9"><a href="#cb88-9" aria-hidden="true" tabindex="-1"></a>        life_var <span class="op">=</span> <span class="dv">0.1</span><span class="op">,</span></span>
+<span id="cb88-10"><a href="#cb88-10" aria-hidden="true" tabindex="-1"></a>        angle <span class="op">=</span> <span class="fu">math.rad</span><span class="op">(</span><span class="dv">90</span><span class="op">),</span></span>
+<span id="cb88-11"><a href="#cb88-11" aria-hidden="true" tabindex="-1"></a>        angle_var <span class="op">=</span> <span class="fu">math.rad</span><span class="op">(</span><span class="dv">180</span><span class="op">),</span></span>
+<span id="cb88-12"><a href="#cb88-12" aria-hidden="true" tabindex="-1"></a>        speed <span class="op">=</span> <span class="dv">200</span><span class="op">,</span></span>
+<span id="cb88-13"><a href="#cb88-13" aria-hidden="true" tabindex="-1"></a>        start_color <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0.3</span><span class="op">,</span> <span class="dv">0.01</span><span class="op">,</span> <span class="dv">0.5</span><span class="op">),</span></span>
+<span id="cb88-14"><a href="#cb88-14" aria-hidden="true" tabindex="-1"></a>        start_color_var <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0.1</span><span class="op">,</span> <span class="dv">0.05</span><span class="op">,</span> <span class="dv">0.0</span><span class="op">,</span> <span class="dv">0.1</span><span class="op">),</span></span>
+<span id="cb88-15"><a href="#cb88-15" aria-hidden="true" tabindex="-1"></a>        end_color <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0.5</span><span class="op">,</span> <span class="dv">0.8</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span></span>
+<span id="cb88-16"><a href="#cb88-16" aria-hidden="true" tabindex="-1"></a>        end_color_var <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0.1</span><span class="op">),</span></span>
+<span id="cb88-17"><a href="#cb88-17" aria-hidden="true" tabindex="-1"></a>        start_size <span class="op">=</span> <span class="dv">30</span><span class="op">,</span></span>
+<span id="cb88-18"><a href="#cb88-18" aria-hidden="true" tabindex="-1"></a>        start_size_var <span class="op">=</span> <span class="dv">10</span><span class="op">,</span></span>
+<span id="cb88-19"><a href="#cb88-19" aria-hidden="true" tabindex="-1"></a>        end_size <span class="op">=</span> <span class="dv">2</span><span class="op">,</span></span>
+<span id="cb88-20"><a href="#cb88-20" aria-hidden="true" tabindex="-1"></a>        end_size_var <span class="op">=</span> <span class="dv">2</span><span class="op">,</span></span>
+<span id="cb88-21"><a href="#cb88-21" aria-hidden="true" tabindex="-1"></a>        gravity <span class="op">=</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">2000</span><span class="op">),</span></span>
+<span id="cb88-22"><a href="#cb88-22" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span></code></pre></div>
 <p>Methods:</p>
 <ul>
-<li><code>reset()</code>: resets the particles as if they had just been created with their current settings.</li>
+<li><code>reset()</code>: resets the particles as if they had just been
+created with their current settings.</li>
 </ul>
-<p>Default tag: <code>&quot;particles2d&quot;</code>.</p>
-<div class="figure">
-<img src="images/screenshot9.jpg" />
-
-</div>
+<p>Default tag: <code>"particles2d"</code>.</p>
+<p><img src="images/screenshot9.jpg" /></p>
 <h2 id="transformation-nodes-1">Transformation nodes</h2>
-<p>The following nodes apply transformations to all their descendants.</p>
-<p><strong>Note</strong>: These nodes have an optional <code>uniform</code> argument in the first position of their construction functions. This argument is only relevant if you're writing your own shader programs. Otherwise you can ignore it.</p>
-<h3 id="am.translate" class="func-def">am.translate([uniform,] position)</h3>
-<p>Apply a translation to a 4x4 matrix uniform. <code>uniform</code> is the uniform name as a string. It is <code>&quot;MV&quot;</code> by default.</p>
-<p><code>position</code> may be either 2 or 3 numbers (the x, y and z components) or a <code>vec2</code> or <code>vec3</code>.</p>
+<p>The following nodes apply transformations to all their
+descendants.</p>
+<p><strong>Note</strong>: These nodes have an optional
+<code>uniform</code> argument in the first position of their
+construction functions. This argument is only relevant if you’re writing
+your own shader programs. Otherwise you can ignore it.</p>
+<h3 class="func-def" id="am.translate">am.translate([uniform,]
+position)</h3>
+<p>Apply a translation to a 4x4 matrix uniform. <code>uniform</code> is
+the uniform name as a string. It is <code>"MV"</code> by default.</p>
+<p><code>position</code> may be either 2 or 3 numbers (the x, y and z
+components) or a <code>vec2</code> or <code>vec3</code>.</p>
 <p>If the z component is omitted it is assumed to be 0.</p>
 <p>Fields:</p>
 <ul>
-<li><code>position</code>: The translation position as a <code>vec3</code>. Updatable.</li>
-<li><code>position2d</code>: The translation position as a <code>vec2</code>. Updatable.</li>
-<li><code>x</code>, <code>y</code>, <code>z</code>: The <code>x</code>, <code>y</code> and <code>z</code> components of the position. Updatable.</li>
+<li><code>position</code>: The translation position as a
+<code>vec3</code>. Updatable.</li>
+<li><code>position2d</code>: The translation position as a
+<code>vec2</code>. Updatable.</li>
+<li><code>x</code>, <code>y</code>, <code>z</code>: The <code>x</code>,
+<code>y</code> and <code>z</code> components of the position.
+Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;translate&quot;</code>.</p>
+<p>Default tag: <code>"translate"</code>.</p>
 <p>Examples:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> node1 <span class="ot">=</span> am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">10</span><span class="ot">,</span> <span class="dv">20</span><span class="ot">)</span>
-<span class="kw">local</span> node2 <span class="ot">=</span> am<span class="ot">.</span>translate<span class="ot">(</span>vec2<span class="ot">(</span><span class="dv">10</span><span class="ot">,</span> <span class="dv">20</span><span class="ot">))</span>
-<span class="kw">local</span> node3 <span class="ot">=</span> am<span class="ot">.</span>translate<span class="ot">(</span><span class="st">&quot;MyModelViewMatrix&quot;</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">3.5</span><span class="ot">)</span>
-<span class="kw">local</span> node4 <span class="ot">=</span> am<span class="ot">.</span>translate<span class="ot">(</span>vec3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">,</span> <span class="dv">3</span><span class="ot">))</span>
-node1<span class="ot">.</span>position2d <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">30</span><span class="ot">,</span> <span class="dv">40</span><span class="ot">)</span>
-node2<span class="ot">.</span>x <span class="ot">=</span> <span class="dv">40</span>
-node2<span class="ot">.</span>y <span class="ot">=</span> <span class="dv">50</span>
-node3<span class="ot">.</span>position <span class="ot">=</span> vec3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">3</span><span class="ot">)</span></code></pre></div>
-<h3 id="am.scale" class="func-def">am.scale([uniform,] scaling)</h3>
-<p>Apply a scale transform to a 4x4 matrix uniform. <code>uniform</code> is the uniform name as a string. It is <code>&quot;MV&quot;</code> by default.</p>
-<p><code>scaling</code> may be 1, 2 or 3 numbers or a <code>vec2</code> or <code>vec3</code>. If 1 number is provided it is assume to be the x and y components of the scaling and the z scaling is assumed to be 1. If 2 numbers or a <code>vec2</code> is provided, they are the scaling for the x and y components and z is assumed to be 1.</p>
+<div class="sourceCode" id="cb89"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb89-1"><a href="#cb89-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> node1 <span class="op">=</span> am<span class="op">.</span>translate<span class="op">(</span><span class="dv">10</span><span class="op">,</span> <span class="dv">20</span><span class="op">)</span></span>
+<span id="cb89-2"><a href="#cb89-2" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> node2 <span class="op">=</span> am<span class="op">.</span>translate<span class="op">(</span>vec2<span class="op">(</span><span class="dv">10</span><span class="op">,</span> <span class="dv">20</span><span class="op">))</span></span>
+<span id="cb89-3"><a href="#cb89-3" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> node3 <span class="op">=</span> am<span class="op">.</span>translate<span class="op">(</span><span class="st">&quot;MyModelViewMatrix&quot;</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">,</span> <span class="op">-</span><span class="dv">3.5</span><span class="op">)</span></span>
+<span id="cb89-4"><a href="#cb89-4" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> node4 <span class="op">=</span> am<span class="op">.</span>translate<span class="op">(</span>vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">,</span> <span class="dv">3</span><span class="op">))</span></span>
+<span id="cb89-5"><a href="#cb89-5" aria-hidden="true" tabindex="-1"></a>node1<span class="op">.</span>position2d <span class="op">=</span> vec2<span class="op">(</span><span class="dv">30</span><span class="op">,</span> <span class="dv">40</span><span class="op">)</span></span>
+<span id="cb89-6"><a href="#cb89-6" aria-hidden="true" tabindex="-1"></a>node2<span class="op">.</span>x <span class="op">=</span> <span class="dv">40</span></span>
+<span id="cb89-7"><a href="#cb89-7" aria-hidden="true" tabindex="-1"></a>node2<span class="op">.</span>y <span class="op">=</span> <span class="dv">50</span></span>
+<span id="cb89-8"><a href="#cb89-8" aria-hidden="true" tabindex="-1"></a>node3<span class="op">.</span>position <span class="op">=</span> vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">,</span> <span class="op">-</span><span class="dv">3</span><span class="op">)</span></span></code></pre></div>
+<h3 class="func-def" id="am.scale">am.scale([uniform,] scaling)</h3>
+<p>Apply a scale transform to a 4x4 matrix uniform. <code>uniform</code>
+is the uniform name as a string. It is <code>"MV"</code> by default.</p>
+<p><code>scaling</code> may be 1, 2 or 3 numbers or a <code>vec2</code>
+or <code>vec3</code>. If 1 number is provided it is assume to be the x
+and y components of the scaling and the z scaling is assumed to be 1. If
+2 numbers or a <code>vec2</code> is provided, they are the scaling for
+the x and y components and z is assumed to be 1.</p>
 <p>Fields:</p>
 <ul>
-<li><code>scale</code>: The scale as a <code>vec3</code>. Updatable.</li>
-<li><code>scale2d</code>: The scale as a <code>vec2</code>. Updatable.</li>
-<li><code>x</code>, <code>y</code>, <code>z</code>: The <code>x</code>, <code>y</code> and <code>z</code> components of the scale. Updatable.</li>
+<li><code>scale</code>: The scale as a <code>vec3</code>.
+Updatable.</li>
+<li><code>scale2d</code>: The scale as a <code>vec2</code>.
+Updatable.</li>
+<li><code>x</code>, <code>y</code>, <code>z</code>: The <code>x</code>,
+<code>y</code> and <code>z</code> components of the scale.
+Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;scale&quot;</code>.</p>
+<p>Default tag: <code>"scale"</code>.</p>
 <p>Examples:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> node1 <span class="ot">=</span> am<span class="ot">.</span>scale<span class="ot">(</span><span class="dv">2</span><span class="ot">)</span>
-<span class="kw">local</span> node2 <span class="ot">=</span> am<span class="ot">.</span>scale<span class="ot">(</span><span class="dv">2</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)</span>
-<span class="kw">local</span> node3 <span class="ot">=</span> am<span class="ot">.</span>scale<span class="ot">(</span>vec2<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">))</span>
-<span class="kw">local</span> node4 <span class="ot">=</span> am<span class="ot">.</span>scale<span class="ot">(</span><span class="st">&quot;MyModelViewMatrix&quot;</span><span class="ot">,</span> vec3<span class="ot">(</span><span class="dv">0.5</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">,</span> <span class="dv">3</span><span class="ot">))</span>
-node1<span class="ot">.</span>scale2d <span class="ot">=</span> vec2<span class="ot">(</span><span class="dv">1</span><span class="ot">)</span>
-node2<span class="ot">.</span>x <span class="ot">=</span> <span class="dv">3</span>
-node4<span class="ot">.</span>scale <span class="ot">=</span> vec3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">3</span><span class="ot">,</span> <span class="dv">2</span><span class="ot">)</span></code></pre></div>
-<h3 id="am.rotate" class="func-def">am.rotate([uniform,] rotation)</h3>
-<p>Apply a rotation to a 4x4 matrix uniform. <code>uniform</code> is the uniform name as a string. It is <code>&quot;MV&quot;</code> by default.</p>
-<p><code>rotation</code> can be either a quaternion, or an angle (in radians) followed by an optional <code>vec3</code> axis. If the axis is omitted it is assumed to be <code>vec3(0, 0, 1)</code> so the rotation becomes a 2D rotation in the xy plane about the z axis.</p>
+<div class="sourceCode" id="cb90"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb90-1"><a href="#cb90-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> node1 <span class="op">=</span> am<span class="op">.</span>scale<span class="op">(</span><span class="dv">2</span><span class="op">)</span></span>
+<span id="cb90-2"><a href="#cb90-2" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> node2 <span class="op">=</span> am<span class="op">.</span>scale<span class="op">(</span><span class="dv">2</span><span class="op">,</span> <span class="dv">1</span><span class="op">)</span></span>
+<span id="cb90-3"><a href="#cb90-3" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> node3 <span class="op">=</span> am<span class="op">.</span>scale<span class="op">(</span>vec2<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">2</span><span class="op">))</span></span>
+<span id="cb90-4"><a href="#cb90-4" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> node4 <span class="op">=</span> am<span class="op">.</span>scale<span class="op">(</span><span class="st">&quot;MyModelViewMatrix&quot;</span><span class="op">,</span> vec3<span class="op">(</span><span class="dv">0.5</span><span class="op">,</span> <span class="dv">2</span><span class="op">,</span> <span class="dv">3</span><span class="op">))</span></span>
+<span id="cb90-5"><a href="#cb90-5" aria-hidden="true" tabindex="-1"></a>node1<span class="op">.</span>scale2d <span class="op">=</span> vec2<span class="op">(</span><span class="dv">1</span><span class="op">)</span></span>
+<span id="cb90-6"><a href="#cb90-6" aria-hidden="true" tabindex="-1"></a>node2<span class="op">.</span>x <span class="op">=</span> <span class="dv">3</span></span>
+<span id="cb90-7"><a href="#cb90-7" aria-hidden="true" tabindex="-1"></a>node4<span class="op">.</span>scale <span class="op">=</span> vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">3</span><span class="op">,</span> <span class="dv">2</span><span class="op">)</span></span></code></pre></div>
+<h3 class="func-def" id="am.rotate">am.rotate([uniform,] rotation)</h3>
+<p>Apply a rotation to a 4x4 matrix uniform. <code>uniform</code> is the
+uniform name as a string. It is <code>"MV"</code> by default.</p>
+<p><code>rotation</code> can be either a quaternion, or an angle (in
+radians) followed by an optional <code>vec3</code> axis. If the axis is
+omitted it is assumed to be <code>vec3(0, 0, 1)</code> so the rotation
+becomes a 2D rotation in the xy plane about the z axis.</p>
 <p>Fields:</p>
 <ul>
-<li><code>rotation</code>: The rotation as a <code>quat</code>. Updatable.</li>
+<li><code>rotation</code>: The rotation as a <code>quat</code>.
+Updatable.</li>
 <li><code>angle</code>: The rotation angle in radians. Updatable.</li>
-<li><code>axis</code>: The rotation axis as a <code>vec3</code>. Updatable.</li>
+<li><code>axis</code>: The rotation axis as a <code>vec3</code>.
+Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;rotate&quot;</code>.</p>
+<p>Default tag: <code>"rotate"</code>.</p>
 <p>Examples:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> node1 <span class="ot">=</span> am<span class="ot">.</span>rotate<span class="ot">(</span><span class="fu">math.rad</span><span class="ot">(</span><span class="dv">45</span><span class="ot">))</span>
-<span class="kw">local</span> node2 <span class="ot">=</span> am<span class="ot">.</span>rotate<span class="ot">(</span>math<span class="ot">.</span>pi<span class="ot">/</span><span class="dv">4</span><span class="ot">,</span> vec3<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">))</span>
-<span class="kw">local</span> node3 <span class="ot">=</span> am<span class="ot">.</span>rotate<span class="ot">(</span><span class="st">&quot;MyModelViewMatrix&quot;</span><span class="ot">,</span> 
-    quat<span class="ot">(</span>math<span class="ot">.</span>pi<span class="ot">/</span><span class="dv">6</span><span class="ot">,</span> vec3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">)))</span>
-node1<span class="ot">.</span>angle <span class="ot">=</span> <span class="fu">math.rad</span><span class="ot">(</span><span class="dv">60</span><span class="ot">)</span>
-node2<span class="ot">.</span>axis <span class="ot">=</span> vec3<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)</span>
-node3<span class="ot">.</span>rotation <span class="ot">=</span> quat<span class="ot">(</span><span class="fu">math.rad</span><span class="ot">(</span><span class="dv">60</span><span class="ot">),</span> vec3<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">))</span></code></pre></div>
-<h3 id="am.transform" class="func-def">am.transform([uniform,] matrix)</h3>
-<p>Pre-multiply a 4x4 matrix uniform by the given 4x4 matrix. <code>uniform</code> is the uniform name as a string (default is <code>&quot;MV&quot;</code>).</p>
+<div class="sourceCode" id="cb91"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb91-1"><a href="#cb91-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> node1 <span class="op">=</span> am<span class="op">.</span>rotate<span class="op">(</span><span class="fu">math.rad</span><span class="op">(</span><span class="dv">45</span><span class="op">))</span></span>
+<span id="cb91-2"><a href="#cb91-2" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> node2 <span class="op">=</span> am<span class="op">.</span>rotate<span class="op">(</span><span class="va">math.pi</span><span class="op">/</span><span class="dv">4</span><span class="op">,</span> vec3<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">))</span></span>
+<span id="cb91-3"><a href="#cb91-3" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> node3 <span class="op">=</span> am<span class="op">.</span>rotate<span class="op">(</span><span class="st">&quot;MyModelViewMatrix&quot;</span><span class="op">,</span> </span>
+<span id="cb91-4"><a href="#cb91-4" aria-hidden="true" tabindex="-1"></a>    quat<span class="op">(</span><span class="va">math.pi</span><span class="op">/</span><span class="dv">6</span><span class="op">,</span> vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">)))</span></span>
+<span id="cb91-5"><a href="#cb91-5" aria-hidden="true" tabindex="-1"></a>node1<span class="op">.</span>angle <span class="op">=</span> <span class="fu">math.rad</span><span class="op">(</span><span class="dv">60</span><span class="op">)</span></span>
+<span id="cb91-6"><a href="#cb91-6" aria-hidden="true" tabindex="-1"></a>node2<span class="op">.</span>axis <span class="op">=</span> vec3<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">)</span></span>
+<span id="cb91-7"><a href="#cb91-7" aria-hidden="true" tabindex="-1"></a>node3<span class="op">.</span>rotation <span class="op">=</span> quat<span class="op">(</span><span class="fu">math.rad</span><span class="op">(</span><span class="dv">60</span><span class="op">),</span> vec3<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">))</span></span></code></pre></div>
+<h3 class="func-def" id="am.transform">am.transform([uniform,]
+matrix)</h3>
+<p>Pre-multiply a 4x4 matrix uniform by the given 4x4 matrix.
+<code>uniform</code> is the uniform name as a string (default is
+<code>"MV"</code>).</p>
 <p>Fields:</p>
 <ul>
-<li><code>mat</code>: The matrix to multiply the uniform by. Updatable.</li>
+<li><code>mat</code>: The matrix to multiply the uniform by.
+Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;transform&quot;</code>.</p>
+<p>Default tag: <code>"transform"</code>.</p>
 <h2 id="advanced-nodes">Advanced nodes</h2>
-<h3 id="am.use_program" class="func-def">am.use_program(program)</h3>
-<p>Sets the <a href="#shader-programs">shader program</a> to use when rendering descendants. A <code>program</code> object can be created using the <a href="#am.program"><code>am.program</code></a> function.</p>
+<h3 class="func-def" id="am.use_program">am.use_program(program)</h3>
+<p>Sets the <a href="#shader-programs">shader program</a> to use when
+rendering descendants. A <code>program</code> object can be created
+using the <a href="#am.program"><code>am.program</code></a>
+function.</p>
 <p>Fields:</p>
 <ul>
 <li><code>program</code>: The shader program to use. Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;use_program&quot;</code>.</p>
-<h3 id="am.bind" class="func-def">am.bind(bindings)</h3>
-<p>Binds <a href="#shader-programs">shader program</a> parameters (uniforms and attributes) to values. <code>bindings</code> is a table mapping shader parameter names to values.</p>
-<p>The named parameters are matched with the uniforms and attributes in the shader program just before a <a href="#am.draw"><code>am.draw</code></a> node is executed.</p>
+<p>Default tag: <code>"use_program"</code>.</p>
+<h3 class="func-def" id="am.bind">am.bind(bindings)</h3>
+<p>Binds <a href="#shader-programs">shader program</a> parameters
+(uniforms and attributes) to values. <code>bindings</code> is a table
+mapping shader parameter names to values.</p>
+<p>The named parameters are matched with the uniforms and attributes in
+the shader program just before a <a
+href="#am.draw"><code>am.draw</code></a> node is executed.</p>
 <p>Program parameter types are mapped to the following Lua types:</p>
 <table>
 <thead>
 <tr class="header">
-<th align="left">Program parameter type</th>
-<th align="left">Lua type</th>
+<th style="text-align: left;">Program parameter type</th>
+<th style="text-align: left;">Lua type</th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td align="left"><code>float</code> uniform</td>
-<td align="left"><code>number</code></td>
+<td style="text-align: left;"><code>float</code> uniform</td>
+<td style="text-align: left;"><code>number</code></td>
 </tr>
 <tr class="even">
-<td align="left"><code>vec2</code> uniform</td>
-<td align="left"><a href="#vectors"><code>vec2</code></a></td>
+<td style="text-align: left;"><code>vec2</code> uniform</td>
+<td style="text-align: left;"><a
+href="#vectors"><code>vec2</code></a></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>vec3</code> uniform</td>
-<td align="left"><a href="#vectors"><code>vec3</code></a></td>
+<td style="text-align: left;"><code>vec3</code> uniform</td>
+<td style="text-align: left;"><a
+href="#vectors"><code>vec3</code></a></td>
 </tr>
 <tr class="even">
-<td align="left"><code>vec4</code> uniform</td>
-<td align="left"><a href="#vectors"><code>vec4</code></a></td>
+<td style="text-align: left;"><code>vec4</code> uniform</td>
+<td style="text-align: left;"><a
+href="#vectors"><code>vec4</code></a></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>mat2</code> uniform</td>
-<td align="left"><a href="#matrices"><code>mat2</code></a></td>
+<td style="text-align: left;"><code>mat2</code> uniform</td>
+<td style="text-align: left;"><a
+href="#matrices"><code>mat2</code></a></td>
 </tr>
 <tr class="even">
-<td align="left"><code>mat3</code> uniform</td>
-<td align="left"><a href="#matrices"><code>mat3</code></a></td>
+<td style="text-align: left;"><code>mat3</code> uniform</td>
+<td style="text-align: left;"><a
+href="#matrices"><code>mat3</code></a></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>mat4</code> uniform</td>
-<td align="left"><a href="#matrices"><code>mat4</code></a></td>
+<td style="text-align: left;"><code>mat4</code> uniform</td>
+<td style="text-align: left;"><a
+href="#matrices"><code>mat4</code></a></td>
 </tr>
 <tr class="even">
-<td align="left"><code>sampler2D</code> uniform</td>
-<td align="left"><a href="#am.texture2d"><code>texture2d</code></a></td>
+<td style="text-align: left;"><code>sampler2D</code> uniform</td>
+<td style="text-align: left;"><a
+href="#am.texture2d"><code>texture2d</code></a></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>float</code> attribute</td>
-<td align="left"><a href="#buffers-and-views"><code>view(&quot;float&quot;)</code></a></td>
+<td style="text-align: left;"><code>float</code> attribute</td>
+<td style="text-align: left;"><a
+href="#buffers-and-views"><code>view("float")</code></a></td>
 </tr>
 <tr class="even">
-<td align="left"><code>vec2</code> attribute</td>
-<td align="left"><a href="#buffers-and-views"><code>view(&quot;vec2&quot;)</code></a></td>
+<td style="text-align: left;"><code>vec2</code> attribute</td>
+<td style="text-align: left;"><a
+href="#buffers-and-views"><code>view("vec2")</code></a></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>vec3</code> attribute</td>
-<td align="left"><a href="#buffers-and-views"><code>view(&quot;vec3&quot;)</code></a></td>
+<td style="text-align: left;"><code>vec3</code> attribute</td>
+<td style="text-align: left;"><a
+href="#buffers-and-views"><code>view("vec3")</code></a></td>
 </tr>
 <tr class="even">
-<td align="left"><code>vec4</code> attribute</td>
-<td align="left"><a href="#buffers-and-views"><code>view(&quot;vec4&quot;)</code></a></td>
+<td style="text-align: left;"><code>vec4</code> attribute</td>
+<td style="text-align: left;"><a
+href="#buffers-and-views"><code>view("vec4")</code></a></td>
 </tr>
 </tbody>
 </table>
-<p>Any bound parameters not in the program are ignored, but all program parameters must have been bound before a <code>draw</code> node is executed.</p>
-<p><strong>Note</strong>: The parameter <code>P</code> is initially bound to a 4x4 projection matrix defined by the window's coordinate system, while the parameter <code>MV</code> (the default model view matrix) is initially bound to the 4x4 identity matrix.</p>
-<p>The bound parameters are available as updatable fields on the bind node. The fields have the same names as their corresponding parameters.</p>
-<p>Default tag: <code>&quot;bind&quot;</code>.</p>
+<p>Any bound parameters not in the program are ignored, but all program
+parameters must have been bound before a <code>draw</code> node is
+executed.</p>
+<p><strong>Note</strong>: The parameter <code>P</code> is initially
+bound to a 4x4 projection matrix defined by the window’s coordinate
+system, while the parameter <code>MV</code> (the default model view
+matrix) is initially bound to the 4x4 identity matrix.</p>
+<p>The bound parameters are available as updatable fields on the bind
+node. The fields have the same names as their corresponding
+parameters.</p>
+<p>Default tag: <code>"bind"</code>.</p>
 <p>Example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> bind_node <span class="ot">=</span> am<span class="ot">.</span>bind<span class="ot">{</span>
-    P <span class="ot">=</span> mat4<span class="ot">(</span><span class="dv">1</span><span class="ot">),</span>
-    MV <span class="ot">=</span> mat4<span class="ot">(</span><span class="dv">1</span><span class="ot">),</span>
-    color <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>
-    vert <span class="ot">=</span> am<span class="ot">.</span>vec2_array<span class="ot">{</span>
-        vec2<span class="ot">(-</span><span class="dv">1</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">1</span><span class="ot">),</span>
-        vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>
-        vec2<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">1</span><span class="ot">)</span>
-    <span class="ot">}</span>
-<span class="ot">}</span>
-<span class="do">-- update a parameter</span>
-bind_node<span class="ot">.</span>color <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)</span></code></pre></div>
-<h3 id="am.draw" class="func-def">am.draw(primitive [, elements] [, first [, count]])</h3>
-<p>Draws the currently bound vertices using the current shader program with the currently bound parameter values.</p>
+<div class="sourceCode" id="cb92"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb92-1"><a href="#cb92-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> bind_node <span class="op">=</span> am<span class="op">.</span>bind<span class="op">{</span></span>
+<span id="cb92-2"><a href="#cb92-2" aria-hidden="true" tabindex="-1"></a>    <span class="cn">P</span> <span class="op">=</span> mat4<span class="op">(</span><span class="dv">1</span><span class="op">),</span></span>
+<span id="cb92-3"><a href="#cb92-3" aria-hidden="true" tabindex="-1"></a>    <span class="cn">MV</span> <span class="op">=</span> mat4<span class="op">(</span><span class="dv">1</span><span class="op">),</span></span>
+<span id="cb92-4"><a href="#cb92-4" aria-hidden="true" tabindex="-1"></a>    color <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span></span>
+<span id="cb92-5"><a href="#cb92-5" aria-hidden="true" tabindex="-1"></a>    vert <span class="op">=</span> am<span class="op">.</span>vec2_array<span class="op">{</span></span>
+<span id="cb92-6"><a href="#cb92-6" aria-hidden="true" tabindex="-1"></a>        vec2<span class="op">(-</span><span class="dv">1</span><span class="op">,</span> <span class="op">-</span><span class="dv">1</span><span class="op">),</span></span>
+<span id="cb92-7"><a href="#cb92-7" aria-hidden="true" tabindex="-1"></a>        vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span></span>
+<span id="cb92-8"><a href="#cb92-8" aria-hidden="true" tabindex="-1"></a>        vec2<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="op">-</span><span class="dv">1</span><span class="op">)</span></span>
+<span id="cb92-9"><a href="#cb92-9" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb92-10"><a href="#cb92-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb92-11"><a href="#cb92-11" aria-hidden="true" tabindex="-1"></a><span class="co">-- update a parameter</span></span>
+<span id="cb92-12"><a href="#cb92-12" aria-hidden="true" tabindex="-1"></a>bind_node<span class="op">.</span>color <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">)</span></span></code></pre></div>
+<h3 class="func-def" id="am.draw">am.draw(primitive [, elements] [,
+first [, count]])</h3>
+<p>Draws the currently bound vertices using the current shader program
+with the currently bound parameter values.</p>
 <p><code>primitive</code> can be one of the following:</p>
 <ul>
-<li><code>&quot;points&quot;</code></li>
-<li><code>&quot;lines&quot;</code></li>
-<li><code>&quot;line_strip&quot;</code></li>
-<li><code>&quot;line_loop&quot;</code></li>
-<li><code>&quot;triangles&quot;</code></li>
-<li><code>&quot;triangle_strip&quot;</code></li>
-<li><code>&quot;triangle_fan&quot;</code></li>
+<li><code>"points"</code></li>
+<li><code>"lines"</code></li>
+<li><code>"line_strip"</code></li>
+<li><code>"line_loop"</code></li>
+<li><code>"triangles"</code></li>
+<li><code>"triangle_strip"</code></li>
+<li><code>"triangle_fan"</code></li>
 </ul>
-<p>Note that <code>&quot;line_loop&quot;</code> and <code>&quot;triangle_fan&quot;</code> may be slow on some systems.</p>
-<p><code>elements</code>, if supplied, should be a <code>ushort_elem</code> or <code>uint_elem</code> view containing 1-based attribute indices. If omitted the attributes are rendered in order as if <code>elements</code> were 1, 2, 3, 4, 5, ... etc. See also <a href="#buffers-and-views">buffers and views</a>.</p>
-<p><code>first</code> specifies where in the list of vertices to start drawing (starting from 1). The default is 1.</p>
-<p><code>count</code> specifies how many vertices to draw. The default is as many as are supplied through bound vertex attributes and the <code>elements</code> view if present.</p>
+<p>Note that <code>"line_loop"</code> and <code>"triangle_fan"</code>
+may be slow on some systems.</p>
+<p><code>elements</code>, if supplied, should be a
+<code>ushort_elem</code> or <code>uint_elem</code> view containing
+1-based attribute indices. If omitted the attributes are rendered in
+order as if <code>elements</code> were 1, 2, 3, 4, 5, … etc. See also <a
+href="#buffers-and-views">buffers and views</a>.</p>
+<p><code>first</code> specifies where in the list of vertices to start
+drawing (starting from 1). The default is 1.</p>
+<p><code>count</code> specifies how many vertices to draw. The default
+is as many as are supplied through bound vertex attributes and the
+<code>elements</code> view if present.</p>
 <p>Fields:</p>
 <ul>
 <li><code>primitive</code>: The primitive to draw. Updatable.</li>
@@ -2385,70 +3654,79 @@ bind_node<span class="ot">.</span>color <span class="ot">=</span> vec4<span clas
 <li><code>first</code>: The first vertex to draw. Updatable.</li>
 <li><code>count</code>: The number of vertices to draw. Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;draw&quot;</code>.</p>
-<p>Here is a complete example that draws a triangle with red, green and blue corners using <a href="#am.use_program"><code>am.use_program</code></a>, <a href="#am.bind"><code>am.bind</code></a> and <a href="#am.draw"><code>am.draw</code></a> nodes:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> win <span class="ot">=</span> am<span class="ot">.</span>window<span class="ot">{}</span>
-<span class="kw">local</span> prog <span class="ot">=</span> am<span class="ot">.</span>program<span class="ot">(</span><span class="st">[[</span>
-<span class="st">    precision highp float;</span>
-<span class="st">    attribute vec2 vert;</span>
-<span class="st">    attribute vec4 color;</span>
-<span class="st">    uniform mat4 MV;</span>
-<span class="st">    uniform mat4 P;</span>
-<span class="st">    varying vec4 v_color;</span>
-<span class="st">    void main() {</span>
-<span class="st">        v_color = color;</span>
-<span class="st">        gl_Position = P * MV * vec4(vert, 0.0, 1.0);</span>
-<span class="st">    }</span>
-<span class="st">]]</span><span class="ot">,</span> <span class="st">[[</span>
-<span class="st">    precision mediump float;</span>
-<span class="st">    varying vec4 v_color;</span>
-<span class="st">    void main() {</span>
-<span class="st">        gl_FragColor = v_color;</span>
-<span class="st">    }</span>
-<span class="st">]]</span><span class="ot">)</span>
-win<span class="ot">.</span>scene <span class="ot">=</span>
-    am<span class="ot">.</span>use_program<span class="ot">(</span>prog<span class="ot">)</span>
-    <span class="ot">^</span> am<span class="ot">.</span>bind<span class="ot">{</span>
-        P <span class="ot">=</span> mat4<span class="ot">(</span><span class="dv">1</span><span class="ot">),</span>
-        MV <span class="ot">=</span> mat4<span class="ot">(</span><span class="dv">1</span><span class="ot">),</span>
-        color <span class="ot">=</span> am<span class="ot">.</span>vec4_array<span class="ot">{</span>
-            vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>
-            vec4<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>
-            vec4<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)</span>
-        <span class="ot">},</span>
-        vert <span class="ot">=</span> am<span class="ot">.</span>vec2_array<span class="ot">{</span>
-            vec2<span class="ot">(-</span><span class="dv">1</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">1</span><span class="ot">),</span>
-            vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>
-            vec2<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">1</span><span class="ot">)</span>
-        <span class="ot">}</span>
-    <span class="ot">}</span>
-    <span class="ot">^</span> am<span class="ot">.</span>draw<span class="st">&quot;triangles&quot;</span></code></pre></div>
+<p>Default tag: <code>"draw"</code>.</p>
+<p>Here is a complete example that draws a triangle with red, green and
+blue corners using <a
+href="#am.use_program"><code>am.use_program</code></a>, <a
+href="#am.bind"><code>am.bind</code></a> and <a
+href="#am.draw"><code>am.draw</code></a> nodes:</p>
+<div class="sourceCode" id="cb93"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb93-1"><a href="#cb93-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> win <span class="op">=</span> am<span class="op">.</span>window<span class="op">{}</span></span>
+<span id="cb93-2"><a href="#cb93-2" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> prog <span class="op">=</span> am<span class="op">.</span>program<span class="op">(</span><span class="vs">[[</span></span>
+<span id="cb93-3"><a href="#cb93-3" aria-hidden="true" tabindex="-1"></a><span class="vs">    precision highp float;</span></span>
+<span id="cb93-4"><a href="#cb93-4" aria-hidden="true" tabindex="-1"></a><span class="vs">    attribute vec2 vert;</span></span>
+<span id="cb93-5"><a href="#cb93-5" aria-hidden="true" tabindex="-1"></a><span class="vs">    attribute vec4 color;</span></span>
+<span id="cb93-6"><a href="#cb93-6" aria-hidden="true" tabindex="-1"></a><span class="vs">    uniform mat4 MV;</span></span>
+<span id="cb93-7"><a href="#cb93-7" aria-hidden="true" tabindex="-1"></a><span class="vs">    uniform mat4 P;</span></span>
+<span id="cb93-8"><a href="#cb93-8" aria-hidden="true" tabindex="-1"></a><span class="vs">    varying vec4 v_color;</span></span>
+<span id="cb93-9"><a href="#cb93-9" aria-hidden="true" tabindex="-1"></a><span class="vs">    void main() {</span></span>
+<span id="cb93-10"><a href="#cb93-10" aria-hidden="true" tabindex="-1"></a><span class="vs">        v_color = color;</span></span>
+<span id="cb93-11"><a href="#cb93-11" aria-hidden="true" tabindex="-1"></a><span class="vs">        gl_Position = P * MV * vec4(vert, 0.0, 1.0);</span></span>
+<span id="cb93-12"><a href="#cb93-12" aria-hidden="true" tabindex="-1"></a><span class="vs">    }</span></span>
+<span id="cb93-13"><a href="#cb93-13" aria-hidden="true" tabindex="-1"></a><span class="vs">]]</span><span class="op">,</span> <span class="vs">[[</span></span>
+<span id="cb93-14"><a href="#cb93-14" aria-hidden="true" tabindex="-1"></a><span class="vs">    precision mediump float;</span></span>
+<span id="cb93-15"><a href="#cb93-15" aria-hidden="true" tabindex="-1"></a><span class="vs">    varying vec4 v_color;</span></span>
+<span id="cb93-16"><a href="#cb93-16" aria-hidden="true" tabindex="-1"></a><span class="vs">    void main() {</span></span>
+<span id="cb93-17"><a href="#cb93-17" aria-hidden="true" tabindex="-1"></a><span class="vs">        gl_FragColor = v_color;</span></span>
+<span id="cb93-18"><a href="#cb93-18" aria-hidden="true" tabindex="-1"></a><span class="vs">    }</span></span>
+<span id="cb93-19"><a href="#cb93-19" aria-hidden="true" tabindex="-1"></a><span class="vs">]]</span><span class="op">)</span></span>
+<span id="cb93-20"><a href="#cb93-20" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene <span class="op">=</span></span>
+<span id="cb93-21"><a href="#cb93-21" aria-hidden="true" tabindex="-1"></a>    am<span class="op">.</span>use_program<span class="op">(</span>prog<span class="op">)</span></span>
+<span id="cb93-22"><a href="#cb93-22" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> am<span class="op">.</span>bind<span class="op">{</span></span>
+<span id="cb93-23"><a href="#cb93-23" aria-hidden="true" tabindex="-1"></a>        <span class="cn">P</span> <span class="op">=</span> mat4<span class="op">(</span><span class="dv">1</span><span class="op">),</span></span>
+<span id="cb93-24"><a href="#cb93-24" aria-hidden="true" tabindex="-1"></a>        <span class="cn">MV</span> <span class="op">=</span> mat4<span class="op">(</span><span class="dv">1</span><span class="op">),</span></span>
+<span id="cb93-25"><a href="#cb93-25" aria-hidden="true" tabindex="-1"></a>        color <span class="op">=</span> am<span class="op">.</span>vec4_array<span class="op">{</span></span>
+<span id="cb93-26"><a href="#cb93-26" aria-hidden="true" tabindex="-1"></a>            vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span></span>
+<span id="cb93-27"><a href="#cb93-27" aria-hidden="true" tabindex="-1"></a>            vec4<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span></span>
+<span id="cb93-28"><a href="#cb93-28" aria-hidden="true" tabindex="-1"></a>            vec4<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">)</span></span>
+<span id="cb93-29"><a href="#cb93-29" aria-hidden="true" tabindex="-1"></a>        <span class="op">},</span></span>
+<span id="cb93-30"><a href="#cb93-30" aria-hidden="true" tabindex="-1"></a>        vert <span class="op">=</span> am<span class="op">.</span>vec2_array<span class="op">{</span></span>
+<span id="cb93-31"><a href="#cb93-31" aria-hidden="true" tabindex="-1"></a>            vec2<span class="op">(-</span><span class="dv">1</span><span class="op">,</span> <span class="op">-</span><span class="dv">1</span><span class="op">),</span></span>
+<span id="cb93-32"><a href="#cb93-32" aria-hidden="true" tabindex="-1"></a>            vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span></span>
+<span id="cb93-33"><a href="#cb93-33" aria-hidden="true" tabindex="-1"></a>            vec2<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="op">-</span><span class="dv">1</span><span class="op">)</span></span>
+<span id="cb93-34"><a href="#cb93-34" aria-hidden="true" tabindex="-1"></a>        <span class="op">}</span></span>
+<span id="cb93-35"><a href="#cb93-35" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb93-36"><a href="#cb93-36" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> am<span class="op">.</span>draw<span class="st">&quot;triangles&quot;</span></span></code></pre></div>
 <p>The resulting image looks like this:</p>
-<div class="figure">
-<img src="images/rgb_triangle.png" />
-
-</div>
-<h3 id="am.blend" class="func-def">am.blend(mode)</h3>
+<p><img src="images/rgb_triangle.png" /></p>
+<h3 class="func-def" id="am.blend">am.blend(mode)</h3>
 <p>Set the blending mode.</p>
 <p>The possible values for <code>mode</code> are:</p>
 <ul>
-<li><code>&quot;off&quot;</code></li>
-<li><code>&quot;alpha&quot;</code></li>
-<li><code>&quot;premult&quot;</code></li>
-<li><code>&quot;add&quot;</code></li>
-<li><code>&quot;subtract&quot;</code></li>
-<li><code>&quot;add_alpha&quot;</code></li>
-<li><code>&quot;subtract_alpha&quot;</code></li>
-<li><code>&quot;multiply&quot;</code></li>
-<li><code>&quot;invert&quot;</code></li>
+<li><code>"off"</code></li>
+<li><code>"alpha"</code></li>
+<li><code>"premult"</code></li>
+<li><code>"add"</code></li>
+<li><code>"subtract"</code></li>
+<li><code>"add_alpha"</code></li>
+<li><code>"subtract_alpha"</code></li>
+<li><code>"multiply"</code></li>
+<li><code>"invert"</code></li>
 </ul>
 <p>Fields:</p>
 <ul>
 <li><code>mode</code>: Updatable.</li>
 </ul>
-<h3 id="am.color_maskred-green-blue-alpha" class="func-def">am.color_mask(red, green, blue, alpha)</h3>
-<p>Apply a color mask. The four arguments can be <code>true</code> or <code>false</code> and determine whether the corresponding color channel is updated in the rendering target (either the current window or framebuffer being rendered to).</p>
-<p>For example using a mask of <code>am.color_mask(false, true, false, true)</code> will cause only the green and alpha channels to be updated.</p>
+<h3 class="func-def"
+id="am.color_maskred-green-blue-alpha">am.color_mask(red, green, blue,
+alpha)</h3>
+<p>Apply a color mask. The four arguments can be <code>true</code> or
+<code>false</code> and determine whether the corresponding color channel
+is updated in the rendering target (either the current window or
+framebuffer being rendered to).</p>
+<p>For example using a mask of
+<code>am.color_mask(false, true, false, true)</code> will cause only the
+green and alpha channels to be updated.</p>
 <p>Fields:</p>
 <ul>
 <li><code>red</code>: Updatable.</li>
@@ -2456,460 +3734,712 @@ win<span class="ot">.</span>scene <span class="ot">=</span>
 <li><code>blue</code>: Updatable.</li>
 <li><code>alpha</code>: Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;color_mask&quot;</code>.</p>
-<h3 id="am.cull_faceface" class="func-def">am.cull_face(face)</h3>
+<p>Default tag: <code>"color_mask"</code>.</p>
+<h3 class="func-def" id="am.cull_faceface">am.cull_face(face)</h3>
 <p>Culls triangles with a specific winding.</p>
 <p>The possible values for <code>face</code> are:</p>
 <ul>
-<li><code>&quot;back&quot;</code>: Cull back-facing triangles (same as <code>&quot;cw&quot;</code> below)</li>
-<li><code>&quot;front&quot;</code>: Cull front-facing triangles (same as <code>&quot;ccw&quot;</code> below)</li>
-<li><code>&quot;cw&quot;</code>: Cull clockwise wound triangles.</li>
-<li><code>&quot;ccw&quot;</code>: Cull counter-clockwise wound triangles.</li>
-<li><code>&quot;none&quot;</code>: Do not cull any triangles.</li>
+<li><code>"back"</code>: Cull back-facing triangles (same as
+<code>"cw"</code> below)</li>
+<li><code>"front"</code>: Cull front-facing triangles (same as
+<code>"ccw"</code> below)</li>
+<li><code>"cw"</code>: Cull clockwise wound triangles.</li>
+<li><code>"ccw"</code>: Cull counter-clockwise wound triangles.</li>
+<li><code>"none"</code>: Do not cull any triangles.</li>
 </ul>
 <p>Fields:</p>
 <ul>
 <li><code>face</code>: Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;cull_face&quot;</code>.</p>
-<h3 id="am.depth_test" class="method-def">am.depth_test(func [, mask])</h3>
-<p>Sets the depth test function and mask. The window or framebuffer being rendered to needs to have a depth buffer for this to have any effect.</p>
-<p><code>func</code> is used to determine whether a fragment is rendered by comparing the depth value of the fragment to the value in the depth buffer. The possible values for <code>func</code> are:</p>
+<p>Default tag: <code>"cull_face"</code>.</p>
+<h3 class="method-def" id="am.depth_test">am.depth_test(func [,
+mask])</h3>
+<p>Sets the depth test function and mask. The window or framebuffer
+being rendered to needs to have a depth buffer for this to have any
+effect.</p>
+<p><code>func</code> is used to determine whether a fragment is rendered
+by comparing the depth value of the fragment to the value in the depth
+buffer. The possible values for <code>func</code> are:</p>
 <ul>
-<li><code>&quot;never&quot;</code></li>
-<li><code>&quot;always&quot;</code></li>
-<li><code>&quot;equal&quot;</code></li>
-<li><code>&quot;notequal&quot;</code></li>
-<li><code>&quot;less&quot;</code></li>
-<li><code>&quot;lequal&quot;</code></li>
-<li><code>&quot;greater&quot;</code></li>
-<li><code>&quot;gequal&quot;</code></li>
+<li><code>"never"</code></li>
+<li><code>"always"</code></li>
+<li><code>"equal"</code></li>
+<li><code>"notequal"</code></li>
+<li><code>"less"</code></li>
+<li><code>"lequal"</code></li>
+<li><code>"greater"</code></li>
+<li><code>"gequal"</code></li>
 </ul>
-<p><code>mask</code> determines whether the fragment depth is written to the depth buffer. The possible values are <code>true</code> and <code>false</code>. The default is <code>true</code>.</p>
+<p><code>mask</code> determines whether the fragment depth is written to
+the depth buffer. The possible values are <code>true</code> and
+<code>false</code>. The default is <code>true</code>.</p>
 <p>Fields:</p>
 <ul>
 <li><code>func</code>: Updatable.</li>
 <li><code>mask</code>: Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;depth_test&quot;</code>.</p>
-<h3 id="am.stencil_test" class="method-def">am.stencil_test(settings)</h3>
-<p>Sets the stencil test and mask. The window or framebuffer being rendered to needs to have a stencil buffer for this to have any effect.</p>
-<p><code>settings</code> should be a table with any combination of the following fields:</p>
+<p>Default tag: <code>"depth_test"</code>.</p>
+<h3 class="method-def"
+id="am.stencil_test">am.stencil_test(settings)</h3>
+<p>Sets the stencil test and mask. The window or framebuffer being
+rendered to needs to have a stencil buffer for this to have any
+effect.</p>
+<p><code>settings</code> should be a table with any combination of the
+following fields:</p>
 <ul>
-<li><code>enabled</code>: whether the stencil test is enabled (<code>true</code>/<code>false</code>, default <code>false</code>)</li>
-<li><code>ref</code>: the reference value to use in the test function (must be an integer between 0 and 255, default 0).</li>
-<li><code>read_mask</code>: a bitmask to apply to the reference value and the stencil buffer value before doing the test (must be an integer between 0 and 255, default 255).</li>
-<li><code>write_mask</code>: a bitmask that controls which stencil buffer bits can be written to (must be an integer between 0 and 255, default 255).</li>
-<li><code>func_front</code>: the test function to use for front-facing (CCW) triangles (<code>&quot;never&quot;</code>, <code>&quot;always&quot;</code>, <code>&quot;equal&quot;</code>, <code>&quot;notequal&quot;</code>, <code>&quot;less&quot;</code>, <code>&quot;lequal&quot;</code>, <code>&quot;greater&quot;</code> or <code>&quot;gequal&quot;</code>, default <code>&quot;always&quot;</code>). The function compares a supplied reference value with the value in the stencil buffer.</li>
-<li><code>op_fail_front</code>: The operation to perform if the stencil test fails (see below for possible values).</li>
-<li><code>op_zfail_front</code>: The operation to perform if the stencil test passes, but the depth test fails (see below for possible values).</li>
-<li><code>op_zpass_front</code>: The operation to perform if the stencil test passes and the depth test passes (see below for possible values).</li>
-<li><code>func_back</code>: same as <code>func_front</code>, but for back-facing (CW) triangles.</li>
-<li><code>op_fail_back</code>: same as <code>op_fail_front</code>, but for back-facing (CW) triangles.</li>
-<li><code>op_zfail_back</code>: same as <code>op_zfail_front</code>, but for back-facing (CW) triangles.</li>
-<li><code>op_zpass_back</code>: same as <code>op_zpass_front</code>, but for back-facing (CW) triangles.</li>
+<li><code>enabled</code>: whether the stencil test is enabled
+(<code>true</code>/<code>false</code>, default <code>false</code>)</li>
+<li><code>ref</code>: the reference value to use in the test function
+(must be an integer between 0 and 255, default 0).</li>
+<li><code>read_mask</code>: a bitmask to apply to the reference value
+and the stencil buffer value before doing the test (must be an integer
+between 0 and 255, default 255).</li>
+<li><code>write_mask</code>: a bitmask that controls which stencil
+buffer bits can be written to (must be an integer between 0 and 255,
+default 255).</li>
+<li><code>func_front</code>: the test function to use for front-facing
+(CCW) triangles (<code>"never"</code>, <code>"always"</code>,
+<code>"equal"</code>, <code>"notequal"</code>, <code>"less"</code>,
+<code>"lequal"</code>, <code>"greater"</code> or <code>"gequal"</code>,
+default <code>"always"</code>). The function compares a supplied
+reference value with the value in the stencil buffer.</li>
+<li><code>op_fail_front</code>: The operation to perform if the stencil
+test fails (see below for possible values).</li>
+<li><code>op_zfail_front</code>: The operation to perform if the stencil
+test passes, but the depth test fails (see below for possible
+values).</li>
+<li><code>op_zpass_front</code>: The operation to perform if the stencil
+test passes and the depth test passes (see below for possible
+values).</li>
+<li><code>func_back</code>: same as <code>func_front</code>, but for
+back-facing (CW) triangles.</li>
+<li><code>op_fail_back</code>: same as <code>op_fail_front</code>, but
+for back-facing (CW) triangles.</li>
+<li><code>op_zfail_back</code>: same as <code>op_zfail_front</code>, but
+for back-facing (CW) triangles.</li>
+<li><code>op_zpass_back</code>: same as <code>op_zpass_front</code>, but
+for back-facing (CW) triangles.</li>
 </ul>
-<p>The <code>op_fail_front</code>, <code>op_zfail_front</code> and <code>op_zpass_front</code> fields (and the analogous fields for back-facing triangles) determine how the stencil buffer is modified. They can be one of the following values:</p>
+<p>The <code>op_fail_front</code>, <code>op_zfail_front</code> and
+<code>op_zpass_front</code> fields (and the analogous fields for
+back-facing triangles) determine how the stencil buffer is modified.
+They can be one of the following values:</p>
 <ul>
-<li><code>&quot;keep&quot;</code>: keeps the existing stencil buffer value</li>
-<li><code>&quot;zero&quot;</code>: sets the stencil buffer to zero</li>
-<li><code>&quot;replace&quot;</code>: replaces the stencil buffer value with the supplied reference value</li>
-<li><code>&quot;invert&quot;</code>: invert the bits of the stencil buffer</li>
-<li><code>&quot;incr&quot;</code>: increment the stencil buffer value</li>
-<li><code>&quot;decr&quot;</code>: decrement the stencil buffer value</li>
-<li><code>&quot;incr_wrap&quot;</code>: increment the stencil buffer value, wrapping back to zero on overflow (&gt; 255)</li>
-<li><code>&quot;decr_wrap&quot;</code>: decrement the stencil buffer value, wrapping to 255 on underflow</li>
+<li><code>"keep"</code>: keeps the existing stencil buffer value</li>
+<li><code>"zero"</code>: sets the stencil buffer to zero</li>
+<li><code>"replace"</code>: replaces the stencil buffer value with the
+supplied reference value</li>
+<li><code>"invert"</code>: invert the bits of the stencil buffer</li>
+<li><code>"incr"</code>: increment the stencil buffer value</li>
+<li><code>"decr"</code>: decrement the stencil buffer value</li>
+<li><code>"incr_wrap"</code>: increment the stencil buffer value,
+wrapping back to zero on overflow (&gt; 255)</li>
+<li><code>"decr_wrap"</code>: decrement the stencil buffer value,
+wrapping to 255 on underflow</li>
 </ul>
-<p>All the settings can be updated after the depth test node has been created using fields on the node with the corresponding names.</p>
-<p>Default tag: <code>&quot;stencil_test&quot;</code>.</p>
-<h3 id="am.viewport" class="func-def">am.viewport(left, bottom, width, height)</h3>
-<p>Set the viewport, which is the rectangular area of the window into which rendering will occur.</p>
-<p><code>left</code> and <code>bottom</code> is the bottom-left corner of the viewport in pixels, where the bottom-left corner of the window is (0, 0). <code>width</code> and <code>height</code> are also in pixels.</p>
+<p>All the settings can be updated after the depth test node has been
+created using fields on the node with the corresponding names.</p>
+<p>Default tag: <code>"stencil_test"</code>.</p>
+<h3 class="func-def" id="am.viewport">am.viewport(left, bottom, width,
+height)</h3>
+<p>Set the viewport, which is the rectangular area of the window into
+which rendering will occur.</p>
+<p><code>left</code> and <code>bottom</code> is the bottom-left corner
+of the viewport in pixels, where the bottom-left corner of the window is
+(0, 0). <code>width</code> and <code>height</code> are also in
+pixels.</p>
 <p>Fields:</p>
 <ul>
-<li><code>left</code>, <code>bottom</code>, <code>width</code>, <code>height</code>: Updatable.</li>
+<li><code>left</code>, <code>bottom</code>, <code>width</code>,
+<code>height</code>: Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;viewport&quot;</code>.</p>
-<h3 id="am.lookat" class="func-def">am.lookat([uniform,] eye, center, up)</h3>
-<p>Sets <code>uniform</code> to the &quot;lookat matrix&quot; which looks from <code>eye</code> (a <code>vec3</code>) to <code>center</code> (a <code>vec3</code>), with <code>up</code> (a unit <code>vec3</code>) as the up direction.</p>
-<p>This node can be thought of a camera positioned at <code>eye</code> and facing the point <code>center</code>.</p>
-<p>The default value for <code>uniform</code> is <code>&quot;MV&quot;</code>.</p>
+<p>Default tag: <code>"viewport"</code>.</p>
+<h3 class="func-def" id="am.lookat">am.lookat([uniform,] eye, center,
+up)</h3>
+<p>Sets <code>uniform</code> to the “lookat matrix” which looks from
+<code>eye</code> (a <code>vec3</code>) to <code>center</code> (a
+<code>vec3</code>), with <code>up</code> (a unit <code>vec3</code>) as
+the up direction.</p>
+<p>This node can be thought of a camera positioned at <code>eye</code>
+and facing the point <code>center</code>.</p>
+<p>The default value for <code>uniform</code> is <code>"MV"</code>.</p>
 <p>Fields:</p>
 <ul>
-<li><code>eye</code>: The camera position (<code>vec3</code>). Updatable.</li>
-<li><code>center</code>: A point the camera is facing (<code>vec3</code>). Updatable.</li>
-<li><code>up</code>: The up direction of the camera (<code>vec3</code>). Updatable.</li>
+<li><code>eye</code>: The camera position (<code>vec3</code>).
+Updatable.</li>
+<li><code>center</code>: A point the camera is facing
+(<code>vec3</code>). Updatable.</li>
+<li><code>up</code>: The up direction of the camera (<code>vec3</code>).
+Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;lookat&quot;</code>.</p>
-<h3 id="am.cull_sphere" class="func-def">am.cull_sphere([uniforms...,] radius [, center])</h3>
-<p>This first takes the matrix product of the given uniforms (which should be <code>mat4</code>s). Then it determines whether the sphere with the given center and radius would be visible using the previously computed matrix product as the model-view-projection matrix. If it wouldn't be visible then none of this node's children are rendered (i.e. they are culled).</p>
-<p>The default value for <code>uniforms</code> is <code>&quot;P&quot; and &quot;MV&quot;</code> and the default value for <code>center</code> is <code>vec3(0)</code>.</p>
+<p>Default tag: <code>"lookat"</code>.</p>
+<h3 class="func-def" id="am.cull_sphere">am.cull_sphere([uniforms…,]
+radius [, center])</h3>
+<p>This first takes the matrix product of the given uniforms (which
+should be <code>mat4</code>s). Then it determines whether the sphere
+with the given center and radius would be visible using the previously
+computed matrix product as the model-view-projection matrix. If it
+wouldn’t be visible then none of this node’s children are rendered
+(i.e. they are culled).</p>
+<p>The default value for <code>uniforms</code> is
+<code>"P" and "MV"</code> and the default value for <code>center</code>
+is <code>vec3(0)</code>.</p>
 <p>Fields:</p>
 <ul>
 <li><code>radius</code>: Updatable.</li>
 <li><code>center</code>: Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;cull_sphere&quot;</code>.</p>
-<h3 id="am.cull_box" class="func-def">am.cull_box([uniforms...,] min, max)</h3>
-<p>This first takes the matrix product of the given uniforms (which should be <code>mat4</code>s). Then it determines whether the box with the min and max coordinates (<code>min</code> and <code>max</code> are <code>vec3</code>s) would be visible using the computed matrix product as the model-view-projection matrix. If it wouldn't be visible then none of this node's children are rendered.</p>
-<p>The default value for <code>uniforms</code> is <code>&quot;P&quot; and &quot;MV&quot;</code>.</p>
+<p>Default tag: <code>"cull_sphere"</code>.</p>
+<h3 class="func-def" id="am.cull_box">am.cull_box([uniforms…,] min,
+max)</h3>
+<p>This first takes the matrix product of the given uniforms (which
+should be <code>mat4</code>s). Then it determines whether the box with
+the min and max coordinates (<code>min</code> and <code>max</code> are
+<code>vec3</code>s) would be visible using the computed matrix product
+as the model-view-projection matrix. If it wouldn’t be visible then none
+of this node’s children are rendered.</p>
+<p>The default value for <code>uniforms</code> is
+<code>"P" and "MV"</code>.</p>
 <p>Fields:</p>
 <ul>
 <li><code>min</code>: Updatable.</li>
 <li><code>max</code>: Updatable.</li>
 </ul>
-<p>Default tag: <code>&quot;cull_box&quot;</code>.</p>
-<h3 id="am.billboard" class="func-def">am.billboard([uniform,] [preserve_scaling])</h3>
-<p>Removes rotation from <code>uniform</code>, which should be a <code>mat4</code>. By default <code>uniform</code> is <code>&quot;MV&quot;</code>.</p>
-<p>If <code>preserve_scaling</code> is <code>false</code> or omitted then any scaling will also be removed from the matrix. If it is <code>true</code>, then scaling will be preserved, as long as it's the same across all three axes.</p>
-<p>Default tag: <code>&quot;billboard&quot;</code></p>
-<h3 id="am.read_param" class="func-def">am.read_uniform(uniform)</h3>
-<p>This node has no effect on rendering. Instead it records the value of the named uniform when rendering occurs.</p>
-<p>This is useful for finding the value of the model-view matrix (<code>MV</code>) at a specific node without having to keep track of all the ancestor transforms. This could then be used to, for example, determine the position of a mouse click in a node's coordinate space, by taking the inverse of the model-view matrix.</p>
+<p>Default tag: <code>"cull_box"</code>.</p>
+<h3 class="func-def" id="am.billboard">am.billboard([uniform,]
+[preserve_scaling])</h3>
+<p>Removes rotation from <code>uniform</code>, which should be a
+<code>mat4</code>. By default <code>uniform</code> is
+<code>"MV"</code>.</p>
+<p>If <code>preserve_scaling</code> is <code>false</code> or omitted
+then any scaling will also be removed from the matrix. If it is
+<code>true</code>, then scaling will be preserved, as long as it’s the
+same across all three axes.</p>
+<p>Default tag: <code>"billboard"</code></p>
+<h3 class="func-def" id="am.read_param">am.read_uniform(uniform)</h3>
+<p>This node has no effect on rendering. Instead it records the value of
+the named uniform when rendering occurs.</p>
+<p>This is useful for finding the value of the model-view matrix
+(<code>MV</code>) at a specific node without having to keep track of all
+the ancestor transforms. This could then be used to, for example,
+determine the position of a mouse click in a node’s coordinate space, by
+taking the inverse of the model-view matrix.</p>
 <p>Fields:</p>
 <ul>
-<li><code>value</code>: The value of the uniform, or nil if the node hasn't been rendered yet, or the named uniform wasn't set in an ancestor node.</li>
+<li><code>value</code>: The value of the uniform, or nil if the node
+hasn’t been rendered yet, or the named uniform wasn’t set in an ancestor
+node.</li>
 </ul>
-<p>Default tag: <code>&quot;read_uniform&quot;</code>.</p>
-<h3 id="am.quads" class="func-def">am.quads(n, spec [, usage])</h3>
-<p>Returns a node that renders a set of quads. The returned node is actually an <a href="#am.bind"><code>am.bind</code></a> node with an <a href="#am.draw"><code>am.draw</code></a> node child. i.e. no program or blending is defined -- these must be created separately as parent nodes.</p>
-<p><code>n</code> is the initial capacity. Set this to the number of quads you think you'll want to render. It doesn't matter if it's too small as the capacity will be increased as required, though it's slightly faster if no capacity increases are required.</p>
-<p><code>spec</code> is a table of attribute name and type pairs (the same as used for <a href="#am.struct_array"><code>am.struct_array</code></a> ).</p>
-<p><code>usage</code> is an optional hint to the graphics driver about how the quads will be used. See the <code>usage</code> property of <a href="#am.buffer"><code>am.buffer</code></a> for more details.</p>
+<p>Default tag: <code>"read_uniform"</code>.</p>
+<h3 class="func-def" id="am.quads">am.quads(n, spec [, usage])</h3>
+<p>Returns a node that renders a set of quads. The returned node is
+actually an <a href="#am.bind"><code>am.bind</code></a> node with an <a
+href="#am.draw"><code>am.draw</code></a> node child. i.e. no program or
+blending is defined – these must be created separately as parent
+nodes.</p>
+<p><code>n</code> is the initial capacity. Set this to the number of
+quads you think you’ll want to render. It doesn’t matter if it’s too
+small as the capacity will be increased as required, though it’s
+slightly faster if no capacity increases are required.</p>
+<p><code>spec</code> is a table of attribute name and type pairs (the
+same as used for <a
+href="#am.struct_array"><code>am.struct_array</code></a> ).</p>
+<p><code>usage</code> is an optional hint to the graphics driver about
+how the quads will be used. See the <code>usage</code> property of <a
+href="#am.buffer"><code>am.buffer</code></a> for more details.</p>
 <p>Fields:</p>
 <ul>
-<li><code>num_quads</code>: The number of quads. This is zero initially.</li>
+<li><code>num_quads</code>: The number of quads. This is zero
+initially.</li>
 </ul>
 <p>Methods:</p>
 <ul>
-<li><code>add_quad(data)</code>: adds a quad to be rendered and returns the quad number. <code>data</code> is a table where the keys are attribute names and the values are the values of the 4 vertices of the quad. The values can be specified in several ways:
+<li><code>add_quad(data)</code>: adds a quad to be rendered and returns
+the quad number. <code>data</code> is a table where the keys are
+attribute names and the values are the values of the 4 vertices of the
+quad. The values can be specified in several ways:
 <ul>
-<li>as a table where each each element is the value for the left-top, left-bottom, right-bottom and right-top corners of the quad.</li>
+<li>as a table where each each element is the value for the left-top,
+left-bottom, right-bottom and right-top corners of the quad.</li>
 <li>a single value for all corners.</li>
-<li>a view containing the values for the elements As with the <a href="#view:set"><code>view:set</code></a> method, if the attribute is a vector, a table of numbers is also accepted. The quad number (starting at 1) is returned.</li>
+<li>a view containing the values for the elements As with the <a
+href="#view:set"><code>view:set</code></a> method, if the attribute is a
+vector, a table of numbers is also accepted. The quad number (starting
+at 1) is returned.</li>
 </ul></li>
-<li><code>remove_quad(n [,count])</code>: Removes <code>count</code> quads starting with the <code>n</code>th. <code>count</code> is 1 if omitted.</li>
+<li><code>remove_quad(n [,count])</code>: Removes <code>count</code>
+quads starting with the <code>n</code>th. <code>count</code> is 1 if
+omitted.</li>
 <li><code>clear()</code>: Removes all quads.</li>
-<li>Additionally methods are created for each attribute of the form <code>quad_&lt;attribute name&gt;</code> that can be used to update the value of a quad attribute. The signature of the method is: <code>quad_attr(n, values)</code> where <code>n</code> is the quad number and <code>values</code> has the same meaning as in the <code>add_quad</code> method.</li>
+<li>Additionally methods are created for each attribute of the form
+<code>quad_&lt;attribute name&gt;</code> that can be used to update the
+value of a quad attribute. The signature of the method is:
+<code>quad_attr(n, values)</code> where <code>n</code> is the quad
+number and <code>values</code> has the same meaning as in the
+<code>add_quad</code> method.</li>
 </ul>
-<p>Default tag: <code>&quot;quads&quot;</code>.</p>
+<p>Default tag: <code>"quads"</code>.</p>
 <p>Example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> quads <span class="ot">=</span> am<span class="ot">.</span>quads<span class="ot">(</span><span class="dv">2</span><span class="ot">,</span> <span class="ot">{</span><span class="st">&quot;vert&quot;</span><span class="ot">,</span> <span class="st">&quot;vec2&quot;</span><span class="ot">,</span> <span class="st">&quot;color&quot;</span><span class="ot">,</span> <span class="st">&quot;vec3&quot;</span><span class="ot">})</span>
-quads:add_quad<span class="ot">{</span>vert <span class="ot">=</span> <span class="ot">{</span>vec2<span class="ot">(-</span><span class="dv">100</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> vec2<span class="ot">(-</span><span class="dv">100</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">100</span><span class="ot">),</span>
-                       vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">100</span><span class="ot">),</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">)},</span>
-               color <span class="ot">=</span> <span class="ot">{</span>vec3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> vec3<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span>
-                        vec3<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span> vec3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)}}</span>
-quads:add_quad<span class="ot">{</span>vert <span class="ot">=</span> <span class="ot">{</span>vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">100</span><span class="ot">),</span> vec2<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span>
-                       vec2<span class="ot">(</span><span class="dv">100</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> vec2<span class="ot">(</span><span class="dv">100</span><span class="ot">,</span> <span class="dv">100</span><span class="ot">)},</span>
-               color <span class="ot">=</span> <span class="ot">{</span>vec3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span> vec3<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">),</span>
-                        vec3<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span> vec3<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">)}}</span>
-<span class="kw">local</span> win <span class="ot">=</span> am<span class="ot">.</span>window<span class="ot">{}</span>
-<span class="kw">local</span> prog <span class="ot">=</span> am<span class="ot">.</span>program<span class="ot">(</span><span class="st">[[</span>
-<span class="st">    precision highp float;</span>
-<span class="st">    attribute vec2 vert;</span>
-<span class="st">    attribute vec3 color;</span>
-<span class="st">    uniform mat4 MV;</span>
-<span class="st">    uniform mat4 P;</span>
-<span class="st">    varying vec3 v_color;</span>
-<span class="st">    void main() {</span>
-<span class="st">        v_color = color;</span>
-<span class="st">        gl_Position = P * MV * vec4(vert, 0.0, 1.0);</span>
-<span class="st">    }</span>
-<span class="st">]]</span><span class="ot">,</span> <span class="st">[[</span>
-<span class="st">    precision mediump float;</span>
-<span class="st">    varying vec3 v_color;</span>
-<span class="st">    void main() {</span>
-<span class="st">        gl_FragColor = vec4(v_color, 1.0);</span>
-<span class="st">    }</span>
-<span class="st">]]</span><span class="ot">)</span>
-win<span class="ot">.</span>scene <span class="ot">=</span> am<span class="ot">.</span>use_program<span class="ot">(</span>prog<span class="ot">)</span> <span class="ot">^</span> quads</code></pre></div>
+<div class="sourceCode" id="cb94"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb94-1"><a href="#cb94-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> quads <span class="op">=</span> am<span class="op">.</span>quads<span class="op">(</span><span class="dv">2</span><span class="op">,</span> <span class="op">{</span><span class="st">&quot;vert&quot;</span><span class="op">,</span> <span class="st">&quot;vec2&quot;</span><span class="op">,</span> <span class="st">&quot;color&quot;</span><span class="op">,</span> <span class="st">&quot;vec3&quot;</span><span class="op">})</span></span>
+<span id="cb94-2"><a href="#cb94-2" aria-hidden="true" tabindex="-1"></a>quads<span class="op">:</span>add_quad<span class="op">{</span>vert <span class="op">=</span> <span class="op">{</span>vec2<span class="op">(-</span><span class="dv">100</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> vec2<span class="op">(-</span><span class="dv">100</span><span class="op">,</span> <span class="op">-</span><span class="dv">100</span><span class="op">),</span></span>
+<span id="cb94-3"><a href="#cb94-3" aria-hidden="true" tabindex="-1"></a>                       vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="op">-</span><span class="dv">100</span><span class="op">),</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">)},</span></span>
+<span id="cb94-4"><a href="#cb94-4" aria-hidden="true" tabindex="-1"></a>               color <span class="op">=</span> <span class="op">{</span>vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> vec3<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span></span>
+<span id="cb94-5"><a href="#cb94-5" aria-hidden="true" tabindex="-1"></a>                        vec3<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span> vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">)}}</span></span>
+<span id="cb94-6"><a href="#cb94-6" aria-hidden="true" tabindex="-1"></a>quads<span class="op">:</span>add_quad<span class="op">{</span>vert <span class="op">=</span> <span class="op">{</span>vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">100</span><span class="op">),</span> vec2<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span></span>
+<span id="cb94-7"><a href="#cb94-7" aria-hidden="true" tabindex="-1"></a>                       vec2<span class="op">(</span><span class="dv">100</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> vec2<span class="op">(</span><span class="dv">100</span><span class="op">,</span> <span class="dv">100</span><span class="op">)},</span></span>
+<span id="cb94-8"><a href="#cb94-8" aria-hidden="true" tabindex="-1"></a>               color <span class="op">=</span> <span class="op">{</span>vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span> vec3<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">),</span></span>
+<span id="cb94-9"><a href="#cb94-9" aria-hidden="true" tabindex="-1"></a>                        vec3<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span> vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">)}}</span></span>
+<span id="cb94-10"><a href="#cb94-10" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> win <span class="op">=</span> am<span class="op">.</span>window<span class="op">{}</span></span>
+<span id="cb94-11"><a href="#cb94-11" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> prog <span class="op">=</span> am<span class="op">.</span>program<span class="op">(</span><span class="vs">[[</span></span>
+<span id="cb94-12"><a href="#cb94-12" aria-hidden="true" tabindex="-1"></a><span class="vs">    precision highp float;</span></span>
+<span id="cb94-13"><a href="#cb94-13" aria-hidden="true" tabindex="-1"></a><span class="vs">    attribute vec2 vert;</span></span>
+<span id="cb94-14"><a href="#cb94-14" aria-hidden="true" tabindex="-1"></a><span class="vs">    attribute vec3 color;</span></span>
+<span id="cb94-15"><a href="#cb94-15" aria-hidden="true" tabindex="-1"></a><span class="vs">    uniform mat4 MV;</span></span>
+<span id="cb94-16"><a href="#cb94-16" aria-hidden="true" tabindex="-1"></a><span class="vs">    uniform mat4 P;</span></span>
+<span id="cb94-17"><a href="#cb94-17" aria-hidden="true" tabindex="-1"></a><span class="vs">    varying vec3 v_color;</span></span>
+<span id="cb94-18"><a href="#cb94-18" aria-hidden="true" tabindex="-1"></a><span class="vs">    void main() {</span></span>
+<span id="cb94-19"><a href="#cb94-19" aria-hidden="true" tabindex="-1"></a><span class="vs">        v_color = color;</span></span>
+<span id="cb94-20"><a href="#cb94-20" aria-hidden="true" tabindex="-1"></a><span class="vs">        gl_Position = P * MV * vec4(vert, 0.0, 1.0);</span></span>
+<span id="cb94-21"><a href="#cb94-21" aria-hidden="true" tabindex="-1"></a><span class="vs">    }</span></span>
+<span id="cb94-22"><a href="#cb94-22" aria-hidden="true" tabindex="-1"></a><span class="vs">]]</span><span class="op">,</span> <span class="vs">[[</span></span>
+<span id="cb94-23"><a href="#cb94-23" aria-hidden="true" tabindex="-1"></a><span class="vs">    precision mediump float;</span></span>
+<span id="cb94-24"><a href="#cb94-24" aria-hidden="true" tabindex="-1"></a><span class="vs">    varying vec3 v_color;</span></span>
+<span id="cb94-25"><a href="#cb94-25" aria-hidden="true" tabindex="-1"></a><span class="vs">    void main() {</span></span>
+<span id="cb94-26"><a href="#cb94-26" aria-hidden="true" tabindex="-1"></a><span class="vs">        gl_FragColor = vec4(v_color, 1.0);</span></span>
+<span id="cb94-27"><a href="#cb94-27" aria-hidden="true" tabindex="-1"></a><span class="vs">    }</span></span>
+<span id="cb94-28"><a href="#cb94-28" aria-hidden="true" tabindex="-1"></a><span class="vs">]]</span><span class="op">)</span></span>
+<span id="cb94-29"><a href="#cb94-29" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene <span class="op">=</span> am<span class="op">.</span>use_program<span class="op">(</span>prog<span class="op">)</span> <span class="op">^</span> quads</span></code></pre></div>
 <p>The above program produces the following output:</p>
-<div class="figure">
-<img src="images/quads_example.png" />
-
-</div>
-<h3 id="am.postprocess" class="func-def">am.postprocess(settings)</h3>
-<p>Allows for post-processing of a scene. First the children of the <code>postprocess</code> node are rendered into a texture, then the texture is rendered to the entire window using a user-supplied shader program.</p>
-<p><code>settings</code> is a table containing any number of the following fields:</p>
+<p><img src="images/quads_example.png" /></p>
+<h3 class="func-def" id="am.postprocess">am.postprocess(settings)</h3>
+<p>Allows for post-processing of a scene. First the children of the
+<code>postprocess</code> node are rendered into a texture, then the
+texture is rendered to the entire window using a user-supplied shader
+program.</p>
+<p><code>settings</code> is a table containing any number of the
+following fields:</p>
 <ul>
-<li><code>width</code>: the width of the texture to render the children into. If omitted the window width is used.</li>
-<li><code>height</code>: the height of the texture to render the children into. If omitted the window height is used.</li>
-<li><code>minfilter</code>: the <a href="#texture.minfilter">minfilter</a> of the texture. The default is <code>&quot;nearest&quot;</code>.</li>
-<li><code>magfilter</code>: the <a href="#texture.magfilter">magfilter</a> of the texture. The default is <code>&quot;nearest&quot;</code>.</li>
-<li><code>depth_buffer</code>: whether there should be a depth buffer when rendering the scene. The default is false.</li>
-<li><code>stencil_buffer</code>: whether there should be a stencil buffer when rendering the scene. The default is false.</li>
-<li><code>clear_color</code>: The color to clear the texture to before rendering each frame (a <code>vec4</code>). The default is black.</li>
-<li><code>auto_clear</code>: Whether to automatically clear the texture before rendering each frame. The default is true.</li>
-<li><code>program</code>: The shader program to use to render the texture.</li>
+<li><code>width</code>: the width of the texture to render the children
+into. If omitted the window width is used.</li>
+<li><code>height</code>: the height of the texture to render the
+children into. If omitted the window height is used.</li>
+<li><code>minfilter</code>: the <a
+href="#texture.minfilter">minfilter</a> of the texture. The default is
+<code>"nearest"</code>.</li>
+<li><code>magfilter</code>: the <a
+href="#texture.magfilter">magfilter</a> of the texture. The default is
+<code>"nearest"</code>.</li>
+<li><code>depth_buffer</code>: whether there should be a depth buffer
+when rendering the scene. The default is false.</li>
+<li><code>stencil_buffer</code>: whether there should be a stencil
+buffer when rendering the scene. The default is false.</li>
+<li><code>clear_color</code>: The color to clear the texture to before
+rendering each frame (a <code>vec4</code>). The default is black.</li>
+<li><code>auto_clear</code>: Whether to automatically clear the texture
+before rendering each frame. The default is true.</li>
+<li><code>program</code>: The shader program to use to render the
+texture.</li>
 </ul>
-<p>The shader program should expect the following uniforms and attributes:</p>
-<div class="sourceCode"><pre class="sourceCode glsl"><code class="sourceCode glsl"><span class="kw">uniform</span> <span class="dt">sampler2D</span> tex;
-<span class="dt">attribute</span> <span class="dt">vec2</span> vert;
-<span class="dt">attribute</span> <span class="dt">vec2</span> uv;</code></pre></div>
-<p>Note that if either <code>width</code> or <code>height</code> are set then they must both be set.</p>
+<p>The shader program should expect the following uniforms and
+attributes:</p>
+<div class="sourceCode" id="cb95"><pre
+class="sourceCode glsl"><code class="sourceCode glsl"><span id="cb95-1"><a href="#cb95-1" aria-hidden="true" tabindex="-1"></a><span class="kw">uniform</span> <span class="dt">sampler2D</span> tex<span class="op">;</span></span>
+<span id="cb95-2"><a href="#cb95-2" aria-hidden="true" tabindex="-1"></a><span class="dt">attribute</span> <span class="dt">vec2</span> vert<span class="op">;</span></span>
+<span id="cb95-3"><a href="#cb95-3" aria-hidden="true" tabindex="-1"></a><span class="dt">attribute</span> <span class="dt">vec2</span> uv<span class="op">;</span></span></code></pre></div>
+<p>Note that if either <code>width</code> or <code>height</code> are set
+then they must both be set.</p>
 <p>Fields:</p>
 <ul>
-<li><code>clear_color</code>: The color to clear the texture to before rendering each frame (a <code>vec4</code>). Updatable.</li>
-<li><code>auto_clear</code>: Whether to automatically clear the texture before rendering each frame. Updatable.</li>
-<li><code>program</code>: The shader program to use to render the texture. Updatable.</li>
+<li><code>clear_color</code>: The color to clear the texture to before
+rendering each frame (a <code>vec4</code>). Updatable.</li>
+<li><code>auto_clear</code>: Whether to automatically clear the texture
+before rendering each frame. Updatable.</li>
+<li><code>program</code>: The shader program to use to render the
+texture. Updatable.</li>
 </ul>
 <p>Methods:</p>
 <ul>
 <li><code>clear()</code>: Clear the texture manually.</li>
 </ul>
-<p>Default tag: <code>&quot;postprocess&quot;</code>.</p>
+<p>Default tag: <code>"postprocess"</code>.</p>
 <h2 id="creating-custom-scene-nodes">Creating custom scene nodes</h2>
-<p>Creating a custom leaf node is relatively simple: just create a function that constructs the graph you want and return it.</p>
-<p>You can add custom methods by setting the appropriate fields on the root node of the returned graph (any node can have any number of custom fields set on it, as long as they don't clash with pre-defined fields).</p>
+<p>Creating a custom leaf node is relatively simple: just create a
+function that constructs the graph you want and return it.</p>
+<p>You can add custom methods by setting the appropriate fields on the
+root node of the returned graph (any node can have any number of custom
+fields set on it, as long as they don’t clash with pre-defined
+fields).</p>
 <p>If you define methods of the form:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">function</span> node:get_FIELD<span class="ot">()</span>
-    <span class="ot">...</span>
-<span class="kw">end</span>
-
-<span class="kw">function</span> node:set_FIELD<span class="ot">(</span>val<span class="ot">)</span>
-    <span class="ot">...</span>
-<span class="kw">end</span></code></pre></div>
-<p>Then you will be able to access <code>FIELD</code> as if it's a regular field and the appropriate access method will be called.</p>
+<div class="sourceCode" id="cb96"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb96-1"><a href="#cb96-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> node<span class="op">:</span>get_FIELD<span class="op">()</span></span>
+<span id="cb96-2"><a href="#cb96-2" aria-hidden="true" tabindex="-1"></a>    <span class="op">...</span></span>
+<span id="cb96-3"><a href="#cb96-3" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb96-4"><a href="#cb96-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb96-5"><a href="#cb96-5" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> node<span class="op">:</span>set_FIELD<span class="op">(</span>val<span class="op">)</span></span>
+<span id="cb96-6"><a href="#cb96-6" aria-hidden="true" tabindex="-1"></a>    <span class="op">...</span></span>
+<span id="cb96-7"><a href="#cb96-7" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
+<p>Then you will be able to access <code>FIELD</code> as if it’s a
+regular field and the appropriate access method will be called.</p>
 <p>For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">node<span class="ot">.</span>FIELD <span class="ot">=</span> val</code></pre></div>
+<div class="sourceCode" id="cb97"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb97-1"><a href="#cb97-1" aria-hidden="true" tabindex="-1"></a>node<span class="op">.</span><span class="cn">FIELD</span> <span class="op">=</span> val</span></code></pre></div>
 <p>will be equivalent to:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">node:set_FIELD<span class="ot">(</span>val<span class="ot">)</span></code></pre></div>
-<p>If you want a readonly field, just define the <code>get_FIELD</code> method and not the <code>set_FIELD</code> method.</p>
-<p>The <a href="#am.text"><code>am.text</code></a>, <a href="#am.sprite"><code>am.sprite</code></a> and <a href="#am.particles2d"><code>am.particles2d</code></a> nodes are all implemented this way. Their source is <a href="https://github.com/ianmaclarty/amulet/blob/master/lua/text.lua">here</a> and <a href="https://github.com/ianmaclarty/amulet/blob/master/lua/particles.lua">here</a>.</p>
-<p>If you want to create a non-leaf node, then you need to use the <code>am.wrap</code> function:</p>
-<h3 id="am.wrap" class="func-def">am.wrap(node)</h3>
-<p>This &quot;wraps&quot; <code>node</code> inside a special type of node called a <em>wrap node</em>.</p>
-<p>When a wrap node is rendered it renders the inner node. However any nodes added as children of a wrap node are also added to the leaf node(s) of the inner node.</p>
-<p>For example suppose we want to create a transformation node called <code>move_and_rotate</code> that does both a translation and a rotation:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">function</span> move_and_rotate<span class="ot">(</span>x<span class="ot">,</span> y<span class="ot">,</span> degrees<span class="ot">)</span>
-    <span class="kw">return</span> am<span class="ot">.</span>translate<span class="ot">(</span>x<span class="ot">,</span> y<span class="ot">)</span> <span class="ot">^</span> am<span class="ot">.</span>rotate<span class="ot">(</span><span class="fu">math.rad</span><span class="ot">(</span>degrees<span class="ot">))</span>
-<span class="kw">end</span></code></pre></div>
-<p>We would like to be able to create such a node and add children to it. Like so:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> mvrot <span class="ot">=</span> move_and_rotate<span class="ot">(</span><span class="dv">10</span><span class="ot">,</span> <span class="dv">20</span><span class="ot">,</span> <span class="dv">60</span><span class="ot">)</span>
-mvrot:append<span class="ot">(</span>am<span class="ot">.</span>rect<span class="ot">(-</span><span class="dv">10</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">10</span><span class="ot">,</span> <span class="dv">10</span><span class="ot">,</span> <span class="dv">10</span><span class="ot">))</span></code></pre></div>
-<p>However what this will do is add the <code>rect</code> node as a child of the <code>translate</code> node returned by <code>move_and_rotate</code>.</p>
+<div class="sourceCode" id="cb98"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb98-1"><a href="#cb98-1" aria-hidden="true" tabindex="-1"></a>node<span class="op">:</span>set_FIELD<span class="op">(</span>val<span class="op">)</span></span></code></pre></div>
+<p>If you want a readonly field, just define the <code>get_FIELD</code>
+method and not the <code>set_FIELD</code> method.</p>
+<p>The <a href="#am.text"><code>am.text</code></a>, <a
+href="#am.sprite"><code>am.sprite</code></a> and <a
+href="#am.particles2d"><code>am.particles2d</code></a> nodes are all
+implemented this way. Their source is <a
+href="https://github.com/ianmaclarty/amulet/blob/master/lua/text.lua">here</a>
+and <a
+href="https://github.com/ianmaclarty/amulet/blob/master/lua/particles.lua">here</a>.</p>
+<p>If you want to create a non-leaf node, then you need to use the
+<code>am.wrap</code> function:</p>
+<h3 class="func-def" id="am.wrap">am.wrap(node)</h3>
+<p>This “wraps” <code>node</code> inside a special type of node called a
+<em>wrap node</em>.</p>
+<p>When a wrap node is rendered it renders the inner node. However any
+nodes added as children of a wrap node are also added to the leaf
+node(s) of the inner node.</p>
+<p>For example suppose we want to create a transformation node called
+<code>move_and_rotate</code> that does both a translation and a
+rotation:</p>
+<div class="sourceCode" id="cb99"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb99-1"><a href="#cb99-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> move_and_rotate<span class="op">(</span>x<span class="op">,</span> y<span class="op">,</span> degrees<span class="op">)</span></span>
+<span id="cb99-2"><a href="#cb99-2" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> am<span class="op">.</span>translate<span class="op">(</span>x<span class="op">,</span> y<span class="op">)</span> <span class="op">^</span> am<span class="op">.</span>rotate<span class="op">(</span><span class="fu">math.rad</span><span class="op">(</span>degrees<span class="op">))</span></span>
+<span id="cb99-3"><a href="#cb99-3" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
+<p>We would like to be able to create such a node and add children to
+it. Like so:</p>
+<div class="sourceCode" id="cb100"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb100-1"><a href="#cb100-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> mvrot <span class="op">=</span> move_and_rotate<span class="op">(</span><span class="dv">10</span><span class="op">,</span> <span class="dv">20</span><span class="op">,</span> <span class="dv">60</span><span class="op">)</span></span>
+<span id="cb100-2"><a href="#cb100-2" aria-hidden="true" tabindex="-1"></a>mvrot<span class="op">:</span>append<span class="op">(</span>am<span class="op">.</span>rect<span class="op">(-</span><span class="dv">10</span><span class="op">,</span> <span class="op">-</span><span class="dv">10</span><span class="op">,</span> <span class="dv">10</span><span class="op">,</span> <span class="dv">10</span><span class="op">))</span></span></code></pre></div>
+<p>However what this will do is add the <code>rect</code> node as a
+child of the <code>translate</code> node returned by
+<code>move_and_rotate</code>.</p>
 <p>Instead we need to do:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">mvrot<span class="st">&quot;rotate&quot;</span>:append<span class="ot">(</span>am<span class="ot">.</span>rect<span class="ot">(-</span><span class="dv">10</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">10</span><span class="ot">,</span> <span class="dv">10</span><span class="ot">,</span> <span class="dv">10</span><span class="ot">))</span></code></pre></div>
+<div class="sourceCode" id="cb101"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb101-1"><a href="#cb101-1" aria-hidden="true" tabindex="-1"></a>mvrot<span class="st">&quot;rotate&quot;</span><span class="op">:</span>append<span class="op">(</span>am<span class="op">.</span>rect<span class="op">(-</span><span class="dv">10</span><span class="op">,</span> <span class="op">-</span><span class="dv">10</span><span class="op">,</span> <span class="dv">10</span><span class="op">,</span> <span class="dv">10</span><span class="op">))</span></span></code></pre></div>
 <p>which is a bit clunky.</p>
 <p>A wrap node solves this problem:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">function</span> move_and_rotate<span class="ot">(</span>x<span class="ot">,</span> y<span class="ot">,</span> degrees<span class="ot">)</span>
-    <span class="kw">return</span> am<span class="ot">.</span>wrap<span class="ot">(</span>am<span class="ot">.</span>translate<span class="ot">(</span>x<span class="ot">,</span> y<span class="ot">)</span> <span class="ot">^</span> am<span class="ot">.</span>rotate<span class="ot">(</span><span class="fu">math.rad</span><span class="ot">(</span>degrees<span class="ot">)))</span>
-<span class="kw">end</span>
-<span class="kw">local</span> mvrot <span class="ot">=</span> move_and_rotate<span class="ot">(</span><span class="dv">10</span><span class="ot">,</span> <span class="dv">20</span><span class="ot">,</span> <span class="dv">60</span><span class="ot">)</span>
-mvrot:append<span class="ot">(</span>am<span class="ot">.</span>rect<span class="ot">(-</span><span class="dv">10</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">10</span><span class="ot">,</span> <span class="dv">10</span><span class="ot">,</span> <span class="dv">10</span><span class="ot">))</span></code></pre></div>
-<p>For completeness here we add some fields to set the x, y and degrees properties of our new node:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">function</span> move_and_rotate<span class="ot">(</span>x<span class="ot">,</span> y<span class="ot">,</span> degrees<span class="ot">)</span>
-    <span class="kw">local</span> inner <span class="ot">=</span> am<span class="ot">.</span>translate<span class="ot">(</span>x<span class="ot">,</span> y<span class="ot">)</span> <span class="ot">^</span> am<span class="ot">.</span>rotate<span class="ot">(</span><span class="fu">math.rad</span><span class="ot">(</span>degrees<span class="ot">))</span>
-    <span class="kw">local</span> wrapped <span class="ot">=</span> am<span class="ot">.</span>wrap<span class="ot">(</span>inner<span class="ot">)</span>
-    <span class="kw">function</span> wrapped:get_x<span class="ot">()</span>
-        <span class="kw">return</span> x
-    <span class="kw">end</span>
-    <span class="kw">function</span> wrapped:set_x<span class="ot">(</span>v<span class="ot">)</span>
-        x <span class="ot">=</span> v
-        inner<span class="ot">.</span>position2d <span class="ot">=</span> vec2<span class="ot">(</span>x<span class="ot">,</span> y<span class="ot">)</span>
-    <span class="kw">end</span>
-    <span class="kw">function</span> wrapped:get_y<span class="ot">()</span>
-        <span class="kw">return</span> y
-    <span class="kw">end</span>
-    <span class="kw">function</span> wrapped:set_y<span class="ot">(</span>v<span class="ot">)</span>
-        y <span class="ot">=</span> v
-        inner<span class="ot">.</span>position2d <span class="ot">=</span> vec2<span class="ot">(</span>x<span class="ot">,</span> y<span class="ot">)</span>
-    <span class="kw">end</span>
-    <span class="kw">function</span> wrapped:get_degrees<span class="ot">()</span>
-        <span class="kw">return</span> degrees
-    <span class="kw">end</span>
-    <span class="kw">function</span> wrapped:set_degrees<span class="ot">(</span>v<span class="ot">)</span>
-        degrees <span class="ot">=</span> v
-        inner<span class="st">&quot;rotate&quot;</span><span class="ot">.</span>angle <span class="ot">=</span> <span class="fu">math.rad</span><span class="ot">(</span>degrees<span class="ot">)</span>
-    <span class="kw">end</span>
-    <span class="kw">return</span> wrapped
-<span class="kw">end</span>
-<span class="kw">local</span> mvrot <span class="ot">=</span> move_and_rotate<span class="ot">(-</span><span class="dv">100</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">100</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">)</span>
-mvrot:append<span class="ot">(</span>am<span class="ot">.</span>rect<span class="ot">(-</span><span class="dv">50</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">50</span><span class="ot">,</span> <span class="dv">50</span><span class="ot">,</span> <span class="dv">50</span><span class="ot">))</span>
-mvrot<span class="ot">.</span>x <span class="ot">=</span> <span class="dv">100</span>
-mvrot<span class="ot">.</span>y <span class="ot">=</span> <span class="dv">100</span>
-mvrot<span class="ot">.</span>degrees <span class="ot">=</span> <span class="dv">45</span></code></pre></div>
+<div class="sourceCode" id="cb102"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb102-1"><a href="#cb102-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> move_and_rotate<span class="op">(</span>x<span class="op">,</span> y<span class="op">,</span> degrees<span class="op">)</span></span>
+<span id="cb102-2"><a href="#cb102-2" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> am<span class="op">.</span>wrap<span class="op">(</span>am<span class="op">.</span>translate<span class="op">(</span>x<span class="op">,</span> y<span class="op">)</span> <span class="op">^</span> am<span class="op">.</span>rotate<span class="op">(</span><span class="fu">math.rad</span><span class="op">(</span>degrees<span class="op">)))</span></span>
+<span id="cb102-3"><a href="#cb102-3" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb102-4"><a href="#cb102-4" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> mvrot <span class="op">=</span> move_and_rotate<span class="op">(</span><span class="dv">10</span><span class="op">,</span> <span class="dv">20</span><span class="op">,</span> <span class="dv">60</span><span class="op">)</span></span>
+<span id="cb102-5"><a href="#cb102-5" aria-hidden="true" tabindex="-1"></a>mvrot<span class="op">:</span>append<span class="op">(</span>am<span class="op">.</span>rect<span class="op">(-</span><span class="dv">10</span><span class="op">,</span> <span class="op">-</span><span class="dv">10</span><span class="op">,</span> <span class="dv">10</span><span class="op">,</span> <span class="dv">10</span><span class="op">))</span></span></code></pre></div>
+<p>For completeness here we add some fields to set the x, y and degrees
+properties of our new node:</p>
+<div class="sourceCode" id="cb103"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb103-1"><a href="#cb103-1" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> move_and_rotate<span class="op">(</span>x<span class="op">,</span> y<span class="op">,</span> degrees<span class="op">)</span></span>
+<span id="cb103-2"><a href="#cb103-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">local</span> inner <span class="op">=</span> am<span class="op">.</span>translate<span class="op">(</span>x<span class="op">,</span> y<span class="op">)</span> <span class="op">^</span> am<span class="op">.</span>rotate<span class="op">(</span><span class="fu">math.rad</span><span class="op">(</span>degrees<span class="op">))</span></span>
+<span id="cb103-3"><a href="#cb103-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">local</span> wrapped <span class="op">=</span> am<span class="op">.</span>wrap<span class="op">(</span>inner<span class="op">)</span></span>
+<span id="cb103-4"><a href="#cb103-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">function</span> wrapped<span class="op">:</span>get_x<span class="op">()</span></span>
+<span id="cb103-5"><a href="#cb103-5" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> x</span>
+<span id="cb103-6"><a href="#cb103-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">end</span></span>
+<span id="cb103-7"><a href="#cb103-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">function</span> wrapped<span class="op">:</span>set_x<span class="op">(</span>v<span class="op">)</span></span>
+<span id="cb103-8"><a href="#cb103-8" aria-hidden="true" tabindex="-1"></a>        x <span class="op">=</span> v</span>
+<span id="cb103-9"><a href="#cb103-9" aria-hidden="true" tabindex="-1"></a>        inner<span class="op">.</span>position2d <span class="op">=</span> vec2<span class="op">(</span>x<span class="op">,</span> y<span class="op">)</span></span>
+<span id="cb103-10"><a href="#cb103-10" aria-hidden="true" tabindex="-1"></a>    <span class="kw">end</span></span>
+<span id="cb103-11"><a href="#cb103-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">function</span> wrapped<span class="op">:</span>get_y<span class="op">()</span></span>
+<span id="cb103-12"><a href="#cb103-12" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> y</span>
+<span id="cb103-13"><a href="#cb103-13" aria-hidden="true" tabindex="-1"></a>    <span class="kw">end</span></span>
+<span id="cb103-14"><a href="#cb103-14" aria-hidden="true" tabindex="-1"></a>    <span class="kw">function</span> wrapped<span class="op">:</span>set_y<span class="op">(</span>v<span class="op">)</span></span>
+<span id="cb103-15"><a href="#cb103-15" aria-hidden="true" tabindex="-1"></a>        y <span class="op">=</span> v</span>
+<span id="cb103-16"><a href="#cb103-16" aria-hidden="true" tabindex="-1"></a>        inner<span class="op">.</span>position2d <span class="op">=</span> vec2<span class="op">(</span>x<span class="op">,</span> y<span class="op">)</span></span>
+<span id="cb103-17"><a href="#cb103-17" aria-hidden="true" tabindex="-1"></a>    <span class="kw">end</span></span>
+<span id="cb103-18"><a href="#cb103-18" aria-hidden="true" tabindex="-1"></a>    <span class="kw">function</span> wrapped<span class="op">:</span>get_degrees<span class="op">()</span></span>
+<span id="cb103-19"><a href="#cb103-19" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> degrees</span>
+<span id="cb103-20"><a href="#cb103-20" aria-hidden="true" tabindex="-1"></a>    <span class="kw">end</span></span>
+<span id="cb103-21"><a href="#cb103-21" aria-hidden="true" tabindex="-1"></a>    <span class="kw">function</span> wrapped<span class="op">:</span>set_degrees<span class="op">(</span>v<span class="op">)</span></span>
+<span id="cb103-22"><a href="#cb103-22" aria-hidden="true" tabindex="-1"></a>        degrees <span class="op">=</span> v</span>
+<span id="cb103-23"><a href="#cb103-23" aria-hidden="true" tabindex="-1"></a>        inner<span class="st">&quot;rotate&quot;</span><span class="op">.</span>angle <span class="op">=</span> <span class="fu">math.rad</span><span class="op">(</span>degrees<span class="op">)</span></span>
+<span id="cb103-24"><a href="#cb103-24" aria-hidden="true" tabindex="-1"></a>    <span class="kw">end</span></span>
+<span id="cb103-25"><a href="#cb103-25" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> wrapped</span>
+<span id="cb103-26"><a href="#cb103-26" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb103-27"><a href="#cb103-27" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> mvrot <span class="op">=</span> move_and_rotate<span class="op">(-</span><span class="dv">100</span><span class="op">,</span> <span class="op">-</span><span class="dv">100</span><span class="op">,</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb103-28"><a href="#cb103-28" aria-hidden="true" tabindex="-1"></a>mvrot<span class="op">:</span>append<span class="op">(</span>am<span class="op">.</span>rect<span class="op">(-</span><span class="dv">50</span><span class="op">,</span> <span class="op">-</span><span class="dv">50</span><span class="op">,</span> <span class="dv">50</span><span class="op">,</span> <span class="dv">50</span><span class="op">))</span></span>
+<span id="cb103-29"><a href="#cb103-29" aria-hidden="true" tabindex="-1"></a>mvrot<span class="op">.</span>x <span class="op">=</span> <span class="dv">100</span></span>
+<span id="cb103-30"><a href="#cb103-30" aria-hidden="true" tabindex="-1"></a>mvrot<span class="op">.</span>y <span class="op">=</span> <span class="dv">100</span></span>
+<span id="cb103-31"><a href="#cb103-31" aria-hidden="true" tabindex="-1"></a>mvrot<span class="op">.</span>degrees <span class="op">=</span> <span class="dv">45</span></span></code></pre></div>
 <p>There are some caveats when using wrap nodes:</p>
 <ul>
-<li>The inner node is not considered part of the scene graph for the purpose of running actions. So any actions need to be attached to the wrap node, not the inner node.</li>
+<li>The inner node is not considered part of the scene graph for the
+purpose of running actions. So any actions need to be attached to the
+wrap node, not the inner node.</li>
 <li>Tag search functions do not search the inner node.</li>
 </ul>
-<p>The <a href="#am.postprocess"><code>am.postprocess</code></a> node is implemented using a wrap node. You can view it's implementation <a href="https://github.com/ianmaclarty/amulet/blob/master/lua/postprocess.lua">here</a>.</p>
+<p>The <a href="#am.postprocess"><code>am.postprocess</code></a> node is
+implemented using a wrap node. You can view it’s implementation <a
+href="https://github.com/ianmaclarty/amulet/blob/master/lua/postprocess.lua">here</a>.</p>
 <h1 id="shader-programs">Shader programs</h1>
 <h2 id="compiling-a-shader-program">Compiling a shader program</h2>
-<h3 id="am.program" class="func-def">am.program(vertex_shader, fragment_shader)</h3>
-<p>Compiles and returns a shader program for use with <a href="#am.use_program"><code>am.use_program</code></a> nodes.</p>
-<p><code>vertex_shader</code> and <code>fragment_shader</code> should be the sources for the vertex and fragment shaders in the OpenGL ES shader language version 1. This is the same shader language supported by WebGL 1.</p>
+<h3 class="func-def" id="am.program">am.program(vertex_shader,
+fragment_shader)</h3>
+<p>Compiles and returns a shader program for use with <a
+href="#am.use_program"><code>am.use_program</code></a> nodes.</p>
+<p><code>vertex_shader</code> and <code>fragment_shader</code> should be
+the sources for the vertex and fragment shaders in the OpenGL ES shader
+language version 1. This is the same shader language supported by WebGL
+1.</p>
 <p>Example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> vert_shader <span class="ot">=</span> <span class="st">[[</span>
-<span class="st">    precision highp float;</span>
-<span class="st">    attribute vec3 vert;</span>
-<span class="st">    uniform mat4 MV;</span>
-<span class="st">    uniform mat4 P;</span>
-<span class="st">    void main() {</span>
-<span class="st">        gl_Position = P * MV * vec4(vert, 1);</span>
-<span class="st">    }</span>
-<span class="st">]]</span>
-<span class="kw">local</span> frag_shader <span class="ot">=</span> <span class="st">[[</span>
-<span class="st">    precision mediump float;</span>
-<span class="st">    void main() {</span>
-<span class="st">        gl_FragColor = vec4(1.0, 0, 0.5, 1.0);</span>
-<span class="st">    }</span>
-<span class="st">]]</span>
-<span class="kw">local</span> prog <span class="ot">=</span> am<span class="ot">.</span>program<span class="ot">(</span>vert_shader<span class="ot">,</span> frag_shader<span class="ot">)</span></code></pre></div>
+<div class="sourceCode" id="cb104"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb104-1"><a href="#cb104-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> vert_shader <span class="op">=</span> <span class="vs">[[</span></span>
+<span id="cb104-2"><a href="#cb104-2" aria-hidden="true" tabindex="-1"></a><span class="vs">    precision highp float;</span></span>
+<span id="cb104-3"><a href="#cb104-3" aria-hidden="true" tabindex="-1"></a><span class="vs">    attribute vec3 vert;</span></span>
+<span id="cb104-4"><a href="#cb104-4" aria-hidden="true" tabindex="-1"></a><span class="vs">    uniform mat4 MV;</span></span>
+<span id="cb104-5"><a href="#cb104-5" aria-hidden="true" tabindex="-1"></a><span class="vs">    uniform mat4 P;</span></span>
+<span id="cb104-6"><a href="#cb104-6" aria-hidden="true" tabindex="-1"></a><span class="vs">    void main() {</span></span>
+<span id="cb104-7"><a href="#cb104-7" aria-hidden="true" tabindex="-1"></a><span class="vs">        gl_Position = P * MV * vec4(vert, 1);</span></span>
+<span id="cb104-8"><a href="#cb104-8" aria-hidden="true" tabindex="-1"></a><span class="vs">    }</span></span>
+<span id="cb104-9"><a href="#cb104-9" aria-hidden="true" tabindex="-1"></a><span class="vs">]]</span></span>
+<span id="cb104-10"><a href="#cb104-10" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> frag_shader <span class="op">=</span> <span class="vs">[[</span></span>
+<span id="cb104-11"><a href="#cb104-11" aria-hidden="true" tabindex="-1"></a><span class="vs">    precision mediump float;</span></span>
+<span id="cb104-12"><a href="#cb104-12" aria-hidden="true" tabindex="-1"></a><span class="vs">    void main() {</span></span>
+<span id="cb104-13"><a href="#cb104-13" aria-hidden="true" tabindex="-1"></a><span class="vs">        gl_FragColor = vec4(1.0, 0, 0.5, 1.0);</span></span>
+<span id="cb104-14"><a href="#cb104-14" aria-hidden="true" tabindex="-1"></a><span class="vs">    }</span></span>
+<span id="cb104-15"><a href="#cb104-15" aria-hidden="true" tabindex="-1"></a><span class="vs">]]</span></span>
+<span id="cb104-16"><a href="#cb104-16" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> prog <span class="op">=</span> am<span class="op">.</span>program<span class="op">(</span>vert_shader<span class="op">,</span> frag_shader<span class="op">)</span></span></code></pre></div>
 <h1 id="image-buffers">Image buffers</h1>
-<p>An image buffer represents a 2D image in memory. Each pixel occupies 4 bytes with 1 byte per channel (RGBA). The data for the image buffer is stored in an <a href="#am.buffer"><code>am.buffer</code></a>.</p>
+<p>An image buffer represents a 2D image in memory. Each pixel occupies
+4 bytes with 1 byte per channel (RGBA). The data for the image buffer is
+stored in an <a href="#am.buffer"><code>am.buffer</code></a>.</p>
 <h2 id="creating-image-buffers">Creating image buffers</h2>
-<h3 id="am.image_buffer" class="func-def">am.image_buffer([buffer, ] width [, height])</h3>
-<p>Creates an image buffer of the given width and height. If <code>height</code> is omitted it is the same as <code>width</code> (the image is square).</p>
-<p>If a <code>buffer</code> (created using <a href="#am.buffer"><code>am.buffer</code></a>) is given, it is used as the image buffer. It must have the correct size, which is <code>4 * width * height</code>. If <code>buffer</code> is omitted a new one is created.</p>
+<h3 class="func-def" id="am.image_buffer">am.image_buffer([buffer, ]
+width [, height])</h3>
+<p>Creates an image buffer of the given width and height. If
+<code>height</code> is omitted it is the same as <code>width</code> (the
+image is square).</p>
+<p>If a <code>buffer</code> (created using <a
+href="#am.buffer"><code>am.buffer</code></a>) is given, it is used as
+the image buffer. It must have the correct size, which is
+<code>4 * width * height</code>. If <code>buffer</code> is omitted a new
+one is created.</p>
 <p>Fields:</p>
 <ul>
 <li><code>width</code>: the image width.</li>
 <li><code>height</code>: the image height.</li>
 <li><code>buffer</code>: the raw data buffer.</li>
 </ul>
-<h3 id="am.load_image" class="func-def">am.load_image(filename)</h3>
-<p>Loads the given image file and returns a new image buffer. Only <code>.png</code> and <code>.jpg</code> files are supported. Returns <code>nil</code> if the file was not found.</p>
+<h3 class="func-def" id="am.load_image">am.load_image(filename)</h3>
+<p>Loads the given image file and returns a new image buffer. Only
+<code>.png</code> and <code>.jpg</code> files are supported. Returns
+<code>nil</code> if the file was not found.</p>
 <h2 id="saving-images">Saving images</h2>
-<h3 id="image_buffer:save_png" class="method-def">image_buffer:save_png(filename)</h3>
+<h3 class="method-def"
+id="image_buffer:save_png">image_buffer:save_png(filename)</h3>
 <p>Saves the given image as a png in <code>filename</code>.</p>
 <h2 id="pasting-images">Pasting images</h2>
-<h3 id="image_buffer:paste" class="method-def">image_buffer:paste(src, x, y)</h3>
-<p>Pastes one image into another such that the bottom-left corner of the source image is at the given pixel coordinate in the target image. The bottom-left pixel of the target image has coordinate (1, 1).</p>
+<h3 class="method-def" id="image_buffer:paste">image_buffer:paste(src,
+x, y)</h3>
+<p>Pastes one image into another such that the bottom-left corner of the
+source image is at the given pixel coordinate in the target image. The
+bottom-left pixel of the target image has coordinate (1, 1).</p>
 <h2 id="decodingencoding-pngs">Decoding/encoding PNGs</h2>
-<h3 id="am.encode_png" class="func-def">am.encode_png(image_buffer)</h3>
-<p>Returns a raw buffer containing the png encoding of the given image.</p>
-<h3 id="am.decode_png" class="func-def">am.decode_png(buffer)</h3>
-<p>Converts the raw buffer, which should be a png encoding of an image, into an image buffer.</p>
+<h3 class="func-def" id="am.encode_png">am.encode_png(image_buffer)</h3>
+<p>Returns a raw buffer containing the png encoding of the given
+image.</p>
+<h3 class="func-def" id="am.decode_png">am.decode_png(buffer)</h3>
+<p>Converts the raw buffer, which should be a png encoding of an image,
+into an image buffer.</p>
 <h1 id="textures">Textures</h1>
-<p>Textures are 2D images that can be used as input to shader programs when bound to a <code>sampler2D</code> uniform.</p>
-<p>They can also be rendered to via <a href="#am.framebuffer">framebuffers</a>.</p>
-<p>A texture may optionally have a backing <a href="#image-buffers">image buffer</a>. If a texture has a backing image buffer, then any changes to the image buffer will be automatically transferred to the texture.</p>
+<p>Textures are 2D images that can be used as input to shader programs
+when bound to a <code>sampler2D</code> uniform.</p>
+<p>They can also be rendered to via <a
+href="#am.framebuffer">framebuffers</a>.</p>
+<p>A texture may optionally have a backing <a
+href="#image-buffers">image buffer</a>. If a texture has a backing image
+buffer, then any changes to the image buffer will be automatically
+transferred to the texture.</p>
 <p>Textures always have 4 channels (RGBA) with 1 byte per channel.</p>
 <h2 id="creating-a-texture">Creating a texture</h2>
-<h3 id="am.texture2d" class="func-def">am.texture2d(width [, height])</h3>
-<p>Creates a texture of the given width and height without a backing image buffer.</p>
-<h3 id="am.texture2dimage_buffer" class="func-def">am.texture2d(image_buffer)</h3>
-<p>Creates a texture using the given image buffer as the backing image buffer.</p>
-<h3 id="am.texture2dfilename" class="func-def">am.texture2d(filename)</h3>
-<p>This is shorthand for <code>am.texture2d(am.load_image(filename))</code>.</p>
+<h3 class="func-def" id="am.texture2d">am.texture2d(width [,
+height])</h3>
+<p>Creates a texture of the given width and height without a backing
+image buffer.</p>
+<h3 class="func-def"
+id="am.texture2dimage_buffer">am.texture2d(image_buffer)</h3>
+<p>Creates a texture using the given image buffer as the backing image
+buffer.</p>
+<h3 class="func-def"
+id="am.texture2dfilename">am.texture2d(filename)</h3>
+<p>This is shorthand for
+<code>am.texture2d(am.load_image(filename))</code>.</p>
 <h2 id="texture-fields">Texture fields</h2>
-<h3 id="texture.width" class="field-def">texture.width</h3>
+<h3 class="field-def" id="texture.width">texture.width</h3>
 <p>Readonly.</p>
-<h3 id="texture.height" class="field-def">texture.height</h3>
+<h3 class="field-def" id="texture.height">texture.height</h3>
 <p>Readonly.</p>
-<h3 id="texture.image_buffer" class="field-def">texture.image_buffer</h3>
-<p>The backing image buffer or <code>nil</code> if there isn't one.</p>
+<h3 class="field-def"
+id="texture.image_buffer">texture.image_buffer</h3>
+<p>The backing image buffer or <code>nil</code> if there isn’t one.</p>
 <p>Readonly.</p>
-<h3 id="texture.minfilter" class="field-def">texture.minfilter</h3>
-<p>Defines the minification filter which is applied when the texture's pixels are smaller that the screen's pixels.</p>
+<h3 class="field-def" id="texture.minfilter">texture.minfilter</h3>
+<p>Defines the minification filter which is applied when the texture’s
+pixels are smaller that the screen’s pixels.</p>
 <p>The allowed values are:</p>
 <ul>
-<li><code>&quot;nearest&quot;</code> (the default)</li>
-<li><code>&quot;linear&quot;</code></li>
-<li><code>&quot;nearest_mipmap_nearest&quot;</code></li>
-<li><code>&quot;linear_mipmap_nearest&quot;</code></li>
-<li><code>&quot;nearest_mipmap_linear&quot;</code></li>
-<li><code>&quot;linear_mipmap_linear&quot;</code></li>
+<li><code>"nearest"</code> (the default)</li>
+<li><code>"linear"</code></li>
+<li><code>"nearest_mipmap_nearest"</code></li>
+<li><code>"linear_mipmap_nearest"</code></li>
+<li><code>"nearest_mipmap_linear"</code></li>
+<li><code>"linear_mipmap_linear"</code></li>
 </ul>
-<p>If one of the mipmap filters is used a mipmap will be automatically generated.</p>
+<p>If one of the mipmap filters is used a mipmap will be automatically
+generated.</p>
 <p>Updatable.</p>
-<h3 id="texture.magfilter" class="field-def">texture.magfilter</h3>
-<p>Defines the magnification filter which is applied when the texture's pixels are larger that the screen's pixels.</p>
+<h3 class="field-def" id="texture.magfilter">texture.magfilter</h3>
+<p>Defines the magnification filter which is applied when the texture’s
+pixels are larger that the screen’s pixels.</p>
 <p>The allowed values are:</p>
 <ul>
-<li><code>&quot;nearest&quot;</code> (the default)</li>
-<li><code>&quot;linear&quot;</code></li>
+<li><code>"nearest"</code> (the default)</li>
+<li><code>"linear"</code></li>
 </ul>
 <p>Updatable.</p>
-<h3 id="texture.filter" class="field-def">texture.filter</h3>
-<p>This field can be used to set both the minification and magnification fields. The allowed values are:</p>
+<h3 class="field-def" id="texture.filter">texture.filter</h3>
+<p>This field can be used to set both the minification and magnification
+fields. The allowed values are:</p>
 <ul>
-<li><code>&quot;nearest&quot;</code></li>
-<li><code>&quot;linear&quot;</code></li>
+<li><code>"nearest"</code></li>
+<li><code>"linear"</code></li>
 </ul>
 <p>Updatable.</p>
-<h3 id="texture.swrap" class="field-def">texture.swrap</h3>
-<p>Sets the wrapping mode in the x direction. The allowed values are:</p>
+<h3 class="field-def" id="texture.swrap">texture.swrap</h3>
+<p>Sets the wrapping mode in the x direction. The allowed values
+are:</p>
 <ul>
-<li><code>&quot;clamp_to_edge&quot;</code> (the default)</li>
-<li><code>&quot;repeat&quot;</code></li>
-<li><code>&quot;mirrored_repeat&quot;</code></li>
+<li><code>"clamp_to_edge"</code> (the default)</li>
+<li><code>"repeat"</code></li>
+<li><code>"mirrored_repeat"</code></li>
 </ul>
-<p>Note that the texture width must be a power of 2 if either <code>&quot;repeat&quot;</code> or <code>&quot;mirrored_repeat&quot;</code> is used.</p>
+<p>Note that the texture width must be a power of 2 if either
+<code>"repeat"</code> or <code>"mirrored_repeat"</code> is used.</p>
 <p>Updatable.</p>
-<h3 id="texture.twrap" class="field-def">texture.twrap</h3>
-<p>Sets the wrapping mode in the y direction. The allowed values are:</p>
+<h3 class="field-def" id="texture.twrap">texture.twrap</h3>
+<p>Sets the wrapping mode in the y direction. The allowed values
+are:</p>
 <ul>
-<li><code>&quot;clamp_to_edge&quot;</code> (the default)</li>
-<li><code>&quot;repeat&quot;</code></li>
-<li><code>&quot;mirrored_repeat&quot;</code></li>
+<li><code>"clamp_to_edge"</code> (the default)</li>
+<li><code>"repeat"</code></li>
+<li><code>"mirrored_repeat"</code></li>
 </ul>
-<p>Note that the texture height must be a power of 2 if either <code>&quot;repeat&quot;</code> or <code>&quot;mirrored_repeat&quot;</code> is used.</p>
+<p>Note that the texture height must be a power of 2 if either
+<code>"repeat"</code> or <code>"mirrored_repeat"</code> is used.</p>
 <p>Updatable.</p>
-<h3 id="texture.wrap" class="field-def">texture.wrap</h3>
-<p>This field can be used to set the wrap mode in both the x and y directions at the same time.</p>
+<h3 class="field-def" id="texture.wrap">texture.wrap</h3>
+<p>This field can be used to set the wrap mode in both the x and y
+directions at the same time.</p>
 <p>The allowed values are:</p>
 <ul>
-<li><code>&quot;clamp_to_edge&quot;</code></li>
-<li><code>&quot;repeat&quot;</code></li>
-<li><code>&quot;mirrored_repeat&quot;</code></li>
+<li><code>"clamp_to_edge"</code></li>
+<li><code>"repeat"</code></li>
+<li><code>"mirrored_repeat"</code></li>
 </ul>
 <p>Updatable.</p>
 <h1 id="framebuffers">Framebuffers</h1>
-<p>A framebuffer is like an off-screen window you can draw to. It has a texture associated with it that gets updated when you draw to the framebuffer. The texture can then be used as input to further rendering.</p>
+<p>A framebuffer is like an off-screen window you can draw to. It has a
+texture associated with it that gets updated when you draw to the
+framebuffer. The texture can then be used as input to further
+rendering.</p>
 <h2 id="creating-a-framebuffer">Creating a framebuffer</h2>
-<h3 id="am.framebuffer" class="func-def">am.framebuffer(texture [, depth_buf [, stencil_buf]])</h3>
+<h3 class="func-def" id="am.framebuffer">am.framebuffer(texture [,
+depth_buf [, stencil_buf]])</h3>
 <p>Creates framebuffer with the given texture attached.</p>
-<p><code>depth_buf</code> and <code>stencil_buf</code> determine whether the framebuffer has a depth and/or stencil buffer. These should be <code>true</code> or <code>false</code> (default is <code>false</code>).</p>
+<p><code>depth_buf</code> and <code>stencil_buf</code> determine whether
+the framebuffer has a depth and/or stencil buffer. These should be
+<code>true</code> or <code>false</code> (default is
+<code>false</code>).</p>
 <h2 id="framebuffer-fields">Framebuffer fields</h2>
-<h3 id="framebuffer.clear_color" class="field-def">framebuffer.clear_color</h3>
-<p>The color to use when clearing the framebuffer (a <code>vec4</code>).</p>
+<h3 class="field-def"
+id="framebuffer.clear_color">framebuffer.clear_color</h3>
+<p>The color to use when clearing the framebuffer (a
+<code>vec4</code>).</p>
 <p>Updatable.</p>
-<h3 id="framebuffer.stencil_clear_value" class="field-def">framebuffer.stencil_clear_value</h3>
-<p>The value to use when clearing the framebuffer's stencil buffer (an integer between 0 and 255).</p>
+<h3 class="field-def"
+id="framebuffer.stencil_clear_value">framebuffer.stencil_clear_value</h3>
+<p>The value to use when clearing the framebuffer’s stencil buffer (an
+integer between 0 and 255).</p>
 <p>Updatable.</p>
-<h3 id="framebuffer.projection" class="field-def">framebuffer.projection</h3>
-<p>A <code>mat4</code> projection matrix to use when rendering nodes into this framebuffer. The <code>&quot;P&quot;</code> uniform will be set to this. If this is not specified then the projection <code>math.ortho(-width/2, width/2, -height/2, height/2)</code> is used.</p>
+<h3 class="field-def"
+id="framebuffer.projection">framebuffer.projection</h3>
+<p>A <code>mat4</code> projection matrix to use when rendering nodes
+into this framebuffer. The <code>"P"</code> uniform will be set to this.
+If this is not specified then the projection
+<code>math.ortho(-width/2, width/2, -height/2, height/2)</code> is
+used.</p>
 <p>Updatable.</p>
-<h3 id="framebuffer.pixel_width" class="field-def">framebuffer.pixel_width</h3>
+<h3 class="field-def"
+id="framebuffer.pixel_width">framebuffer.pixel_width</h3>
 <p>The width of the framebuffer, in pixels.</p>
 <p>Readonly.</p>
-<h3 id="framebuffer.pixel_height" class="field-def">framebuffer.pixel_height</h3>
+<h3 class="field-def"
+id="framebuffer.pixel_height">framebuffer.pixel_height</h3>
 <p>The height of the framebuffer, in pixels.</p>
 <p>Readonly.</p>
 <h2 id="framebuffer-methods">Framebuffer methods</h2>
-<h3 id="framebuffer:render" class="method-def">framebuffer:render(node)</h3>
+<h3 class="method-def"
+id="framebuffer:render">framebuffer:render(node)</h3>
 <p>Renders <code>node</code> into the framebuffer.</p>
-<h3 id="framebuffer:render_children" class="method-def">framebuffer:render_children(node)</h3>
-<p>Renders <code>node</code>'s children into the framebuffer (but not <code>node</code> itself).</p>
-<h3 id="framebuffer:clear" class="method-def">framebuffer:clear([color [, depth [, stencil]]])</h3>
-<p>Clears the framebuffer, using the current <a href="#framebuffer.clear_color"><code>clear_color</code></a>.</p>
-<p>By default the color, depth and stencil buffers are cleared, but you can selectively clear only some buffers by setting the <code>color</code>, <code>depth</code> and <code>stencil</code> argumnets to <code>true</code> or <code>false</code>.</p>
-<h3 id="framebuffer:read_back" class="method-def">framebuffer:read_back()</h3>
-<p>Reads the pixels from the framebuffer into the texture's backing image buffer. This is a relatively slow operation, so use it sparingly.</p>
-<h3 id="framebuffer:resize" class="method-def">framebuffer:resize(width, height)</h3>
-<p>Resize the framebuffer. Only framebuffers with textures that have no backing image buffers can be resized. Also the texture must not use a filter that requires a mipmap.</p>
+<h3 class="method-def"
+id="framebuffer:render_children">framebuffer:render_children(node)</h3>
+<p>Renders <code>node</code>’s children into the framebuffer (but not
+<code>node</code> itself).</p>
+<h3 class="method-def" id="framebuffer:clear">framebuffer:clear([color
+[, depth [, stencil]]])</h3>
+<p>Clears the framebuffer, using the current <a
+href="#framebuffer.clear_color"><code>clear_color</code></a>.</p>
+<p>By default the color, depth and stencil buffers are cleared, but you
+can selectively clear only some buffers by setting the
+<code>color</code>, <code>depth</code> and <code>stencil</code>
+argumnets to <code>true</code> or <code>false</code>.</p>
+<h3 class="method-def"
+id="framebuffer:read_back">framebuffer:read_back()</h3>
+<p>Reads the pixels from the framebuffer into the texture’s backing
+image buffer. This is a relatively slow operation, so use it
+sparingly.</p>
+<h3 class="method-def" id="framebuffer:resize">framebuffer:resize(width,
+height)</h3>
+<p>Resize the framebuffer. Only framebuffers with textures that have no
+backing image buffers can be resized. Also the texture must not use a
+filter that requires a mipmap.</p>
 <h1 id="actions-1">Actions</h1>
-<p>This section covers useful action utility functions. For information on the action mechanism see the description of the <a href="#node:action"><code>action</code></a> method.</p>
+<p>This section covers useful action utility functions. For information
+on the action mechanism see the description of the <a
+href="#node:action"><code>action</code></a> method.</p>
 <h2 id="delay-action">Delay action</h2>
-<h3 id="am.delay" class="func-def">am.delay(seconds)</h3>
-<p>Returns an action that does nothing for the given number of seconds.</p>
+<h3 class="func-def" id="am.delay">am.delay(seconds)</h3>
+<p>Returns an action that does nothing for the given number of
+seconds.</p>
 <h2 id="combining-actions">Combining actions</h2>
-<h3 id="am.series" class="func-def">am.series(actions)</h3>
-<p>Returns an action that runs the given array of actions one after another.</p>
-<h3 id="am.parallel" class="func-def">am.parallel(actions)</h3>
-<p>Returns an action that runs the given array of actions all at the same time. The returned action finishes once all the actions in the array are finished.</p>
-<h3 id="am.loop" class="func-def">am.loop(func)</h3>
-<p><code>func</code> should be a function that returns an action. <code>am.loop</code> returns an action that repeatedly runs the action returned by <code>func</code>.</p>
+<h3 class="func-def" id="am.series">am.series(actions)</h3>
+<p>Returns an action that runs the given array of actions one after
+another.</p>
+<h3 class="func-def" id="am.parallel">am.parallel(actions)</h3>
+<p>Returns an action that runs the given array of actions all at the
+same time. The returned action finishes once all the actions in the
+array are finished.</p>
+<h3 class="func-def" id="am.loop">am.loop(func)</h3>
+<p><code>func</code> should be a function that returns an action.
+<code>am.loop</code> returns an action that repeatedly runs the action
+returned by <code>func</code>.</p>
 <h2 id="tweens">Tweens</h2>
-<h3 id="am.tween" class="func-def">am.tween([target,] time, values [, ease])</h3>
-<p>Returns an action that changes the values of one or more fields of <code>target</code> to new values over a given time period.</p>
+<h3 class="func-def" id="am.tween">am.tween([target,] time, values [,
+ease])</h3>
+<p>Returns an action that changes the values of one or more fields of
+<code>target</code> to new values over a given time period.</p>
 <p><code>time</code> is in seconds.</p>
-<p><code>values</code> is a table mapping field names to their new values.</p>
-<p><code>ease</code> is an easing function. This function takes a value between 0 and 1 and returns a value between 0 and 1. This determines the &quot;shape&quot; of the interpolation between the two values. If omitted a linear interpolation is used.</p>
-<p>The following easing functions are pre-defined (though of course you can define your own):</p>
+<p><code>values</code> is a table mapping field names to their new
+values.</p>
+<p><code>ease</code> is an easing function. This function takes a value
+between 0 and 1 and returns a value between 0 and 1. This determines the
+“shape” of the interpolation between the two values. If omitted a linear
+interpolation is used.</p>
+<p>The following easing functions are pre-defined (though of course you
+can define your own):</p>
 <ul>
 <li><code>am.ease.linear</code></li>
 <li><code>am.ease.quadratic</code></li>
@@ -2919,612 +4449,1000 @@ mvrot<span class="ot">.</span>degrees <span class="ot">=</span> <span class="dv"
 <li><code>am.ease.windup</code></li>
 <li><code>am.ease.elastic</code></li>
 <li><code>am.ease.bounce</code></li>
-<li><code>am.ease.cubic_bezier(x1, y1, x2, y2)</code>: This returns a cubic bezier ease function with the given control points.</li>
-<li><code>am.ease.out(f)</code>: This takes an existing ease function and returns its reverse. E.g. if the existing ease function is slow and then fast, the new one will be fast and then slow.</li>
-<li><code>am.ease.inout(f, g)</code>. This returns an ease function that uses the ease function <code>f</code> for the first half of the transition and <code>out(g)</code> for the second half.</li>
+<li><code>am.ease.cubic_bezier(x1, y1, x2, y2)</code>: This returns a
+cubic bezier ease function with the given control points.</li>
+<li><code>am.ease.out(f)</code>: This takes an existing ease function
+and returns its reverse. E.g. if the existing ease function is slow and
+then fast, the new one will be fast and then slow.</li>
+<li><code>am.ease.inout(f, g)</code>. This returns an ease function that
+uses the ease function <code>f</code> for the first half of the
+transition and <code>out(g)</code> for the second half.</li>
 </ul>
-<p>Tweening works with fields that are numbers or vectors (<code>vec2</code>, <code>vec3</code> or <code>vec4</code>). It also works with <a href="#quaternions">quaternions</a>. In all cases the <a href="#math.mix"><code>math.mix</code></a> function is used to interpolate between the initial value and the final value.</p>
-<p>If target is omitted it is taken to be the node to which the tween action is attached.</p>
+<p>Tweening works with fields that are numbers or vectors
+(<code>vec2</code>, <code>vec3</code> or <code>vec4</code>). It also
+works with <a href="#quaternions">quaternions</a>. In all cases the <a
+href="#math.mix"><code>math.mix</code></a> function is used to
+interpolate between the initial value and the final value.</p>
+<p>If target is omitted it is taken to be the node to which the tween
+action is attached.</p>
 <p>Example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">am<span class="ot">.</span>window<span class="ot">{}.</span>scene <span class="ot">=</span>
-    am<span class="ot">.</span>rect<span class="ot">(-</span><span class="dv">100</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">100</span><span class="ot">,</span> <span class="dv">100</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">))</span>
-    :action<span class="ot">(</span>
-        am<span class="ot">.</span>tween<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="ot">{</span>
-            color <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>
-            y2 <span class="ot">=</span> <span class="dv">100</span>
-        <span class="ot">}))</span></code></pre></div>
+<div class="sourceCode" id="cb105"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb105-1"><a href="#cb105-1" aria-hidden="true" tabindex="-1"></a>am<span class="op">.</span>window<span class="op">{}.</span>scene <span class="op">=</span></span>
+<span id="cb105-2"><a href="#cb105-2" aria-hidden="true" tabindex="-1"></a>    am<span class="op">.</span>rect<span class="op">(-</span><span class="dv">100</span><span class="op">,</span> <span class="op">-</span><span class="dv">100</span><span class="op">,</span> <span class="dv">100</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">))</span></span>
+<span id="cb105-3"><a href="#cb105-3" aria-hidden="true" tabindex="-1"></a>    <span class="op">:</span>action<span class="op">(</span></span>
+<span id="cb105-4"><a href="#cb105-4" aria-hidden="true" tabindex="-1"></a>        am<span class="op">.</span>tween<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="op">{</span></span>
+<span id="cb105-5"><a href="#cb105-5" aria-hidden="true" tabindex="-1"></a>            color <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span></span>
+<span id="cb105-6"><a href="#cb105-6" aria-hidden="true" tabindex="-1"></a>            y2 <span class="op">=</span> <span class="dv">100</span></span>
+<span id="cb105-7"><a href="#cb105-7" aria-hidden="true" tabindex="-1"></a>        <span class="op">}))</span></span></code></pre></div>
 <h2 id="coroutine-actions">Coroutine actions</h2>
-<p>An action can also be a coroutine. Inside a coroutine action it can sometimes be useful to wait for another action to finish, such as a tween. That is what the <code>am.wait</code> function is for:</p>
-<h3 id="am.wait" class="func-def">am.wait(action)</h3>
-<p>Waits for the given action to finish before continuing. This can only be called from within a coroutine.</p>
+<p>An action can also be a coroutine. Inside a coroutine action it can
+sometimes be useful to wait for another action to finish, such as a
+tween. That is what the <code>am.wait</code> function is for:</p>
+<h3 class="func-def" id="am.wait">am.wait(action)</h3>
+<p>Waits for the given action to finish before continuing. This can only
+be called from within a coroutine.</p>
 <p>Example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">am<span class="ot">.</span>window<span class="ot">{}.</span>scene <span class="ot">=</span>
-    am<span class="ot">.</span>rect<span class="ot">(-</span><span class="dv">100</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">100</span><span class="ot">,</span> <span class="dv">100</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">))</span>
-    :action<span class="ot">(</span>coroutine<span class="ot">.</span>create<span class="ot">(</span><span class="kw">function</span><span class="ot">(</span>node<span class="ot">)</span>
-        <span class="kw">while</span> <span class="kw">true</span> <span class="kw">do</span>
-            am<span class="ot">.</span>wait<span class="ot">(</span>am<span class="ot">.</span>tween<span class="ot">(</span>node<span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="ot">{</span>
-                color <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>
-                y2 <span class="ot">=</span> <span class="dv">100</span>
-            <span class="ot">}))</span>
-            am<span class="ot">.</span>wait<span class="ot">(</span>am<span class="ot">.</span>tween<span class="ot">(</span>node<span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="ot">{</span>
-                color <span class="ot">=</span> vec4<span class="ot">(</span><span class="dv">1</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">),</span>
-                y2 <span class="ot">=</span> <span class="dv">0</span>
-            <span class="ot">}))</span>
-        <span class="kw">end</span>
-    <span class="kw">end</span><span class="ot">))</span></code></pre></div>
+<div class="sourceCode" id="cb106"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb106-1"><a href="#cb106-1" aria-hidden="true" tabindex="-1"></a>am<span class="op">.</span>window<span class="op">{}.</span>scene <span class="op">=</span></span>
+<span id="cb106-2"><a href="#cb106-2" aria-hidden="true" tabindex="-1"></a>    am<span class="op">.</span>rect<span class="op">(-</span><span class="dv">100</span><span class="op">,</span> <span class="op">-</span><span class="dv">100</span><span class="op">,</span> <span class="dv">100</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">))</span></span>
+<span id="cb106-3"><a href="#cb106-3" aria-hidden="true" tabindex="-1"></a>    <span class="op">:</span>action<span class="op">(</span><span class="fu">coroutine.create</span><span class="op">(</span><span class="kw">function</span><span class="op">(</span>node<span class="op">)</span></span>
+<span id="cb106-4"><a href="#cb106-4" aria-hidden="true" tabindex="-1"></a>        <span class="cf">while</span> <span class="kw">true</span> <span class="cf">do</span></span>
+<span id="cb106-5"><a href="#cb106-5" aria-hidden="true" tabindex="-1"></a>            am<span class="op">.</span>wait<span class="op">(</span>am<span class="op">.</span>tween<span class="op">(</span>node<span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="op">{</span></span>
+<span id="cb106-6"><a href="#cb106-6" aria-hidden="true" tabindex="-1"></a>                color <span class="op">=</span> vec4<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span></span>
+<span id="cb106-7"><a href="#cb106-7" aria-hidden="true" tabindex="-1"></a>                y2 <span class="op">=</span> <span class="dv">100</span></span>
+<span id="cb106-8"><a href="#cb106-8" aria-hidden="true" tabindex="-1"></a>            <span class="op">}))</span></span>
+<span id="cb106-9"><a href="#cb106-9" aria-hidden="true" tabindex="-1"></a>            am<span class="op">.</span>wait<span class="op">(</span>am<span class="op">.</span>tween<span class="op">(</span>node<span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="op">{</span></span>
+<span id="cb106-10"><a href="#cb106-10" aria-hidden="true" tabindex="-1"></a>                color <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">),</span></span>
+<span id="cb106-11"><a href="#cb106-11" aria-hidden="true" tabindex="-1"></a>                y2 <span class="op">=</span> <span class="dv">0</span></span>
+<span id="cb106-12"><a href="#cb106-12" aria-hidden="true" tabindex="-1"></a>            <span class="op">}))</span></span>
+<span id="cb106-13"><a href="#cb106-13" aria-hidden="true" tabindex="-1"></a>        <span class="cf">end</span></span>
+<span id="cb106-14"><a href="#cb106-14" aria-hidden="true" tabindex="-1"></a>    <span class="kw">end</span><span class="op">))</span></span></code></pre></div>
 <h1 id="time">Time</h1>
 <h2 id="frame-time">Frame time</h2>
-<h3 id="am.frame_time" class="field-def">am.frame_time</h3>
+<h3 class="field-def" id="am.frame_time">am.frame_time</h3>
 <p>This contains the time the current frame started, in seconds.</p>
 <h2 id="delta-time">Delta time</h2>
-<h3 id="am.delta_time" class="field-def">am.delta_time</h3>
-<p>This contains the amount of time that lapsed between the start of the current frame and the start of the previous frame, in seconds.</p>
+<h3 class="field-def" id="am.delta_time">am.delta_time</h3>
+<p>This contains the amount of time that lapsed between the start of the
+current frame and the start of the previous frame, in seconds.</p>
 <h2 id="real-time">Real time</h2>
-<h3 id="am.current_time" class="func-def">am.current_time()</h3>
-<p>This returns the time since the program started, in seconds. This value can change over the course of a frame.</p>
+<h3 class="func-def" id="am.current_time">am.current_time()</h3>
+<p>This returns the time since the program started, in seconds. This
+value can change over the course of a frame.</p>
 <h1 id="saving-and-loading-state">Saving and loading state</h1>
-<h3 id="am.save_statekey-state-format">am.save_state(key, state [,format])</h3>
+<h3 id="am.save_statekey-state-format">am.save_state(key, state
+[,format])</h3>
 <p>Save the table <code>state</code> under <code>key</code>.</p>
-<p><code>format</code> can be <code>json</code> or <code>lua</code>. The default is <code>lua</code>.</p>
-<p>The location of the save file varies from platform to platform, but will generally be the recommended location to store app data on that system. The <code>shortname</code> and <code>author</code> fields from <a href="#config"><code>conf.lua</code></a> will be used to derive this location if provided.</p>
-<p>On iOS this also saves to iCloud. Be aware that iCloud has a 1MB size limit.</p>
-<p><strong>Note</strong>: The <code>lua</code> format allows users to execute arbitrary lua code by modifying the save file.</p>
+<p><code>format</code> can be <code>json</code> or <code>lua</code>. The
+default is <code>lua</code>.</p>
+<p>The location of the save file varies from platform to platform, but
+will generally be the recommended location to store app data on that
+system. The <code>shortname</code> and <code>author</code> fields from
+<a href="#config"><code>conf.lua</code></a> will be used to derive this
+location if provided.</p>
+<p>On iOS this also saves to iCloud. Be aware that iCloud has a 1MB size
+limit.</p>
+<p><strong>Note</strong>: The <code>lua</code> format allows users to
+execute arbitrary lua code by modifying the save file.</p>
 <h3 id="am.load_statekey-format">am.load_state(key, [,format])</h3>
-<p>Loads the table saved under <code>key</code> and returns it. If no table has been previously saved under <code>key</code> then <code>nil</code> is returned.</p>
-<p><code>format</code> can be <code>json</code> or <code>lua</code>. The default is <code>lua</code>.</p>
-<p><strong>Note</strong>: The <code>lua</code> format allows users to execute arbitrary lua code by modifying the save file.</p>
+<p>Loads the table saved under <code>key</code> and returns it. If no
+table has been previously saved under <code>key</code> then
+<code>nil</code> is returned.</p>
+<p><code>format</code> can be <code>json</code> or <code>lua</code>. The
+default is <code>lua</code>.</p>
+<p><strong>Note</strong>: The <code>lua</code> format allows users to
+execute arbitrary lua code by modifying the save file.</p>
 <h1 id="audio">Audio</h1>
 <h2 id="audio-buffers">Audio buffers</h2>
-<p>An audio buffer is a block of memory that stores an uncompressed audio sample.</p>
-<p>An audio buffer may have any number of channels, although Amulet will currently only play up to two channels.</p>
-<p>An audio buffer also has a sample rate. Amulet currently plays all audio at a sample rate 44.1kHz and will resample an audio buffer if it has a different sample rate (this requires extra processing).</p>
-<p>The audio data itself is stored in a raw <a href="#buffers-and-views">buffer</a> as a series of single precision floats (4 bytes each). The samples for each channel are contiguous. The first channel's data comes first, then the second channel's data, etc (the channels are not interleaved).</p>
-<p>If the sample data is stored in the buffer <code>buf</code>, and there are two channels, then the following code will create <a href="#buffers-and-views">views</a> that can be used to update or read the samples for each channel:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> c <span class="ot">=</span> <span class="dv">2</span> <span class="do">-- channels</span>
-<span class="kw">local</span> s <span class="ot">=</span> <span class="ot">#</span>buf <span class="ot">/</span> <span class="dv">4</span> <span class="ot">/</span> c <span class="do">-- samples per channel</span>
-<span class="kw">local</span> left_channel <span class="ot">=</span> buf:view<span class="ot">(</span><span class="st">&quot;float&quot;</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="dv">4</span><span class="ot">,</span> s<span class="ot">)</span>
-<span class="kw">local</span> right_channel <span class="ot">=</span> buf:view<span class="ot">(</span><span class="st">&quot;float&quot;</span><span class="ot">,</span> s <span class="ot">*</span> <span class="dv">4</span><span class="ot">,</span> <span class="dv">4</span><span class="ot">,</span> s<span class="ot">)</span></code></pre></div>
-<h3 id="am.audio_buffer" class="func-def">am.audio_buffer(buffer, channels, sample_rate)</h3>
-<p>Returns a new audio buffer using the given raw buffer (a buffer created with <a href="#am.buffer"><code>am.buffer</code></a>). The audio data should be layed out as described <a href="#audio-buffers">above</a>.</p>
-<p><code>channels</code> is the number of channels and <code>sample_rate</code> is the sample rate in Hz.</p>
-<h3 id="am.load_audio" class="func-def">am.load_audio(filename)</h3>
-<p>Loads the given audio file and returns a new audio buffer. The file must be a <code>.ogg</code> audio file. Returns <code>nil</code> if the file was not found.</p>
+<p>An audio buffer is a block of memory that stores an uncompressed
+audio sample.</p>
+<p>An audio buffer may have any number of channels, although Amulet will
+currently only play up to two channels.</p>
+<p>An audio buffer also has a sample rate. Amulet currently plays all
+audio at a sample rate 44.1kHz and will resample an audio buffer if it
+has a different sample rate (this requires extra processing).</p>
+<p>The audio data itself is stored in a raw <a
+href="#buffers-and-views">buffer</a> as a series of single precision
+floats (4 bytes each). The samples for each channel are contiguous. The
+first channel’s data comes first, then the second channel’s data, etc
+(the channels are not interleaved).</p>
+<p>If the sample data is stored in the buffer <code>buf</code>, and
+there are two channels, then the following code will create <a
+href="#buffers-and-views">views</a> that can be used to update or read
+the samples for each channel:</p>
+<div class="sourceCode" id="cb107"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb107-1"><a href="#cb107-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> c <span class="op">=</span> <span class="dv">2</span> <span class="co">-- channels</span></span>
+<span id="cb107-2"><a href="#cb107-2" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> s <span class="op">=</span> <span class="op">#</span>buf <span class="op">/</span> <span class="dv">4</span> <span class="op">/</span> c <span class="co">-- samples per channel</span></span>
+<span id="cb107-3"><a href="#cb107-3" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> left_channel <span class="op">=</span> buf<span class="op">:</span>view<span class="op">(</span><span class="st">&quot;float&quot;</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">4</span><span class="op">,</span> s<span class="op">)</span></span>
+<span id="cb107-4"><a href="#cb107-4" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> right_channel <span class="op">=</span> buf<span class="op">:</span>view<span class="op">(</span><span class="st">&quot;float&quot;</span><span class="op">,</span> s <span class="op">*</span> <span class="dv">4</span><span class="op">,</span> <span class="dv">4</span><span class="op">,</span> s<span class="op">)</span></span></code></pre></div>
+<h3 class="func-def" id="am.audio_buffer">am.audio_buffer(buffer,
+channels, sample_rate)</h3>
+<p>Returns a new audio buffer using the given raw buffer (a buffer
+created with <a href="#am.buffer"><code>am.buffer</code></a>). The audio
+data should be layed out as described <a
+href="#audio-buffers">above</a>.</p>
+<p><code>channels</code> is the number of channels and
+<code>sample_rate</code> is the sample rate in Hz.</p>
+<h3 class="func-def" id="am.load_audio">am.load_audio(filename)</h3>
+<p>Loads the given audio file and returns a new audio buffer. The file
+must be a <code>.ogg</code> audio file. Returns <code>nil</code> if the
+file was not found.</p>
 <h2 id="audio-buffer-fields">Audio buffer fields</h2>
-<h3 id="audio_buffer.channels" class="field-def">audio_buffer.channels</h3>
+<h3 class="field-def"
+id="audio_buffer.channels">audio_buffer.channels</h3>
 <p>The number of channels. Readonly.</p>
-<h3 id="audio_buffer.sample_rate" class="field-def">audio_buffer.sample_rate</h3>
+<h3 class="field-def"
+id="audio_buffer.sample_rate">audio_buffer.sample_rate</h3>
 <p>The sample rate in Hz. Readonly.</p>
-<h3 id="audio_buffer.samples_per_channel" class="field-def">audio_buffer.samples_per_channel</h3>
+<h3 class="field-def"
+id="audio_buffer.samples_per_channel">audio_buffer.samples_per_channel</h3>
 <p>The number of samples per channel. Readonly.</p>
-<h3 id="audio_buffer.length" class="field-def">audio_buffer.length</h3>
+<h3 class="field-def" id="audio_buffer.length">audio_buffer.length</h3>
 <p>The length of the audio in seconds. Readonly.</p>
-<h3 id="audio_buffer.buffer" class="field-def">audio_buffer.buffer</h3>
-<p>The underlying raw <a href="#buffers-and-views">buffer</a> where the audio data is stored. Readonly.</p>
+<h3 class="field-def" id="audio_buffer.buffer">audio_buffer.buffer</h3>
+<p>The underlying raw <a href="#buffers-and-views">buffer</a> where the
+audio data is stored. Readonly.</p>
 <h2 id="audio-tracks">Audio tracks</h2>
-<p>An audio track contains the playback state of an audio buffer - that is the current position and speed of playback. The same audio buffer can be used with multiple audio tracks.</p>
-<p>Note that you normally don't need to explicitly create tracks to play audio, unless you want to change the speed and position during playback.</p>
-<h3 id="am.track" class="func-def">am.track(buffer [, loop [, playback_speed [, volume]]])</h3>
-<p>Creates a new track with the given buffer, loop setting (<code>true</code>/<code>false</code>), playback_speed and volume. This doesn't cause the track to start playing, use <a href="#am.play"><code>am.play</code></a> for that.</p>
+<p>An audio track contains the playback state of an audio buffer - that
+is the current position and speed of playback. The same audio buffer can
+be used with multiple audio tracks.</p>
+<p>Note that you normally don’t need to explicitly create tracks to play
+audio, unless you want to change the speed and position during
+playback.</p>
+<h3 class="func-def" id="am.track">am.track(buffer [, loop [,
+playback_speed [, volume]]])</h3>
+<p>Creates a new track with the given buffer, loop setting
+(<code>true</code>/<code>false</code>), playback_speed and volume. This
+doesn’t cause the track to start playing, use <a
+href="#am.play"><code>am.play</code></a> for that.</p>
 <h2 id="audio-track-fields">Audio track fields</h2>
-<h3 id="track.playback_speed" class="field-def">track.playback_speed</h3>
-<p>Playback speed as a multiplier of the normal speed (e.g. 0.5 means half speed and 2 means double speed). Updatable.</p>
-<h3 id="track.volume" class="field-def">track.volume</h3>
+<h3 class="field-def"
+id="track.playback_speed">track.playback_speed</h3>
+<p>Playback speed as a multiplier of the normal speed (e.g. 0.5 means
+half speed and 2 means double speed). Updatable.</p>
+<h3 class="field-def" id="track.volume">track.volume</h3>
 <p>Playback volume (1 is normal volume). Updatable.</p>
 <h2 id="audio-track-methods">Audio track methods</h2>
-<h3 id="track:reset" class="method-def">track:reset([position])</h3>
-<p>Sets playback to the given position, measured in seconds. If the argument is omitted, playback is reset to the start.</p>
+<h3 class="method-def" id="track:reset">track:reset([position])</h3>
+<p>Sets playback to the given position, measured in seconds. If the
+argument is omitted, playback is reset to the start.</p>
 <h2 id="playing-audio-1">Playing audio</h2>
-<h3 id="am.play" class="func-def">am.play(source, loop, pitch, volume)</h3>
-<p>Returns an action that plays audio. Like any other <a href="#node:action">action</a> it needs to be attached to a scene node that's connected to a window to run.</p>
-<p><code>source</code> can either be an <a href="#audio-tracks">audio track</a>, an <a href="#audio-buffers">audio buffer</a>, the name of a &quot;.ogg&quot; file or a seed generated by the sfxr tool (there's an online version of that tool in the examples list of the <a href="http://www.amulet.xyz/editor.html">online editor</a>).</p>
+<h3 class="func-def" id="am.play">am.play(source, loop, pitch,
+volume)</h3>
+<p>Returns an action that plays audio. Like any other <a
+href="#node:action">action</a> it needs to be attached to a scene node
+that’s connected to a window to run.</p>
+<p><code>source</code> can either be an <a href="#audio-tracks">audio
+track</a>, an <a href="#audio-buffers">audio buffer</a>, the name of a
+“.ogg” file or a seed generated by the sfxr tool (there’s an online
+version of that tool in the examples list of the <a
+href="http://www.amulet.xyz/editor.html">online editor</a>).</p>
 <p><code>loop</code> can be <code>true</code> or <code>false</code>.</p>
-<p><code>pitch</code> is a multiplier applied to the playback speed. 1.0 mean play at the original speed. 2.0 means play twice as fast and 0.5 means play at half the original speed.</p>
+<p><code>pitch</code> is a multiplier applied to the playback speed. 1.0
+mean play at the original speed. 2.0 means play twice as fast and 0.5
+means play at half the original speed.</p>
 <p><code>volume</code> should be between 0 and 1.</p>
-<p><strong>Note</strong>: When the source is an sfxr seed or a filename, an <a href="#audio-buffers">audio buffer</a> is generated behind the scenes and cached. Therefore there might be a short delay the first time this function is called with a given seed or filename (though for short audio clips this will probably not be noticeable). Also avoid calling this function many times with different seeds or filenames, because that will cause unbounded memory growth.</p>
-<p><strong>Note</strong>: When playing audio in a web browser via HTML export, most browsers will not play any sounds until the user interacts with the page in some way. This is an effort by browser creators to suppress annoying auto-play advertisements. Amulet attempts to detect this and begins playing sound after the first click or key press.</p>
+<p><strong>Note</strong>: When the source is an sfxr seed or a filename,
+an <a href="#audio-buffers">audio buffer</a> is generated behind the
+scenes and cached. Therefore there might be a short delay the first time
+this function is called with a given seed or filename (though for short
+audio clips this will probably not be noticeable). Also avoid calling
+this function many times with different seeds or filenames, because that
+will cause unbounded memory growth.</p>
+<p><strong>Note</strong>: When playing audio in a web browser via HTML
+export, most browsers will not play any sounds until the user interacts
+with the page in some way. This is an effort by browser creators to
+suppress annoying auto-play advertisements. Amulet attempts to detect
+this and begins playing sound after the first click or key press.</p>
 <h2 id="generating-sound-effects">Generating sound effects</h2>
-<h3 id="am.sfxr_synth" class="func-def">am.sfxr_synth(settings)</h3>
+<h3 class="func-def" id="am.sfxr_synth">am.sfxr_synth(settings)</h3>
 <p>Returns an audio buffer containing a generated sound effect.</p>
-<p><code>settings</code> can either be a table containing any number of the following fields:</p>
+<p><code>settings</code> can either be a table containing any number of
+the following fields:</p>
 <table>
 <thead>
 <tr class="header">
-<th align="left">Field</th>
-<th align="left">Default value</th>
-<th align="left">Notes</th>
+<th style="text-align: left;">Field</th>
+<th style="text-align: left;">Default value</th>
+<th style="text-align: left;">Notes</th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td align="left"><code>wave_type</code></td>
-<td align="left"><code>&quot;square&quot;</code></td>
-<td align="left">Can also be <code>&quot;sawtooth&quot;</code>, <code>&quot;sine&quot;</code> or <code>&quot;noise&quot;</code></td>
+<td style="text-align: left;"><code>wave_type</code></td>
+<td style="text-align: left;"><code>"square"</code></td>
+<td style="text-align: left;">Can also be <code>"sawtooth"</code>,
+<code>"sine"</code> or <code>"noise"</code></td>
 </tr>
 <tr class="even">
-<td align="left"><code>base_freq</code></td>
-<td align="left"><code>0.3</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>base_freq</code></td>
+<td style="text-align: left;"><code>0.3</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>freq_limit</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>freq_limit</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="even">
-<td align="left"><code>freq_ramp</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>freq_ramp</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>freq_dramp</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>freq_dramp</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="even">
-<td align="left"><code>duty</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>duty</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>duty_ramp</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>duty_ramp</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="even">
-<td align="left"><code>vib_strength</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>vib_strength</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>vib_speed</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>vib_speed</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="even">
-<td align="left"><code>vib_delay</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>vib_delay</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>env_attack</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>env_attack</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="even">
-<td align="left"><code>env_sustain</code></td>
-<td align="left"><code>0.3</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>env_sustain</code></td>
+<td style="text-align: left;"><code>0.3</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>env_decay</code></td>
-<td align="left"><code>0.4</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>env_decay</code></td>
+<td style="text-align: left;"><code>0.4</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="even">
-<td align="left"><code>env_punch</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>env_punch</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>filter_on</code></td>
-<td align="left"><code>false</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>filter_on</code></td>
+<td style="text-align: left;"><code>false</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="even">
-<td align="left"><code>lpf_resonance</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>lpf_resonance</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>lpf_freq</code></td>
-<td align="left"><code>1.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>lpf_freq</code></td>
+<td style="text-align: left;"><code>1.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="even">
-<td align="left"><code>lpf_ramp</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>lpf_ramp</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>hpf_freq</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>hpf_freq</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="even">
-<td align="left"><code>hpf_ramp</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>hpf_ramp</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>pha_offset</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>pha_offset</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="even">
-<td align="left"><code>pha_ramp</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>pha_ramp</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>repeat_speed</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>repeat_speed</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="even">
-<td align="left"><code>arp_speed</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>arp_speed</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 <tr class="odd">
-<td align="left"><code>arp_mod</code></td>
-<td align="left"><code>0.0</code></td>
-<td align="left"></td>
+<td style="text-align: left;"><code>arp_mod</code></td>
+<td style="text-align: left;"><code>0.0</code></td>
+<td style="text-align: left;"></td>
 </tr>
 </tbody>
 </table>
-<p>or a numeric seed. Use the sfxr example in the <a href="http://www.amulet.xyz/editor.html">online editor</a> to generate seeds.</p>
+<p>or a numeric seed. Use the sfxr example in the <a
+href="http://www.amulet.xyz/editor.html">online editor</a> to generate
+seeds.</p>
 <h2 id="audio-graphs">Audio graphs</h2>
 <p>TODO</p>
-<p>(Amulet has support for building graphs of audio effect nodes, however it is currently undocumented because the API is unstable).</p>
+<p>(Amulet has support for building graphs of audio effect nodes,
+however it is currently undocumented because the API is unstable).</p>
 <h2 id="audio-graph-nodes">Audio graph nodes</h2>
 <p>TODO</p>
 <h2 id="analysing-audio">Analysing audio</h2>
 <p>TODO</p>
 <h1 id="controllers">Controllers</h1>
-<p>Each controller is assigned an index starting from 1. The first controller attached will always have index 1, so if your game only uses one controller you can just use index 1.</p>
-<p>Controllers are supported on Windows, OSX and Linux and up to 8 controllers can be connected at once.</p>
-<h3 id="am.controller_present" class="func-def">am.controller_present(index)</h3>
-<p>Returns <code>true</code> if controller <code>index</code> is currently connected.</p>
-<h3 id="am.controller_attached" class="func-def">am.controller_attached(index)</h3>
-<p>Returns <code>true</code> if controller <code>index</code> was attached since the last frame.</p>
-<h3 id="am.controller_detached" class="func-def">am.controller_detached(index)</h3>
-<p>Returns <code>true</code> if controller <code>index</code> was removed since the last frame.</p>
-<h3 id="am.controllers_present" class="func-def">am.controllers_present()</h3>
+<p>Each controller is assigned an index starting from 1. The first
+controller attached will always have index 1, so if your game only uses
+one controller you can just use index 1.</p>
+<p>Controllers are supported on Windows, OSX and Linux and up to 8
+controllers can be connected at once.</p>
+<h3 class="func-def"
+id="am.controller_present">am.controller_present(index)</h3>
+<p>Returns <code>true</code> if controller <code>index</code> is
+currently connected.</p>
+<h3 class="func-def"
+id="am.controller_attached">am.controller_attached(index)</h3>
+<p>Returns <code>true</code> if controller <code>index</code> was
+attached since the last frame.</p>
+<h3 class="func-def"
+id="am.controller_detached">am.controller_detached(index)</h3>
+<p>Returns <code>true</code> if controller <code>index</code> was
+removed since the last frame.</p>
+<h3 class="func-def"
+id="am.controllers_present">am.controllers_present()</h3>
 <p>Returns a list of currently connected controller indexes.</p>
-<h3 id="am.controllers_attached" class="func-def">am.controllers_attached()</h3>
-<p>Returns a list of controller indexes attached since the last frame.</p>
-<h3 id="am.controllers_detached" class="func-def">am.controllers_detached()</h3>
-<p>Returns a list of controller indexes removed since the last frame.</p>
-<h3 id="am.controller_lt_val" class="func-def">am.controller_lt_val(index)</h3>
-<p>Returns the value of the left trigger axis of controller <code>index</code>. The returned value is between 0 and 1.</p>
-<h3 id="am.controller_rt_val" class="func-def">am.controller_rt_val(index)</h3>
-<p>Returns the value of the right trigger axis of controller <code>index</code>. The returned value is between 0 and 1.</p>
-<h3 id="am.controller_lstick_pos" class="func-def">am.controller_lstick_pos(index)</h3>
-<p>Returns the position of the left stick of controller <code>index</code> as a <code>vec2</code>. The position values range from -1 to 1 in both the x and y components. Negative x means left and negative y means down.</p>
-<h3 id="am.controller_rstick_pos" class="func-def">am.controller_rstick_pos(index)</h3>
-<p>Returns the position of the left stick of controller <code>index</code> as a <code>vec2</code>. The position values range from -1 to 1 in both the x and y components. Negative x means left and negative y means down.</p>
-<h3 id="am.controller_button_pressed" class="func-def">am.controller_button_pressed(index, button)</h3>
-<p>Returns <code>true</code> if the given button of controller <code>index</code> was pressed since the last frame.</p>
+<h3 class="func-def"
+id="am.controllers_attached">am.controllers_attached()</h3>
+<p>Returns a list of controller indexes attached since the last
+frame.</p>
+<h3 class="func-def"
+id="am.controllers_detached">am.controllers_detached()</h3>
+<p>Returns a list of controller indexes removed since the last
+frame.</p>
+<h3 class="func-def"
+id="am.controller_lt_val">am.controller_lt_val(index)</h3>
+<p>Returns the value of the left trigger axis of controller
+<code>index</code>. The returned value is between 0 and 1.</p>
+<h3 class="func-def"
+id="am.controller_rt_val">am.controller_rt_val(index)</h3>
+<p>Returns the value of the right trigger axis of controller
+<code>index</code>. The returned value is between 0 and 1.</p>
+<h3 class="func-def"
+id="am.controller_lstick_pos">am.controller_lstick_pos(index)</h3>
+<p>Returns the position of the left stick of controller
+<code>index</code> as a <code>vec2</code>. The position values range
+from -1 to 1 in both the x and y components. Negative x means left and
+negative y means down.</p>
+<h3 class="func-def"
+id="am.controller_rstick_pos">am.controller_rstick_pos(index)</h3>
+<p>Returns the position of the left stick of controller
+<code>index</code> as a <code>vec2</code>. The position values range
+from -1 to 1 in both the x and y components. Negative x means left and
+negative y means down.</p>
+<h3 class="func-def"
+id="am.controller_button_pressed">am.controller_button_pressed(index,
+button)</h3>
+<p>Returns <code>true</code> if the given button of controller
+<code>index</code> was pressed since the last frame.</p>
 <p><code>button</code> can be one of the following strings:</p>
 <ul>
-<li><code>&quot;a&quot;</code></li>
-<li><code>&quot;b&quot;</code></li>
-<li><code>&quot;x&quot;</code></li>
-<li><code>&quot;y&quot;</code></li>
-<li><code>&quot;back&quot;</code></li>
-<li><code>&quot;guide&quot;</code></li>
-<li><code>&quot;start&quot;</code></li>
-<li><code>&quot;ls&quot;</code></li>
-<li><code>&quot;rs&quot;</code></li>
-<li><code>&quot;lb&quot;</code></li>
-<li><code>&quot;rb&quot;</code></li>
-<li><code>&quot;up&quot;</code></li>
-<li><code>&quot;down&quot;</code></li>
-<li><code>&quot;left&quot;</code></li>
-<li><code>&quot;right&quot;</code></li>
+<li><code>"a"</code></li>
+<li><code>"b"</code></li>
+<li><code>"x"</code></li>
+<li><code>"y"</code></li>
+<li><code>"back"</code></li>
+<li><code>"guide"</code></li>
+<li><code>"start"</code></li>
+<li><code>"ls"</code></li>
+<li><code>"rs"</code></li>
+<li><code>"lb"</code></li>
+<li><code>"rb"</code></li>
+<li><code>"up"</code></li>
+<li><code>"down"</code></li>
+<li><code>"left"</code></li>
+<li><code>"right"</code></li>
 </ul>
-<h3 id="am.controller_button_released" class="func-def">am.controller_button_released(index, button)</h3>
-<p>Returns <code>true</code> if the given button of controller <code>index</code> was released since the last frame. See <a href="#am.controller_button_pressed">am.controller_button_pressed</a> for a list of valid values for <code>button</code>.</p>
-<h3 id="am.controller_button_down" class="func-def">am.controller_button_down(index, button)</h3>
-<p>Returns <code>true</code> if the given button of controller <code>index</code> was down at the start of the current frame. See <a href="#am.controller_button_pressed">am.controller_button_pressed</a> for a list of valid values for <code>button</code>.</p>
+<h3 class="func-def"
+id="am.controller_button_released">am.controller_button_released(index,
+button)</h3>
+<p>Returns <code>true</code> if the given button of controller
+<code>index</code> was released since the last frame. See <a
+href="#am.controller_button_pressed">am.controller_button_pressed</a>
+for a list of valid values for <code>button</code>.</p>
+<h3 class="func-def"
+id="am.controller_button_down">am.controller_button_down(index,
+button)</h3>
+<p>Returns <code>true</code> if the given button of controller
+<code>index</code> was down at the start of the current frame. See <a
+href="#am.controller_button_pressed">am.controller_button_pressed</a>
+for a list of valid values for <code>button</code>.</p>
 <h1 id="spritepack">Packing sprites and generating fonts</h1>
 <h2 id="overview">Overview</h2>
-<p>Amulet includes a tool for packing images and font glyphs into a sprite sheet and generating a Lua module for conveniently accessing the images and glyphs therein.</p>
-<p>Suppose you have an <code>images</code> directory containing some <code>.png</code> files and a <code>fonts</code> directory containing <code>myfont.ttf</code> and suppose these two directories are subdirectories of the main game directory (where your <code>main.lua</code> file lives). To generate a sprite sheet, run the following command while in the main game directory:</p>
+<p>Amulet includes a tool for packing images and font glyphs into a
+sprite sheet and generating a Lua module for conveniently accessing the
+images and glyphs therein.</p>
+<p>Suppose you have an <code>images</code> directory containing some
+<code>.png</code> files and a <code>fonts</code> directory containing
+<code>myfont.ttf</code> and suppose these two directories are
+subdirectories of the main game directory (where your
+<code>main.lua</code> file lives). To generate a sprite sheet, run the
+following command while in the main game directory:</p>
 <pre class="console"><code>&gt; amulet pack -png mysprites.png -lua mysprites.lua 
               images/*.png fonts/myfont.ttf@32</code></pre>
-<p>This will generate <code>mysprites.png</code> and <code>mysprites.lua</code> in the current directory.</p>
-<p>The <code>@32</code> after the font file specifies the size of the glyphs to generate (in this case 32px).</p>
-<p>To use the generated sprite sheet in your code, first required the Lua module and then pass the fields in that module to <code>am.sprite</code> or <code>am.text</code>. For example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> mysprites <span class="ot">=</span> <span class="fu">require</span> <span class="st">&quot;mysprites&quot;</span>
-<span class="kw">local</span> run1_node <span class="ot">=</span> am<span class="ot">.</span>sprite<span class="ot">(</span>mysprites<span class="ot">.</span>run1<span class="ot">)</span>
-<span class="kw">local</span> text_node <span class="ot">=</span> am<span class="ot">.</span>text<span class="ot">(</span>mysprites<span class="ot">.</span>myfont32<span class="ot">,</span> <span class="st">&quot;BARF!&quot;</span><span class="ot">)</span></code></pre></div>
-<p>The sprite field names are generated from the image filenames with the extension removed (so the file <code>images/run1.png</code> would result in the field <code>mysprites.run1</code>).</p>
-<p>The font field name (<code>myfont32</code>) is the concatenation of the font file name (without the extension) and the font size.</p>
+<p>This will generate <code>mysprites.png</code> and
+<code>mysprites.lua</code> in the current directory.</p>
+<p>The <code>@32</code> after the font file specifies the size of the
+glyphs to generate (in this case 32px).</p>
+<p>To use the generated sprite sheet in your code, first required the
+Lua module and then pass the fields in that module to
+<code>am.sprite</code> or <code>am.text</code>. For example:</p>
+<div class="sourceCode" id="cb109"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb109-1"><a href="#cb109-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> mysprites <span class="op">=</span> <span class="fu">require</span> <span class="st">&quot;mysprites&quot;</span></span>
+<span id="cb109-2"><a href="#cb109-2" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> run1_node <span class="op">=</span> am<span class="op">.</span>sprite<span class="op">(</span>mysprites<span class="op">.</span>run1<span class="op">)</span></span>
+<span id="cb109-3"><a href="#cb109-3" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> text_node <span class="op">=</span> am<span class="op">.</span>text<span class="op">(</span>mysprites<span class="op">.</span>myfont32<span class="op">,</span> <span class="st">&quot;BARF!&quot;</span><span class="op">)</span></span></code></pre></div>
+<p>The sprite field names are generated from the image filenames with
+the extension removed (so the file <code>images/run1.png</code> would
+result in the field <code>mysprites.run1</code>).</p>
+<p>The font field name (<code>myfont32</code>) is the concatenation of
+the font file name (without the extension) and the font size.</p>
 <h2 id="pack-options">Pack options</h2>
-<p>In addition to the required <code>-png</code> and <code>-lua</code> options the pack command also supports the following options:</p>
+<p>In addition to the required <code>-png</code> and <code>-lua</code>
+options the pack command also supports the following options:</p>
 <table>
 <thead>
 <tr class="header">
-<th align="left">Option</th>
-<th align="left">Description</th>
+<th style="text-align: left;">Option</th>
+<th style="text-align: left;">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td align="left"><code>-mono</code></td>
-<td align="left">Do not anti-alias fonts.</td>
+<td style="text-align: left;"><code>-mono</code></td>
+<td style="text-align: left;">Do not anti-alias fonts.</td>
 </tr>
 <tr class="even">
-<td align="left"><code>-minfilter</code></td>
-<td align="left">The minification filter to apply when loading the sprite sheet texture. <code>linear</code> (the default) or <code>nearest</code>.</td>
+<td style="text-align: left;"><code>-minfilter</code></td>
+<td style="text-align: left;">The minification filter to apply when
+loading the sprite sheet texture. <code>linear</code> (the default) or
+<code>nearest</code>.</td>
 </tr>
 <tr class="odd">
-<td align="left"><code>-magfilter</code></td>
-<td align="left">The magnification filter to apply when loading the sprite sheet texture. <code>linear</code> (the default) or <code>nearest</code>.</td>
+<td style="text-align: left;"><code>-magfilter</code></td>
+<td style="text-align: left;">The magnification filter to apply when
+loading the sprite sheet texture. <code>linear</code> (the default) or
+<code>nearest</code>.</td>
 </tr>
 <tr class="even">
-<td align="left"><code>-no-premult</code></td>
-<td align="left">Do not pre-multiply RGB channels by alpha.</td>
+<td style="text-align: left;"><code>-no-premult</code></td>
+<td style="text-align: left;">Do not pre-multiply RGB channels by
+alpha.</td>
 </tr>
 <tr class="odd">
-<td align="left"><code>-keep-padding</code></td>
-<td align="left">Do not strip transparent pixels around images.</td>
+<td style="text-align: left;"><code>-keep-padding</code></td>
+<td style="text-align: left;">Do not strip transparent pixels around
+images.</td>
 </tr>
 </tbody>
 </table>
 <h2 id="padding">Padding</h2>
-<p>Unless you specify the <code>-keep-padding</code> option, Amulet will remove excess rows and columns of completely transparent pixels from each image before packing it. It will always however leave a one pixel border of transparent pixels if the image was surrounded by transparent pixels to begin with. This is done to prevent pixels from one image &quot;bleeding&quot; into another image when it's drawn.</p>
-<p>When excess rows and columns are removed the vertices of the sprite will be adjusted so the images is still drawn in the correct position, as if the excess pixels were still there.</p>
-<p>If an image is not surrounded by a border of transparent pixels, then the border pixels will be duplicated around the image. This helps prevent &quot;cracks&quot; when tiling the image.</p>
-<p>In summary, if you don't intend to use an image for tiling, surround it with a border of completely transparent pixels.</p>
-<h2 id="specifying-which-font-glyphs-to-generate">Specifying which font glyphs to generate</h2>
-<p>Optionally each font item may also be followed by a colon and a comma separated list of character ranges to include in the sprite sheet.</p>
-<p>The characters in the character range can be written directly if they are ASCII, or given as hexadecimal Unicode codepoints.</p>
+<p>Unless you specify the <code>-keep-padding</code> option, Amulet will
+remove excess rows and columns of completely transparent pixels from
+each image before packing it. It will always however leave a one pixel
+border of transparent pixels if the image was surrounded by transparent
+pixels to begin with. This is done to prevent pixels from one image
+“bleeding” into another image when it’s drawn.</p>
+<p>When excess rows and columns are removed the vertices of the sprite
+will be adjusted so the images is still drawn in the correct position,
+as if the excess pixels were still there.</p>
+<p>If an image is not surrounded by a border of transparent pixels, then
+the border pixels will be duplicated around the image. This helps
+prevent “cracks” when tiling the image.</p>
+<p>In summary, if you don’t intend to use an image for tiling, surround
+it with a border of completely transparent pixels.</p>
+<h2 id="specifying-which-font-glyphs-to-generate">Specifying which font
+glyphs to generate</h2>
+<p>Optionally each font item may also be followed by a colon and a comma
+separated list of character ranges to include in the sprite sheet.</p>
+<p>The characters in the character range can be written directly if they
+are ASCII, or given as hexadecimal Unicode codepoints.</p>
 <p>Here are some examples of valid font items:</p>
 <ul>
 <li><code>VeraMono.ttf@32:A-Z,0-9</code></li>
 <li><code>ComicSans.ttf@122:0x20-0xFF</code></li>
 <li><code>gbsn00lp.ttf@42:a-z,A-Z,0-9,0x4E00-0x9FFF</code></li>
 </ul>
-<p>If the character range list is omitted, it defaults to <code>0x20-0x7E</code>, i.e:</p>
+<p>If the character range list is omitted, it defaults to
+<code>0x20-0x7E</code>, i.e:</p>
 <pre class="text"><code>!&quot;#$%&amp;&#39;()*+,-./:;&lt;=&gt;?@[\]^_`{|}~0123456789
 ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz</code></pre>
 <h2 id="loading-bitmap-font-images">Loading bitmap font images</h2>
-<h3 id="am.load_bitmap_font" class="func-def">am.load_bitmap_font(filename, key)</h3>
-<p>Loads the image <code>filename</code> and returns a font using the glyph layout described by <code>key</code> where <code>key</code> is a string containing all the glyphs in the file as they are layed out. All glyphs must have the same width and height which is determined from the width and height of the image and the number of rows and columns in <code>key</code>. For example if the key is:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="st">[[</span>
-<span class="st">ABC</span>
-<span class="st">DEF</span>
-<span class="st">GHI</span>
-<span class="st">]]</span></code></pre></div>
-<p>then the image contains 9 glyphs in 3 rows and 3 columns. If the image has height 30 and width 36 then each glyph has width 10 and height 12.</p>
+<h3 class="func-def"
+id="am.load_bitmap_font">am.load_bitmap_font(filename, key)</h3>
+<p>Loads the image <code>filename</code> and returns a font using the
+glyph layout described by <code>key</code> where <code>key</code> is a
+string containing all the glyphs in the file as they are layed out. All
+glyphs must have the same width and height which is determined from the
+width and height of the image and the number of rows and columns in
+<code>key</code>. For example if the key is:</p>
+<div class="sourceCode" id="cb111"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb111-1"><a href="#cb111-1" aria-hidden="true" tabindex="-1"></a><span class="vs">[[</span></span>
+<span id="cb111-2"><a href="#cb111-2" aria-hidden="true" tabindex="-1"></a><span class="vs">ABC</span></span>
+<span id="cb111-3"><a href="#cb111-3" aria-hidden="true" tabindex="-1"></a><span class="vs">DEF</span></span>
+<span id="cb111-4"><a href="#cb111-4" aria-hidden="true" tabindex="-1"></a><span class="vs">GHI</span></span>
+<span id="cb111-5"><a href="#cb111-5" aria-hidden="true" tabindex="-1"></a><span class="vs">]]</span></span></code></pre></div>
+<p>then the image contains 9 glyphs in 3 rows and 3 columns. If the
+image has height 30 and width 36 then each glyph has width 10 and height
+12.</p>
 <h1 id="exporting">Exporting</h1>
-<p>To generate distribution packages, use the amulet export command like so:</p>
+<p>To generate distribution packages, use the amulet export command like
+so:</p>
 <pre class="console"><code>&gt; amulet export [&lt;dir&gt;]</code></pre>
-<p><code>&lt;dir&gt;</code> is the directory containing your <code>main.lua</code> file and optional <code>conf.lua</code> file (see <a href="#config">below</a>). It defaults to the current directory.</p>
-<p>This will generate zip package files for Windows, Mac and Linux in the current directory. Alternatively you can pass one of the options <code>-windows</code>, <code>-mac</code>, <code>-linux</code>, <code>-html</code>, <code>-ios-xcode-proj</code> or <code>-android-studio-proj</code>, to generate packages for a specific platform.</p>
-<p>If the <code>-r</code> option is given then all subdirectories will also be included (recursively), otherwise only the files in the given directory are included.</p>
-<p>By default all files in the directory with the following extensions will be included in the export: <code>.lua</code>, <code>.json</code>, <code>.png</code>, <code>.jpg</code>, <code>.ogg</code>, <code>.obj</code>, <code>.vert</code>, <code>.frag</code>. You can include all files with the <code>-a</code> option.</p>
-<p>All .txt files will also be copied to the generated zip and be visible to the user when they unzip it. This is intended for <code>README.txt</code> or similar files.</p>
-<p>By default packages are exported to the current directory. The -d option can be used to specify a different directory (the directory must already exist).</p>
-<p>The -o option allows you to specify the complete path (dir + filename) of the generated package. In this case the -d option is ignored. The -o option doesn't work if you're exporting multiple platforms at once.</p>
-<p>For example the following will export a windows build to <code>builds/mygame.zip</code>. It will look in <code>src</code> for the game files, recursively including all files.</p>
+<p><code>&lt;dir&gt;</code> is the directory containing your
+<code>main.lua</code> file and optional <code>conf.lua</code> file (see
+<a href="#config">below</a>). It defaults to the current directory.</p>
+<p>This will generate zip package files for Windows, Mac and Linux in
+the current directory. Alternatively you can pass one of the options
+<code>-windows</code>, <code>-mac</code>, <code>-linux</code>,
+<code>-html</code>, <code>-ios-xcode-proj</code> or
+<code>-android-studio-proj</code>, to generate packages for a specific
+platform.</p>
+<p>If the <code>-r</code> option is given then all subdirectories will
+also be included (recursively), otherwise only the files in the given
+directory are included.</p>
+<p>By default all files in the directory with the following extensions
+will be included in the export: <code>.lua</code>, <code>.json</code>,
+<code>.png</code>, <code>.jpg</code>, <code>.ogg</code>,
+<code>.obj</code>, <code>.vert</code>, <code>.frag</code>. You can
+include all files with the <code>-a</code> option.</p>
+<p>All .txt files will also be copied to the generated zip and be
+visible to the user when they unzip it. This is intended for
+<code>README.txt</code> or similar files.</p>
+<p>By default packages are exported to the current directory. The -d
+option can be used to specify a different directory (the directory must
+already exist).</p>
+<p>The -o option allows you to specify the complete path (dir +
+filename) of the generated package. In this case the -d option is
+ignored. The -o option doesn’t work if you’re exporting multiple
+platforms at once.</p>
+<p>For example the following will export a windows build to
+<code>builds/mygame.zip</code>. It will look in <code>src</code> for the
+game files, recursively including all files.</p>
 <pre class="console"><code>amulet export -windows -r -a -o builds/mygame.zip src</code></pre>
-<p>The following will generate mac and linux builds in the <code>builds</code> directory, this time looking for game files in <code>game</code> recursively, but only including recognised files (since no <code>-a</code> option is given):</p>
+<p>The following will generate mac and linux builds in the
+<code>builds</code> directory, this time looking for game files in
+<code>game</code> recursively, but only including recognised files
+(since no <code>-a</code> option is given):</p>
 <pre class="console"><code>amulet export -mac -linux -r -d builds game</code></pre>
-<p>As a courtesy to the user, the generate zip packages will contain the game files in a sub-folder. If you instead want the game files to appear in the root of the zip, use -nozipdir. You might want this if the game will run from a launcher such as Steam.</p>
-<p>If you want to generate only the <code>data.pak</code> file for your project you can specify the <code>-datapak</code> option. It behaves in a similar way to the platform options, but generates a platform agnostic <code>data.pak</code> file containing your projects Lua files and other assets. You might want to do this to update a previously generated xcode project without regenerating all the project files.</p>
-<p>The generated zip will also contain an <code>amulet_license.txt</code> file containing the Amulet license as well as the licenses of all third party libraries used by Amulet. Some of these licenses require that they be distributed with copies of their libraries, so to comply you should include amulet_license.txt when you distribute your work. Note that these licenses do not apply to your work itself.</p>
-<p><strong>IMPORTANT</strong>: Avoid unzipping and re-zipping the generated packages as you may inadvertently strip the executable marker from some files, which will cause them not to work on some platforms.</p>
+<p>As a courtesy to the user, the generate zip packages will contain the
+game files in a sub-folder. If you instead want the game files to appear
+in the root of the zip, use -nozipdir. You might want this if the game
+will run from a launcher such as Steam.</p>
+<p>If you want to generate only the <code>data.pak</code> file for your
+project you can specify the <code>-datapak</code> option. It behaves in
+a similar way to the platform options, but generates a platform agnostic
+<code>data.pak</code> file containing your projects Lua files and other
+assets. You might want to do this to update a previously generated xcode
+project without regenerating all the project files.</p>
+<p>The generated zip will also contain an
+<code>amulet_license.txt</code> file containing the Amulet license as
+well as the licenses of all third party libraries used by Amulet. Some
+of these licenses require that they be distributed with copies of their
+libraries, so to comply you should include amulet_license.txt when you
+distribute your work. Note that these licenses do not apply to your work
+itself.</p>
+<p><strong>IMPORTANT</strong>: Avoid unzipping and re-zipping the
+generated packages as you may inadvertently strip the executable marker
+from some files, which will cause them not to work on some
+platforms.</p>
 <h1 id="config">Project Configuration</h1>
-<p>Project metadata can be specified in a <code>conf.lua</code> file in the same directory as <code>main.lua</code>. Information like the icon to use for Mac and iOS exports, your game title, author and version, as well as app signing information for iOS is all specified here.</p>
+<p>Project metadata can be specified in a <code>conf.lua</code> file in
+the same directory as <code>main.lua</code>. Information like the icon
+to use for Mac and iOS exports, your game title, author and version, as
+well as app signing information for iOS is all specified here.</p>
 <h2 id="basic-metadata">Basic metadata</h2>
 <p>A minimal <code>conf.lua</code> might look like this:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">title <span class="ot">=</span> <span class="st">&quot;My Game Title&quot;</span>
-author <span class="ot">=</span> <span class="st">&quot;Your Name&quot;</span>
-shortname <span class="ot">=</span> <span class="st">&quot;mygame&quot;</span>
-version <span class="ot">=</span> <span class="st">&quot;1.0.0&quot;</span>
-support_email <span class="ot">=</span> <span class="st">&quot;support@example.com&quot;</span>
-copyright_message <span class="ot">=</span> <span class="st">&quot;Copyright © 2019 Your Name.&quot;</span></code></pre></div>
-<p><code>shortname</code> is used for the name of the executable and in a few other places. <code>support_email</code> is displayed to the user in error messages if provided. <code>author</code> is used to determine where save files go as well as in package metadata. The other metadata may or may not be included in the generated package metadata, depending on the target platform.</p>
+<div class="sourceCode" id="cb115"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a>title <span class="op">=</span> <span class="st">&quot;My Game Title&quot;</span></span>
+<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a>author <span class="op">=</span> <span class="st">&quot;Your Name&quot;</span></span>
+<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a>shortname <span class="op">=</span> <span class="st">&quot;mygame&quot;</span></span>
+<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a>version <span class="op">=</span> <span class="st">&quot;1.0.0&quot;</span></span>
+<span id="cb115-5"><a href="#cb115-5" aria-hidden="true" tabindex="-1"></a>support_email <span class="op">=</span> <span class="st">&quot;support@example.com&quot;</span></span>
+<span id="cb115-6"><a href="#cb115-6" aria-hidden="true" tabindex="-1"></a>copyright_message <span class="op">=</span> <span class="st">&quot;Copyright © 2019 Your Name.&quot;</span></span></code></pre></div>
+<p><code>shortname</code> is used for the name of the executable and in
+a few other places. <code>support_email</code> is displayed to the user
+in error messages if provided. <code>author</code> is used to determine
+where save files go as well as in package metadata. The other metadata
+may or may not be included in the generated package metadata, depending
+on the target platform.</p>
 <h2 id="language-configuration">Language configuration</h2>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">dev_region <span class="ot">=</span> <span class="st">&quot;en&quot;</span>
-supported_languages <span class="ot">=</span> <span class="st">&quot;en,fr,de,ja,zh-Hans,zh-Hant,ko&quot;</span></code></pre></div>
-<p>These options specify the main language and supported languages of the app respectively. <a href="#am.language"><code>am.language</code></a> will always return one of the supported languages. Note that not all platforms currently support this feature.</p>
+<div class="sourceCode" id="cb116"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a>dev_region <span class="op">=</span> <span class="st">&quot;en&quot;</span></span>
+<span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a>supported_languages <span class="op">=</span> <span class="st">&quot;en,fr,de,ja,zh-Hans,zh-Hant,ko&quot;</span></span></code></pre></div>
+<p>These options specify the main language and supported languages of
+the app respectively. <a
+href="#am.language"><code>am.language</code></a> will always return one
+of the supported languages. Note that not all platforms currently
+support this feature.</p>
 <h2 id="lua-version">Lua version</h2>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">luavm <span class="ot">=</span> <span class="st">&quot;lua52&quot;</span></code></pre></div>
-<p>Specify which version of Lua to use for exported builds. This does not currently affect which version of Lua is used to run the game from the command line. Valid values are <code>&quot;lua51&quot;</code>, <code>&quot;lua52&quot;</code> and <code>&quot;luajit&quot;</code>.</p>
+<div class="sourceCode" id="cb117"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a>luavm <span class="op">=</span> <span class="st">&quot;lua52&quot;</span></span></code></pre></div>
+<p>Specify which version of Lua to use for exported builds. This does
+not currently affect which version of Lua is used to run the game from
+the command line. Valid values are <code>"lua51"</code>,
+<code>"lua52"</code> and <code>"luajit"</code>.</p>
 <h2 id="windows-settings">Windows settings</h2>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">d3dangle <span class="ot">=</span> <span class="kw">true</span></code></pre></div>
-<p>Use Direct3D on Windows instead of OpenGL. Your GLSL shaders will be translated to HLSL using the Angle library. Note that MSAA is currently not supported when using Direct3D.</p>
+<div class="sourceCode" id="cb118"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a>d3dangle <span class="op">=</span> <span class="kw">true</span></span></code></pre></div>
+<p>Use Direct3D on Windows instead of OpenGL. Your GLSL shaders will be
+translated to HLSL using the Angle library. Note that MSAA is currently
+not supported when using Direct3D.</p>
 <h2 id="mac-settings">Mac settings</h2>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">appid_mac <span class="ot">=</span> <span class="st">&quot;com.example.myappid&quot;</span>
-icon_mac <span class="ot">=</span> <span class="st">&quot;assets/icon_mac.png&quot;</span></code></pre></div>
-<p>Specify the icon and appid for Mac exports. The icon path is relative to where you run amulet from.</p>
+<div class="sourceCode" id="cb119"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a>appid_mac <span class="op">=</span> <span class="st">&quot;com.example.myappid&quot;</span></span>
+<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a>icon_mac <span class="op">=</span> <span class="st">&quot;assets/icon_mac.png&quot;</span></span></code></pre></div>
+<p>Specify the icon and appid for Mac exports. The icon path is relative
+to where you run amulet from.</p>
 <h2 id="ios-settings">iOS settings</h2>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">display_name <span class="ot">=</span> <span class="st">&quot;My Game&quot;</span>
-appid_ios <span class="ot">=</span> <span class="st">&quot;com.example.mygameid&quot;</span>
-icon_ios_ <span class="ot">=</span> <span class="st">&quot;assets/icon.png&quot;</span>
-launch_image <span class="ot">=</span> <span class="st">&quot;assets/launch_image.png&quot;</span>
-orientation <span class="ot">=</span> <span class="st">&quot;portrait&quot;</span>
-ios_dev_cert_identity <span class="ot">=</span> <span class="st">&quot;XXXX123456&quot;</span>
-ios_appstore_cert_identity <span class="ot">=</span> <span class="st">&quot;XXXX123456&quot;</span>
-ios_code_sign_identity <span class="ot">=</span> <span class="st">&quot;Apple Distribution&quot;</span>
-ios_dev_prov_profile_name <span class="ot">=</span> <span class="st">&quot;MyGame Dev Profile&quot;</span>
-ios_dist_prov_profile_name <span class="ot">=</span> <span class="st">&quot;MyGame App Store Profile&quot;</span>
-game_center_enabled <span class="ot">=</span> <span class="kw">true</span>
-icloud_enabled <span class="ot">=</span> <span class="kw">true</span></code></pre></div>
-<p>The above metadata is used when the <code>-ios-xcode-proj</code> export option is given to generate an Xcode project for iOS. All the data is required.</p>
-<p><code>orientation</code> can be <code>&quot;portrait&quot;</code>, <code>&quot;landscape&quot;</code>, <code>&quot;any&quot;</code> or <code>&quot;hybrid&quot;</code> (portrait on iPhone, but landscape on iPad).</p>
-<p><code>ios_dev_cert_identity</code> and <code>ios_appstore_cert_identity</code> is the code that appears in parenthesis in your certificate name (e.g. if you certificate name in Key Access is &quot;iPhone Distribution: Your Name (XXXX123456)&quot;, then this value should be <code>&quot;XXXX123456&quot;</code>.</p>
-<p><code>ios_code_sign_identity</code> is the part that comes before the colon in your distribution certificate name. Typically this is either <code>&quot;iPhone Distribution&quot;</code> or <code>&quot;Apple Distribution&quot;</code>. (Use the Keychain Access application in Utilities to view your certificates.)</p>
-<p><code>ios_dev_prov_profile_name</code> and <code>ios_dist_prov_profile_name</code> are the names of your installed development and distribution provisioning profiles respectively. You can install a provisioning profile by downloading and double clicking it.</p>
+<div class="sourceCode" id="cb120"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a>display_name <span class="op">=</span> <span class="st">&quot;My Game&quot;</span></span>
+<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a>appid_ios <span class="op">=</span> <span class="st">&quot;com.example.mygameid&quot;</span></span>
+<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a>icon_ios_ <span class="op">=</span> <span class="st">&quot;assets/icon.png&quot;</span></span>
+<span id="cb120-4"><a href="#cb120-4" aria-hidden="true" tabindex="-1"></a>launch_image <span class="op">=</span> <span class="st">&quot;assets/launch_image.png&quot;</span></span>
+<span id="cb120-5"><a href="#cb120-5" aria-hidden="true" tabindex="-1"></a>orientation <span class="op">=</span> <span class="st">&quot;portrait&quot;</span></span>
+<span id="cb120-6"><a href="#cb120-6" aria-hidden="true" tabindex="-1"></a>ios_dev_cert_identity <span class="op">=</span> <span class="st">&quot;XXXX123456&quot;</span></span>
+<span id="cb120-7"><a href="#cb120-7" aria-hidden="true" tabindex="-1"></a>ios_appstore_cert_identity <span class="op">=</span> <span class="st">&quot;XXXX123456&quot;</span></span>
+<span id="cb120-8"><a href="#cb120-8" aria-hidden="true" tabindex="-1"></a>ios_code_sign_identity <span class="op">=</span> <span class="st">&quot;Apple Distribution&quot;</span></span>
+<span id="cb120-9"><a href="#cb120-9" aria-hidden="true" tabindex="-1"></a>ios_dev_prov_profile_name <span class="op">=</span> <span class="st">&quot;MyGame Dev Profile&quot;</span></span>
+<span id="cb120-10"><a href="#cb120-10" aria-hidden="true" tabindex="-1"></a>ios_dist_prov_profile_name <span class="op">=</span> <span class="st">&quot;MyGame App Store Profile&quot;</span></span>
+<span id="cb120-11"><a href="#cb120-11" aria-hidden="true" tabindex="-1"></a>game_center_enabled <span class="op">=</span> <span class="kw">true</span></span>
+<span id="cb120-12"><a href="#cb120-12" aria-hidden="true" tabindex="-1"></a>icloud_enabled <span class="op">=</span> <span class="kw">true</span></span></code></pre></div>
+<p>The above metadata is used when the <code>-ios-xcode-proj</code>
+export option is given to generate an Xcode project for iOS. All the
+data is required.</p>
+<p><code>orientation</code> can be <code>"portrait"</code>,
+<code>"landscape"</code>, <code>"any"</code> or <code>"hybrid"</code>
+(portrait on iPhone, but landscape on iPad).</p>
+<p><code>ios_dev_cert_identity</code> and
+<code>ios_appstore_cert_identity</code> is the code that appears in
+parenthesis in your certificate name (e.g. if you certificate name in
+Key Access is “iPhone Distribution: Your Name (XXXX123456)”, then this
+value should be <code>"XXXX123456"</code>.</p>
+<p><code>ios_code_sign_identity</code> is the part that comes before the
+colon in your distribution certificate name. Typically this is either
+<code>"iPhone Distribution"</code> or <code>"Apple Distribution"</code>.
+(Use the Keychain Access application in Utilities to view your
+certificates.)</p>
+<p><code>ios_dev_prov_profile_name</code> and
+<code>ios_dist_prov_profile_name</code> are the names of your installed
+development and distribution provisioning profiles respectively. You can
+install a provisioning profile by downloading and double clicking
+it.</p>
 <h2 id="android-settings">Android settings</h2>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua">display_name <span class="ot">=</span> <span class="st">&quot;My Game&quot;</span>
-appid_android <span class="ot">=</span> <span class="st">&quot;com.example.mygameid&quot;</span>
-icon_android <span class="ot">=</span> <span class="st">&quot;assets/icon.png&quot;</span>
-orientation <span class="ot">=</span> <span class="st">&quot;portrait&quot;</span>
-android_app_version_code <span class="ot">=</span> <span class="st">&quot;4&quot;</span>
-google_play_services_id <span class="ot">=</span> <span class="st">&quot;58675281521&quot;</span></code></pre></div>
-<p>The above metadata is used when the <code>-android-studio-proj</code> export option is given to generate an Android Studio project. All the data, except <code>google_play_services_id</code> is required (<code>google_play_services_id</code> is only required if you want to use Google Play leaderboards or achievements).</p>
-<p><code>orientation</code> can be <code>&quot;portrait&quot;</code>, <code>&quot;landscape&quot;</code> or <code>&quot;any&quot;</code>.</p>
-<p><code>appid_android</code> is used for the Java package name of the app. It should not contain dashes.</p>
+<div class="sourceCode" id="cb121"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a>display_name <span class="op">=</span> <span class="st">&quot;My Game&quot;</span></span>
+<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a>appid_android <span class="op">=</span> <span class="st">&quot;com.example.mygameid&quot;</span></span>
+<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a>icon_android <span class="op">=</span> <span class="st">&quot;assets/icon.png&quot;</span></span>
+<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a>orientation <span class="op">=</span> <span class="st">&quot;portrait&quot;</span></span>
+<span id="cb121-5"><a href="#cb121-5" aria-hidden="true" tabindex="-1"></a>android_app_version_code <span class="op">=</span> <span class="st">&quot;4&quot;</span></span>
+<span id="cb121-6"><a href="#cb121-6" aria-hidden="true" tabindex="-1"></a>google_play_services_id <span class="op">=</span> <span class="st">&quot;58675281521&quot;</span></span></code></pre></div>
+<p>The above metadata is used when the <code>-android-studio-proj</code>
+export option is given to generate an Android Studio project. All the
+data, except <code>google_play_services_id</code> is required
+(<code>google_play_services_id</code> is only required if you want to
+use Google Play leaderboards or achievements).</p>
+<p><code>orientation</code> can be <code>"portrait"</code>,
+<code>"landscape"</code> or <code>"any"</code>.</p>
+<p><code>appid_android</code> is used for the Java package name of the
+app. It should not contain dashes.</p>
 <h1 id="d-models">3D models</h1>
-<p>Amulet has some basic support for loading 3D models in Wavefront <code>.obj</code> format.</p>
-<h3 id="am.load_obj" class="func-def">am.load_obj(filename)</h3>
+<p>Amulet has some basic support for loading 3D models in Wavefront
+<code>.obj</code> format.</p>
+<h3 class="func-def" id="am.load_obj">am.load_obj(filename)</h3>
 <p>This loads the given <code>.obj</code> file and returns 4 things:</p>
-<ol style="list-style-type: decimal">
-<li>A buffer containing the vertex, normal and texture coordinate data.</li>
+<ol type="1">
+<li>A buffer containing the vertex, normal and texture coordinate
+data.</li>
 <li>The stride in bytes.</li>
 <li>The offset of the normals in bytes.</li>
 <li>The offset of the texture coordinates in bytes.</li>
 </ol>
-<p>The vertex data is always at offset 0. If the normal or texture coordinate data is not present, the corresponding return value will be nil.</p>
-<p>The faces in the <code>.obj</code> file must all be triangles (quads aren't supported).</p>
-<p>Here's an example of how to load a model and display it. The example loads an model from <code>model.obj</code> and assumes it contains normal and texture coordinate data and the triangles have a counter-clockwise winding. It loads a texture from the file <code>texture.png</code>.</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> win <span class="ot">=</span> am<span class="ot">.</span>window<span class="ot">{</span>depth_buffer <span class="ot">=</span> <span class="kw">true</span><span class="ot">}</span>
-
-<span class="kw">local</span> buf<span class="ot">,</span> stride<span class="ot">,</span> norm_offset<span class="ot">,</span> tex_offset <span class="ot">=</span> am<span class="ot">.</span>load_obj<span class="ot">(</span><span class="st">&quot;model.obj&quot;</span><span class="ot">)</span>
-<span class="kw">local</span> verts <span class="ot">=</span> buf:view<span class="ot">(</span><span class="st">&quot;vec3&quot;</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> stride<span class="ot">)</span>
-<span class="kw">local</span> normals <span class="ot">=</span> buf:view<span class="ot">(</span><span class="st">&quot;vec3&quot;</span><span class="ot">,</span> norm_offset<span class="ot">,</span> stride<span class="ot">)</span>
-<span class="kw">local</span> uvs <span class="ot">=</span> buf:view<span class="ot">(</span><span class="st">&quot;vec2&quot;</span><span class="ot">,</span> tex_offset<span class="ot">,</span> stride<span class="ot">)</span>
-    
-<span class="kw">local</span> shader <span class="ot">=</span> am<span class="ot">.</span>program<span class="ot">(</span><span class="st">[[</span>
-<span class="st">precision mediump float;</span>
-<span class="st">attribute vec3 vert;</span>
-<span class="st">attribute vec2 uv;</span>
-<span class="st">attribute vec3 normal;</span>
-<span class="st">uniform mat4 MV;</span>
-<span class="st">uniform mat4 P;</span>
-<span class="st">varying vec3 v_shadow;</span>
-<span class="st">varying vec2 v_uv;</span>
-<span class="st">void main() {</span>
-<span class="st">    vec3 light = normalize(vec3(1, 0, 2));</span>
-<span class="st">    vec3 nm = normalize((MV * vec4(normal, 0.0)).xyz);</span>
-<span class="st">    v_shadow = vec3(max(0.1, dot(light, nm)));</span>
-<span class="st">    v_uv = uv;</span>
-<span class="st">    gl_Position = P * MV * vec4(vert, 1.0);</span>
-<span class="st">}</span>
-<span class="st">]]</span><span class="ot">,</span> <span class="st">[[</span>
-<span class="st">precision mediump float;</span>
-<span class="st">uniform sampler2D tex;</span>
-<span class="st">varying vec3 v_shadow;</span>
-<span class="st">varying vec2 v_uv;</span>
-<span class="st">void main() {</span>
-<span class="st">    gl_FragColor = texture2D(tex, v_uv) * vec4(v_shadow, 1.0);</span>
-<span class="st">}</span>
-<span class="st">]]</span><span class="ot">)</span>
-
-win<span class="ot">.</span>scene <span class="ot">=</span>
-    am<span class="ot">.</span>cull_face<span class="st">&quot;ccw&quot;</span>
-    <span class="ot">^</span> am<span class="ot">.</span>translate<span class="ot">(</span><span class="dv">0</span><span class="ot">,</span> <span class="dv">0</span><span class="ot">,</span> <span class="ot">-</span><span class="dv">5</span><span class="ot">)</span>
-    <span class="ot">^</span> am<span class="ot">.</span>use_program<span class="ot">(</span>shader<span class="ot">)</span>
-    <span class="ot">^</span> am<span class="ot">.</span>bind<span class="ot">{</span>
-        P <span class="ot">=</span> math<span class="ot">.</span>perspective<span class="ot">(</span><span class="fu">math.rad</span><span class="ot">(</span><span class="dv">60</span><span class="ot">),</span> win<span class="ot">.</span>width<span class="ot">/</span>win<span class="ot">.</span>height<span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="dv">1000</span><span class="ot">),</span>
-        vert <span class="ot">=</span> verts<span class="ot">,</span>
-        normal <span class="ot">=</span> normals<span class="ot">,</span>
-        uv <span class="ot">=</span> uvs<span class="ot">,</span>
-        tex <span class="ot">=</span> am<span class="ot">.</span>texture2d<span class="ot">(</span><span class="st">&quot;texture.png&quot;</span><span class="ot">),</span>
-    <span class="ot">}</span>
-    <span class="ot">^</span>am<span class="ot">.</span>draw<span class="st">&quot;triangles&quot;</span></code></pre></div>
+<p>The vertex data is always at offset 0. If the normal or texture
+coordinate data is not present, the corresponding return value will be
+nil.</p>
+<p>The faces in the <code>.obj</code> file must all be triangles (quads
+aren’t supported).</p>
+<p>Here’s an example of how to load a model and display it. The example
+loads an model from <code>model.obj</code> and assumes it contains
+normal and texture coordinate data and the triangles have a
+counter-clockwise winding. It loads a texture from the file
+<code>texture.png</code>.</p>
+<div class="sourceCode" id="cb122"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> win <span class="op">=</span> am<span class="op">.</span>window<span class="op">{</span>depth_buffer <span class="op">=</span> <span class="kw">true</span><span class="op">}</span></span>
+<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> buf<span class="op">,</span> stride<span class="op">,</span> norm_offset<span class="op">,</span> tex_offset <span class="op">=</span> am<span class="op">.</span>load_obj<span class="op">(</span><span class="st">&quot;model.obj&quot;</span><span class="op">)</span></span>
+<span id="cb122-4"><a href="#cb122-4" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> verts <span class="op">=</span> buf<span class="op">:</span>view<span class="op">(</span><span class="st">&quot;vec3&quot;</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> stride<span class="op">)</span></span>
+<span id="cb122-5"><a href="#cb122-5" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> normals <span class="op">=</span> buf<span class="op">:</span>view<span class="op">(</span><span class="st">&quot;vec3&quot;</span><span class="op">,</span> norm_offset<span class="op">,</span> stride<span class="op">)</span></span>
+<span id="cb122-6"><a href="#cb122-6" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> uvs <span class="op">=</span> buf<span class="op">:</span>view<span class="op">(</span><span class="st">&quot;vec2&quot;</span><span class="op">,</span> tex_offset<span class="op">,</span> stride<span class="op">)</span></span>
+<span id="cb122-7"><a href="#cb122-7" aria-hidden="true" tabindex="-1"></a>    </span>
+<span id="cb122-8"><a href="#cb122-8" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> shader <span class="op">=</span> am<span class="op">.</span>program<span class="op">(</span><span class="vs">[[</span></span>
+<span id="cb122-9"><a href="#cb122-9" aria-hidden="true" tabindex="-1"></a><span class="vs">precision mediump float;</span></span>
+<span id="cb122-10"><a href="#cb122-10" aria-hidden="true" tabindex="-1"></a><span class="vs">attribute vec3 vert;</span></span>
+<span id="cb122-11"><a href="#cb122-11" aria-hidden="true" tabindex="-1"></a><span class="vs">attribute vec2 uv;</span></span>
+<span id="cb122-12"><a href="#cb122-12" aria-hidden="true" tabindex="-1"></a><span class="vs">attribute vec3 normal;</span></span>
+<span id="cb122-13"><a href="#cb122-13" aria-hidden="true" tabindex="-1"></a><span class="vs">uniform mat4 MV;</span></span>
+<span id="cb122-14"><a href="#cb122-14" aria-hidden="true" tabindex="-1"></a><span class="vs">uniform mat4 P;</span></span>
+<span id="cb122-15"><a href="#cb122-15" aria-hidden="true" tabindex="-1"></a><span class="vs">varying vec3 v_shadow;</span></span>
+<span id="cb122-16"><a href="#cb122-16" aria-hidden="true" tabindex="-1"></a><span class="vs">varying vec2 v_uv;</span></span>
+<span id="cb122-17"><a href="#cb122-17" aria-hidden="true" tabindex="-1"></a><span class="vs">void main() {</span></span>
+<span id="cb122-18"><a href="#cb122-18" aria-hidden="true" tabindex="-1"></a><span class="vs">    vec3 light = normalize(vec3(1, 0, 2));</span></span>
+<span id="cb122-19"><a href="#cb122-19" aria-hidden="true" tabindex="-1"></a><span class="vs">    vec3 nm = normalize((MV * vec4(normal, 0.0)).xyz);</span></span>
+<span id="cb122-20"><a href="#cb122-20" aria-hidden="true" tabindex="-1"></a><span class="vs">    v_shadow = vec3(max(0.1, dot(light, nm)));</span></span>
+<span id="cb122-21"><a href="#cb122-21" aria-hidden="true" tabindex="-1"></a><span class="vs">    v_uv = uv;</span></span>
+<span id="cb122-22"><a href="#cb122-22" aria-hidden="true" tabindex="-1"></a><span class="vs">    gl_Position = P * MV * vec4(vert, 1.0);</span></span>
+<span id="cb122-23"><a href="#cb122-23" aria-hidden="true" tabindex="-1"></a><span class="vs">}</span></span>
+<span id="cb122-24"><a href="#cb122-24" aria-hidden="true" tabindex="-1"></a><span class="vs">]]</span><span class="op">,</span> <span class="vs">[[</span></span>
+<span id="cb122-25"><a href="#cb122-25" aria-hidden="true" tabindex="-1"></a><span class="vs">precision mediump float;</span></span>
+<span id="cb122-26"><a href="#cb122-26" aria-hidden="true" tabindex="-1"></a><span class="vs">uniform sampler2D tex;</span></span>
+<span id="cb122-27"><a href="#cb122-27" aria-hidden="true" tabindex="-1"></a><span class="vs">varying vec3 v_shadow;</span></span>
+<span id="cb122-28"><a href="#cb122-28" aria-hidden="true" tabindex="-1"></a><span class="vs">varying vec2 v_uv;</span></span>
+<span id="cb122-29"><a href="#cb122-29" aria-hidden="true" tabindex="-1"></a><span class="vs">void main() {</span></span>
+<span id="cb122-30"><a href="#cb122-30" aria-hidden="true" tabindex="-1"></a><span class="vs">    gl_FragColor = texture2D(tex, v_uv) * vec4(v_shadow, 1.0);</span></span>
+<span id="cb122-31"><a href="#cb122-31" aria-hidden="true" tabindex="-1"></a><span class="vs">}</span></span>
+<span id="cb122-32"><a href="#cb122-32" aria-hidden="true" tabindex="-1"></a><span class="vs">]]</span><span class="op">)</span></span>
+<span id="cb122-33"><a href="#cb122-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb122-34"><a href="#cb122-34" aria-hidden="true" tabindex="-1"></a>win<span class="op">.</span>scene <span class="op">=</span></span>
+<span id="cb122-35"><a href="#cb122-35" aria-hidden="true" tabindex="-1"></a>    am<span class="op">.</span>cull_face<span class="st">&quot;ccw&quot;</span></span>
+<span id="cb122-36"><a href="#cb122-36" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> am<span class="op">.</span>translate<span class="op">(</span><span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="op">-</span><span class="dv">5</span><span class="op">)</span></span>
+<span id="cb122-37"><a href="#cb122-37" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> am<span class="op">.</span>use_program<span class="op">(</span>shader<span class="op">)</span></span>
+<span id="cb122-38"><a href="#cb122-38" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span> am<span class="op">.</span>bind<span class="op">{</span></span>
+<span id="cb122-39"><a href="#cb122-39" aria-hidden="true" tabindex="-1"></a>        <span class="cn">P</span> <span class="op">=</span> math<span class="op">.</span>perspective<span class="op">(</span><span class="fu">math.rad</span><span class="op">(</span><span class="dv">60</span><span class="op">),</span> win<span class="op">.</span>width<span class="op">/</span>win<span class="op">.</span>height<span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1000</span><span class="op">),</span></span>
+<span id="cb122-40"><a href="#cb122-40" aria-hidden="true" tabindex="-1"></a>        vert <span class="op">=</span> verts<span class="op">,</span></span>
+<span id="cb122-41"><a href="#cb122-41" aria-hidden="true" tabindex="-1"></a>        normal <span class="op">=</span> normals<span class="op">,</span></span>
+<span id="cb122-42"><a href="#cb122-42" aria-hidden="true" tabindex="-1"></a>        uv <span class="op">=</span> uvs<span class="op">,</span></span>
+<span id="cb122-43"><a href="#cb122-43" aria-hidden="true" tabindex="-1"></a>        tex <span class="op">=</span> am<span class="op">.</span>texture2d<span class="op">(</span><span class="st">&quot;texture.png&quot;</span><span class="op">),</span></span>
+<span id="cb122-44"><a href="#cb122-44" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb122-45"><a href="#cb122-45" aria-hidden="true" tabindex="-1"></a>    <span class="op">^</span>am<span class="op">.</span>draw<span class="st">&quot;triangles&quot;</span></span></code></pre></div>
 <h1 id="extra-table-functions">Extra table functions</h1>
-<p>The following functions suplement the standard Lua table functions.</p>
-<h3 id="table.shallow_copy" class="func-def">table.shallow_copy(t)</h3>
-<p>Returns a shallow copy of <code>t</code> (i.e. a new table with the same keys and values as <code>t</code>).</p>
-<h3 id="table.deep_copy" class="func-def">table.deep_copy(t)</h3>
-<p>Returns a deep copy of <code>t</code> (all <code>t</code>'s keys and values are copied recursively). Cycles are detected and reproduced in the new table.</p>
-<h3 id="table.search" class="func-def">table.search(arr, elem)</h3>
-<p>Return the index of <code>elem</code> in <code>arr</code> or nil if it's not found.</p>
-<h3 id="table.shuffle" class="func-def">table.shuffle(t [,rand])</h3>
-<p>Randomly rearranges the values of <code>t</code>. The optional <code>rand</code> argument should be a function where <code>rand(n)</code> returns an integer between 1 and n (like <code>math.random</code>). By default <code>math.random</code> is used.</p>
-<h3 id="table.clear" class="func-def">table.clear(t)</h3>
-<p>Remove all <code>t</code>'s pairs.</p>
-<h3 id="table.remove_all" class="func-def">table.remove_all(arr, elem)</h3>
-<p>Remove all values equal to <code>elem</code> from <code>arr</code>.</p>
-<h3 id="table.append" class="func-def">table.append(arr1, arr2)</h3>
-<p>Inserts all of <code>arr2</code>'s values at the end of <code>arr1</code>.</p>
-<h3 id="table.merge" class="func-def">table.merge(t1, t2)</h3>
-<p>Sets all the key-value pairs from <code>t2</code> in <code>t1</code>.</p>
-<h3 id="table.keys" class="func-def">table.keys(t)</h3>
-<p>Returns an array of <code>t</code>'s keys.</p>
-<h3 id="table.values" class="func-def">table.values(t)</h3>
-<p>Returns an array of <code>t</code>'s values.</p>
-<h3 id="table.filter" class="func-def">table.filter(arr, f)</h3>
-<p>Returns a new array which contains only the values from <code>arr</code> for which <code>f(elem)</code> returns true (or any value besides <code>nil</code> or <code>false</code>).</p>
-<h3 id="table.tostring" class="func-def">table.tostring(t)</h3>
-<p>Converts a table to a string. The returned string is a valid Lua table literal.</p>
-<h3 id="table.count" class="func-def">table.count(t)</h3>
+<p>The following functions suplement the standard Lua table
+functions.</p>
+<h3 class="func-def" id="table.shallow_copy">table.shallow_copy(t)</h3>
+<p>Returns a shallow copy of <code>t</code> (i.e. a new table with the
+same keys and values as <code>t</code>).</p>
+<h3 class="func-def" id="table.deep_copy">table.deep_copy(t)</h3>
+<p>Returns a deep copy of <code>t</code> (all <code>t</code>’s keys and
+values are copied recursively). Cycles are detected and reproduced in
+the new table.</p>
+<h3 class="func-def" id="table.search">table.search(arr, elem)</h3>
+<p>Return the index of <code>elem</code> in <code>arr</code> or nil if
+it’s not found.</p>
+<h3 class="func-def" id="table.shuffle">table.shuffle(t [,rand])</h3>
+<p>Randomly rearranges the values of <code>t</code>. The optional
+<code>rand</code> argument should be a function where
+<code>rand(n)</code> returns an integer between 1 and n (like
+<code>math.random</code>). By default <code>math.random</code> is
+used.</p>
+<h3 class="func-def" id="table.clear">table.clear(t)</h3>
+<p>Remove all <code>t</code>’s pairs.</p>
+<h3 class="func-def" id="table.remove_all">table.remove_all(arr,
+elem)</h3>
+<p>Remove all values equal to <code>elem</code> from
+<code>arr</code>.</p>
+<h3 class="func-def" id="table.append">table.append(arr1, arr2)</h3>
+<p>Inserts all of <code>arr2</code>’s values at the end of
+<code>arr1</code>.</p>
+<h3 class="func-def" id="table.merge">table.merge(t1, t2)</h3>
+<p>Sets all the key-value pairs from <code>t2</code> in
+<code>t1</code>.</p>
+<h3 class="func-def" id="table.keys">table.keys(t)</h3>
+<p>Returns an array of <code>t</code>’s keys.</p>
+<h3 class="func-def" id="table.values">table.values(t)</h3>
+<p>Returns an array of <code>t</code>’s values.</p>
+<h3 class="func-def" id="table.filter">table.filter(arr, f)</h3>
+<p>Returns a new array which contains only the values from
+<code>arr</code> for which <code>f(elem)</code> returns true (or any
+value besides <code>nil</code> or <code>false</code>).</p>
+<h3 class="func-def" id="table.tostring">table.tostring(t)</h3>
+<p>Converts a table to a string. The returned string is a valid Lua
+table literal.</p>
+<h3 class="func-def" id="table.count">table.count(t)</h3>
 <p>Returns the total number of pairs in the table.</p>
+<h1 id="deriving-amulet-types">Deriving Amulet Types</h1>
+<h3 class="func-def" id="am.type">am.type(value)</h3>
+<p>Using Lua’s builtin function <code>type</code> to derive the type of
+various amulet types will often return the unhelpful string
+<code>"userdata"</code>.</p>
+<p>You can use <code>am.type</code> instead which will often yield a
+more flexible result.</p>
+<div class="sourceCode" id="cb123"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> v4 <span class="op">=</span> vec4<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">0</span><span class="op">,</span> <span class="dv">1</span><span class="op">)</span></span>
+<span id="cb123-2"><a href="#cb123-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb123-3"><a href="#cb123-3" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> m2 <span class="op">=</span> mat2<span class="op">(</span></span>
+<span id="cb123-4"><a href="#cb123-4" aria-hidden="true" tabindex="-1"></a>    vec2<span class="op">(</span><span class="dv">50</span><span class="op">,</span> <span class="dv">50</span><span class="op">),</span></span>
+<span id="cb123-5"><a href="#cb123-5" aria-hidden="true" tabindex="-1"></a>    vec2<span class="op">(</span><span class="dv">120</span><span class="op">,</span> <span class="dv">70</span><span class="op">)</span></span>
+<span id="cb123-6"><a href="#cb123-6" aria-hidden="true" tabindex="-1"></a><span class="op">)</span></span>
+<span id="cb123-7"><a href="#cb123-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb123-8"><a href="#cb123-8" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> quat <span class="op">=</span> quat<span class="op">(</span><span class="fu">math.rad</span><span class="op">(</span><span class="dv">30</span><span class="op">),</span> vec3<span class="op">(</span><span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="dv">1</span><span class="op">))</span></span>
+<span id="cb123-9"><a href="#cb123-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb123-10"><a href="#cb123-10" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> win <span class="op">=</span> am<span class="op">.</span>window<span class="op">{}</span></span>
+<span id="cb123-11"><a href="#cb123-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb123-12"><a href="#cb123-12" aria-hidden="true" tabindex="-1"></a><span class="co">-- normal lua types</span></span>
+<span id="cb123-13"><a href="#cb123-13" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> str <span class="op">=</span> <span class="st">&quot;Hi!&quot;</span></span>
+<span id="cb123-14"><a href="#cb123-14" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> num <span class="op">=</span> <span class="dv">4.2</span><span class="op">;</span></span>
+<span id="cb123-15"><a href="#cb123-15" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> f <span class="op">=</span> <span class="kw">function</span><span class="op">(</span>x<span class="op">,</span> y<span class="op">)</span></span>
+<span id="cb123-16"><a href="#cb123-16" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> x <span class="op">^</span> y<span class="op">;</span></span>
+<span id="cb123-17"><a href="#cb123-17" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span>
+<span id="cb123-18"><a href="#cb123-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb123-19"><a href="#cb123-19" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>am<span class="op">.</span>type<span class="op">(</span>v4<span class="op">))</span>   <span class="co">-- prints &quot;vec4&quot;</span></span>
+<span id="cb123-20"><a href="#cb123-20" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>am<span class="op">.</span>type<span class="op">(</span>m2<span class="op">))</span>   <span class="co">-- prints &quot;mat2&quot;</span></span>
+<span id="cb123-21"><a href="#cb123-21" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>am<span class="op">.</span>type<span class="op">(</span>quat<span class="op">))</span> <span class="co">-- prints &quot;quat&quot;</span></span>
+<span id="cb123-22"><a href="#cb123-22" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>am<span class="op">.</span>type<span class="op">(</span>win<span class="op">))</span>  <span class="co">-- prints &quot;window&quot;</span></span>
+<span id="cb123-23"><a href="#cb123-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb123-24"><a href="#cb123-24" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>am<span class="op">.</span>type<span class="op">(</span>str<span class="op">))</span>  <span class="co">-- prints &quot;string&quot;</span></span>
+<span id="cb123-25"><a href="#cb123-25" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>am<span class="op">.</span>type<span class="op">(</span>num<span class="op">))</span>  <span class="co">-- prints &quot;number&quot;</span></span>
+<span id="cb123-26"><a href="#cb123-26" aria-hidden="true" tabindex="-1"></a><span class="fu">print</span><span class="op">(</span>am<span class="op">.</span>type<span class="op">(</span>f<span class="op">))</span>    <span class="co">-- prints &quot;function&quot;</span></span></code></pre></div>
 <h1 id="amulet-require-function">Amulet require function</h1>
-<p>The <code>require</code> function in Amulet is slightly different from the default one. The default Lua package loaders have been removed and replaced with a custom loader. The loader passes a new empty table into each module it loads. All exported functions can be added to this table, instead of creating a new table. If no other value is returned by the module, the passed in table will be used as the return value for <code>require</code>.</p>
-<p>The passed in export table can be accessed via the <code>...</code> expression. Here's a short example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> mymodule <span class="ot">=</span> <span class="ot">...</span>
-
-mymodule<span class="ot">.</span>message <span class="ot">=</span> <span class="st">&quot;hello&quot;</span>
-
-<span class="kw">function</span> mymodule<span class="ot">.</span>print_message<span class="ot">()</span>
-    <span class="fu">print</span><span class="ot">(</span>mymodule<span class="ot">.</span>message<span class="ot">)</span>
-<span class="kw">end</span></code></pre></div>
-<p>If this module is in the file <code>mymodule.lua</code>, then it can be imported like so:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> mymodule <span class="ot">=</span> <span class="fu">require</span> <span class="st">&quot;mymodule&quot;</span>
-
-mymodule<span class="ot">.</span>print_message<span class="ot">()</span> <span class="do">-- prints hello</span></code></pre></div>
-<p>This scheme allows cyclic module imports, e.g. module A requires module B which in turn requires module A. Amulet will detect the recursion and return A's (incomplete) export table in B. Then when A has finished initialising, all its functions will be available in B. This does mean that B can't call any of A's functions while its initialising, but after initialisation all of A's functions will be available.</p>
-<p>Of course you can still return your own values from modules and they will be returned by <code>require</code> as with the default Lua <code>require</code> function.</p>
+<p>The <code>require</code> function in Amulet is slightly different
+from the default one. The default Lua package loaders have been removed
+and replaced with a custom loader. The loader passes a new empty table
+into each module it loads. All exported functions can be added to this
+table, instead of creating a new table. If no other value is returned by
+the module, the passed in table will be used as the return value for
+<code>require</code>.</p>
+<p>The passed in export table can be accessed via the <code>...</code>
+expression. Here’s a short example:</p>
+<div class="sourceCode" id="cb124"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> mymodule <span class="op">=</span> <span class="op">...</span></span>
+<span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb124-3"><a href="#cb124-3" aria-hidden="true" tabindex="-1"></a>mymodule<span class="op">.</span>message <span class="op">=</span> <span class="st">&quot;hello&quot;</span></span>
+<span id="cb124-4"><a href="#cb124-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb124-5"><a href="#cb124-5" aria-hidden="true" tabindex="-1"></a><span class="kw">function</span> mymodule<span class="op">.</span>print_message<span class="op">()</span></span>
+<span id="cb124-6"><a href="#cb124-6" aria-hidden="true" tabindex="-1"></a>    <span class="fu">print</span><span class="op">(</span>mymodule<span class="op">.</span>message<span class="op">)</span></span>
+<span id="cb124-7"><a href="#cb124-7" aria-hidden="true" tabindex="-1"></a><span class="kw">end</span></span></code></pre></div>
+<p>If this module is in the file <code>mymodule.lua</code>, then it can
+be imported like so:</p>
+<div class="sourceCode" id="cb125"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> mymodule <span class="op">=</span> <span class="fu">require</span> <span class="st">&quot;mymodule&quot;</span></span>
+<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a>mymodule<span class="op">.</span>print_message<span class="op">()</span> <span class="co">-- prints hello</span></span></code></pre></div>
+<p>This scheme allows cyclic module imports, e.g. module A requires
+module B which in turn requires module A. Amulet will detect the
+recursion and return A’s (incomplete) export table in B. Then when A has
+finished initialising, all its functions will be available in B. This
+does mean that B can’t call any of A’s functions while its initialising,
+but after initialisation all of A’s functions will be available.</p>
+<p>Of course you can still return your own values from modules and they
+will be returned by <code>require</code> as with the default Lua
+<code>require</code> function.</p>
 <h1 id="logging">Logging</h1>
-<h3 id="log" class="func-def">log(msg, ...)</h3>
-<p>Log a message to the console. The message will also appear in an overlay on the main window.</p>
-<p><code>msg</code> may contain format specifiers like the standard Lua <code>string.format</code> function.</p>
-<p>The logged messages are prefixed with the file name and line number where <code>log</code> was called.</p>
+<h3 class="func-def" id="log">log(msg, …)</h3>
+<p>Log a message to the console. The message will also appear in an
+overlay on the main window.</p>
+<p><code>msg</code> may contain format specifiers like the standard Lua
+<code>string.format</code> function.</p>
+<p>The logged messages are prefixed with the file name and line number
+where <code>log</code> was called.</p>
 <p>Example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="fu">log</span><span class="ot">(</span><span class="st">&quot;here&quot;</span><span class="ot">)</span>
-<span class="fu">log</span><span class="ot">(</span><span class="st">&quot;num = %g, string = %s&quot;</span><span class="ot">,</span> <span class="dv">1</span><span class="ot">,</span> <span class="st">&quot;two&quot;</span><span class="ot">)</span></code></pre></div>
-<h1 id="preventing-accidental-global-variable-usage">Preventing accidental global variable usage</h1>
-<h3 id="noglobals" class="func-def">noglobals()</h3>
-<p>Prevents the creation of new global variables. An error will be raised if a new global is created after this call, or if an attempt is made to read a nil global.</p>
+<div class="sourceCode" id="cb126"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a>log<span class="op">(</span><span class="st">&quot;here&quot;</span><span class="op">)</span></span>
+<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>log<span class="op">(</span><span class="st">&quot;num = %g, string = %s&quot;</span><span class="op">,</span> <span class="dv">1</span><span class="op">,</span> <span class="st">&quot;two&quot;</span><span class="op">)</span></span></code></pre></div>
+<h1 id="preventing-accidental-global-variable-usage">Preventing
+accidental global variable usage</h1>
+<h3 class="func-def" id="noglobals">noglobals()</h3>
+<p>Prevents the creation of new global variables. An error will be
+raised if a new global is created after this call, or if an attempt is
+made to read a nil global.</p>
 <h1 id="globbing">Globbing</h1>
-<h3 id="am.glob" class="func-def">am.glob(patterns)</h3>
-<p>Returns an array (table) of file names matching the given glob pattern(s). <code>patterns</code> should be a table of glob pattern strings. A glob pattern is a file path with zero or more wildcard (<code>*</code>) characters.</p>
-<p>Any matching files that are directories will have a slash (<code>/</code>) appended to their names, even on Windows.</p>
-<p>The slash character (<code>/</code>) can be used as a directory separator on Windows (you don't need to use <code>\</code>). Furthermore returned paths will always have '/' as the directory separator, even on Windows.</p>
-<p><strong>Note:</strong> This function only searches for files on the file system. It won't search the resource archive in a exported game. Its intended use is for writing file processing utilities and not for use directly in games you wish to distribute.</p>
+<h3 class="func-def" id="am.glob">am.glob(patterns)</h3>
+<p>Returns an array (table) of file names matching the given glob
+pattern(s). <code>patterns</code> should be a table of glob pattern
+strings. A glob pattern is a file path with zero or more wildcard
+(<code>*</code>) characters.</p>
+<p>Any matching files that are directories will have a slash
+(<code>/</code>) appended to their names, even on Windows.</p>
+<p>The slash character (<code>/</code>) can be used as a directory
+separator on Windows (you don’t need to use <code>\</code>). Furthermore
+returned paths will always have ‘/’ as the directory separator, even on
+Windows.</p>
+<p><strong>Note:</strong> This function only searches for files on the
+file system. It won’t search the resource archive in a exported game.
+Its intended use is for writing file processing utilities and not for
+use directly in games you wish to distribute.</p>
 <p>Example:</p>
-<div class="sourceCode"><pre class="sourceCode lua"><code class="sourceCode lua"><span class="kw">local</span> image_files <span class="ot">=</span> am<span class="ot">.</span>glob<span class="ot">{</span><span class="st">&quot;images/*.png&quot;</span><span class="ot">,</span> <span class="st">&quot;images/*.jpg&quot;</span><span class="ot">}</span></code></pre></div>
+<div class="sourceCode" id="cb127"><pre
+class="sourceCode lua"><code class="sourceCode lua"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a><span class="kw">local</span> image_files <span class="op">=</span> am<span class="op">.</span>glob<span class="op">{</span><span class="st">&quot;images/*.png&quot;</span><span class="op">,</span> <span class="st">&quot;images/*.jpg&quot;</span><span class="op">}</span></span></code></pre></div>
 <h1 id="running-javascript">Running JavaScript</h1>
-<h3 id="am.eval_js" class="func-def">am.eval_js(js)</h3>
-<p>Runs the given JavaScript string and returns the result as a Lua value. JavaScript objects and arrays are converted to Lua tables and other JavaScript types are converted to the corresponding Lua types. <code>undefined</code> is converted to <code>nil</code>.</p>
-<p>This function only works when running in a browser. On other platforms it has no effect and always returns <code>nil</code>.</p>
+<h3 class="func-def" id="am.eval_js">am.eval_js(js)</h3>
+<p>Runs the given JavaScript string and returns the result as a Lua
+value. JavaScript objects and arrays are converted to Lua tables and
+other JavaScript types are converted to the corresponding Lua types.
+<code>undefined</code> is converted to <code>nil</code>.</p>
+<p>This function only works when running in a browser. On other
+platforms it has no effect and always returns <code>nil</code>.</p>
 <h1 id="converting-tofrom-json">Converting to/from JSON</h1>
-<h3 id="am.to_json" class="func-def">am.to_json(value)</h3>
+<h3 class="func-def" id="am.to_json">am.to_json(value)</h3>
 <p>Converts the given Lua value to a JSON string and returns it.</p>
-<p>Tables with string keys are converted to JSON objects and tables with consecutive integer keys starting at 1 are converted to JSON arrays. Empty tables are converted to empty JSON arrays. Other types of tables are not supported anc cycles are not detected.</p>
-<h3 id="am.parse_json" class="func-def">am.parse_json(json)</h3>
-<p>Converts the given JSON string to a Lua value and returns it. If there was an error parsing the JSON then <code>nil</code> is returned and the error message is returned as a second return value.</p>
+<p>Tables with string keys are converted to JSON objects and tables with
+consecutive integer keys starting at 1 are converted to JSON arrays.
+Empty tables are converted to empty JSON arrays. Other types of tables
+are not supported anc cycles are not detected.</p>
+<h3 class="func-def" id="am.parse_json">am.parse_json(json)</h3>
+<p>Converts the given JSON string to a Lua value and returns it. If
+there was an error parsing the JSON then <code>nil</code> is returned
+and the error message is returned as a second return value.</p>
 <h1 id="loading-other-resources">Loading other resources</h1>
-<h3 id="am.load_script" class="func-def">am.load_script(filename)</h3>
-<p>Loads the Lua script in <code>filename</code> and returns a function that, when called, will run the script. If the file doesn't exist <code>nil</code> is returned.</p>
-<h3 id="am.load_string" class="func-def">am.load_string(filename)</h3>
-<p>Loads <code>filename</code> and returns its contents as a string or <code>nil</code> if the file wasn't found.</p>
+<h3 class="func-def" id="am.load_script">am.load_script(filename)</h3>
+<p>Loads the Lua script in <code>filename</code> and returns a function
+that, when called, will run the script. If the file doesn’t exist
+<code>nil</code> is returned.</p>
+<h3 class="func-def" id="am.load_string">am.load_string(filename)</h3>
+<p>Loads <code>filename</code> and returns its contents as a string or
+<code>nil</code> if the file wasn’t found.</p>
 <h1 id="performance-stats">Performance stats</h1>
-<h3 id="am.perf_stats" class="func-def">am.perf_stats()</h3>
+<h3 class="func-def" id="am.perf_stats">am.perf_stats()</h3>
 <p>Returns a table with the following fields:</p>
 <ul>
-<li><code>avg_fps</code>: frames per second averaged over the last 60 frames</li>
-<li><code>min_fps</code>: the minimum frames per second over the last 60 frames</li>
-<li><code>frame_draw_calls</code>: the number of <code>draw</code> calls in the last frame</li>
-<li><code>frame_use_program_calls</code>: the number of <code>use_program</code> calls in the last frame</li>
+<li><code>avg_fps</code>: frames per second averaged over the last 60
+frames</li>
+<li><code>min_fps</code>: the minimum frames per second over the last 60
+frames</li>
+<li><code>frame_draw_calls</code>: the number of <code>draw</code> calls
+in the last frame</li>
+<li><code>frame_use_program_calls</code>: the number of
+<code>use_program</code> calls in the last frame</li>
 </ul>
 <h1 id="amulet-version">Amulet version</h1>
-<h3 id="am.version" class="field-def">am.version</h3>
-<p>The current Amulet version, as a string. E.g. <code>&quot;1.0.3&quot;</code>.</p>
+<h3 class="field-def" id="am.version">am.version</h3>
+<p>The current Amulet version, as a string. E.g.
+<code>"1.0.3"</code>.</p>
 <h1 id="platform">Platform</h1>
-<h3 id="am.platform" class="field-def">am.platform</h3>
-<p>The platform Amulet is running on. It will be one of the strings <code>&quot;linux&quot;</code> <code>&quot;windows&quot;</code> <code>&quot;osx&quot;</code> <code>&quot;ios&quot;</code> <code>&quot;android&quot;</code> or <code>&quot;html&quot;</code>.</p>
+<h3 class="field-def" id="am.platform">am.platform</h3>
+<p>The platform Amulet is running on. It will be one of the strings
+<code>"linux"</code> <code>"windows"</code> <code>"osx"</code>
+<code>"ios"</code> <code>"android"</code> or <code>"html"</code>.</p>
 <h1 id="language">Language</h1>
-<h3 id="am.language" class="func-def">am.language()</h3>
-<p>Returns the user's preferred ISO 639-1 language code in lower case(e.g. <code>&quot;en&quot;</code>), possibly followed by a dash and an ISO 3166-1 coutry code in upper case (e.g. <code>&quot;fr-CA&quot;</code>). The returned value will be one of the languages listed in the <code>conf.lua</code> file (see <a href="#config">here</a>). This currently only returns a meaningful value on Mac, iOS and Android (on other platforms it always returns <code>&quot;en&quot;</code>).</p>
+<h3 class="func-def" id="am.language">am.language()</h3>
+<p>Returns the user’s preferred ISO 639-1 language code in lower
+case(e.g. <code>"en"</code>), possibly followed by a dash and an ISO
+3166-1 coutry code in upper case (e.g. <code>"fr-CA"</code>). The
+returned value will be one of the languages listed in the
+<code>conf.lua</code> file (see <a href="#config">here</a>). This
+currently only returns a meaningful value on Mac, iOS and Android (on
+other platforms it always returns <code>"en"</code>).</p>
 <h1 id="game-center-ios-only">Game Center (iOS only)</h1>
 <p>The following functions are only available on iOS.</p>
-<h3 id="am.init_gamecenter" class="func-def">am.init_gamecenter()</h3>
-<p>Initialize Game Center. This must be called before any other Game Center functions.</p>
-<h3 id="am.gamecenter_available" class="func-def">am.gamecenter_available()</h3>
+<h3 class="func-def" id="am.init_gamecenter">am.init_gamecenter()</h3>
+<p>Initialize Game Center. This must be called before any other Game
+Center functions.</p>
+<h3 class="func-def"
+id="am.gamecenter_available">am.gamecenter_available()</h3>
 <p>Returns true if Game Center was successfully initialized.</p>
-<h3 id="am.submit_gamecenter_score" class="func-def">am.submit_gamecenter_score(leaderboard_id, score)</h3>
-<p>Submit a score to a leaderboard. Note that Game Center accepts only integer scores.</p>
-<h3 id="am.submit_gamecenter_achievement" class="func-def">am.submit_gamecenter_achievement(achievment_id)</h3>
+<h3 class="func-def"
+id="am.submit_gamecenter_score">am.submit_gamecenter_score(leaderboard_id,
+score)</h3>
+<p>Submit a score to a leaderboard. Note that Game Center accepts only
+integer scores.</p>
+<h3 class="func-def"
+id="am.submit_gamecenter_achievement">am.submit_gamecenter_achievement(achievment_id)</h3>
 <p>Submit an achievement.</p>
-<h3 id="am.show_gamecenter_leaderboard" class="func-def">am.show_gamecenter_leaderboard(leaderboard_id)</h3>
+<h3 class="func-def"
+id="am.show_gamecenter_leaderboard">am.show_gamecenter_leaderboard(leaderboard_id)</h3>
 <p>Display a leaderboard.</p>
 </div>
 </div>

--- a/doc/types.md
+++ b/doc/types.md
@@ -1,0 +1,37 @@
+
+# Deriving Amulet Types
+
+### am.type(value) {#am.type .func-def}
+
+Using Lua's builtin function `type` to derive the type of various amulet types will often return the unhelpful string `"userdata"`.
+
+You can use `am.type` instead which will often yield a more flexible result.
+
+~~~ {.lua}
+local v4 = vec4(1, 0, 0, 1)
+
+local m2 = mat2(
+    vec2(50, 50),
+    vec2(120, 70)
+)
+
+local quat = quat(math.rad(30), vec3(1, 1, 1))
+
+local win = am.window{}
+
+-- normal lua types
+local str = "Hi!"
+local num = 4.2;
+local f = function(x, y)
+    return x ^ y;
+end
+
+print(am.type(v4))   -- prints "vec4"
+print(am.type(m2))   -- prints "mat2"
+print(am.type(quat)) -- prints "quat"
+print(am.type(win))  -- prints "window"
+
+print(am.type(str))  -- prints "string"
+print(am.type(num))  -- prints "number"
+print(am.type(f))    -- prints "function"
+~~~


### PR DESCRIPTION
I suspect this wasn't added yet because some scene nodes behave confusingly, ie: am.rect returns something which has the type `program_node` and am.circle returns something which has the type `translate`. However, I still find this useful to use sometimes. 