### PR TITLE
Allow get/set am.window title property

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -306,6 +306,7 @@ id="toc-window.show_cursor">window.show_cursor</a></li>
 <li><a href="#window.scene" id="toc-window.scene">window.scene</a></li>
 <li><a href="#window.projection"
 id="toc-window.projection">window.projection</a></li>
+<li><a href="#window.title" id="toc-window.title">window.title</a></li>
 </ul></li>
 <li><a href="#closing-a-window" id="toc-closing-a-window">Closing a
 window</a>
@@ -2626,6 +2627,9 @@ id="window.stencil_clear_value">window.stencil_clear_value</h3>
 window. This scene will be rendered to the window each frame.</p>
 <p>Updatable.</p>
 <h3 class="field-def" id="window.projection">window.projection</h3>
+<p>See <a href="#am.window">window settings</a>.</p>
+<p>Updatable.</p>
+<h3 class="field-def" id="window.title">window.title</h3>
 <p>See <a href="#am.window">window settings</a>.</p>
 <p>Updatable.</p>
 <h2 id="closing-a-window">Closing a window</h2>

--- a/doc/windows.md
+++ b/doc/windows.md
@@ -28,9 +28,9 @@ table with any of the following fields:
     `physical_size` property is given (see below).
 
 - **`physical_size`**:
-    The initial physical size of the window in windowed mode (a `vec2`). 
+    The initial physical size of the window in windowed mode (a `vec2`).
     This is in "screen units" which usually correspond to pixels, but not
-    always. For example on a retina Mac display where `highdpi` is enabled 
+    always. For example on a retina Mac display where `highdpi` is enabled
     there are 2 pixels per screen unit. If this property is omitted then
     the `width` and `height` properties will be used for the physical window
     size. Note that this property has no effect on the coordinate system
@@ -101,7 +101,7 @@ table with any of the following fields:
 
 ### window.left {.func-def}
 
-The x coordinate of the left edge of the 
+The x coordinate of the left edge of the
 window in the window's default coordinate system.
 
 Readonly.
@@ -161,7 +161,7 @@ Readonly.
 
 ### window.safe_left {.func-def}
 
-The x coordinate of the left edge of the 
+The x coordinate of the left edge of the
 window's safe area in the window's default coordinate system.
 
 This should be used to position elements that you don't want obscured
@@ -243,6 +243,12 @@ This scene will be rendered to the window each frame.
 Updatable.
 
 ### window.projection {.field-def}
+
+See [window settings](#am.window).
+
+Updatable.
+
+### window.title {.field-def}
 
 See [window settings](#am.window).
 
@@ -465,7 +471,7 @@ last frame.
 `button` may be `"left"`, `"right"` or `"middle"`.
 
 Note that if `mouse_pressed` returns `true` for a particular button then
-`mouse_down` will also return `true`. Also 
+`mouse_down` will also return `true`. Also
 if `mouse_pressed` returns `true` for a particular button then `mouse_released`
 will return `false`. (If necessary, Amulet will
 postpone button release events to the next frame to ensure this.)
@@ -477,7 +483,7 @@ from down to up since the last frame.
 `button` may be `"left"`, `"right"` or `"middle"`.
 
 Note that if `mouse_released` returns `true` for a particular button then
-`mouse_down` will return `false`. Also 
+`mouse_down` will return `false`. Also
 if `mouse_released` returns `true` for a particular button then `mouse_pressed`
 will return `false`. (If necessary, Amulet will
 postpone button press events to the next frame to ensure this.)

--- a/doc/windows.md
+++ b/doc/windows.md
@@ -28,9 +28,9 @@ table with any of the following fields:
     `physical_size` property is given (see below).
 
 - **`physical_size`**:
-    The initial physical size of the window in windowed mode (a `vec2`).
+    The initial physical size of the window in windowed mode (a `vec2`). 
     This is in "screen units" which usually correspond to pixels, but not
-    always. For example on a retina Mac display where `highdpi` is enabled
+    always. For example on a retina Mac display where `highdpi` is enabled 
     there are 2 pixels per screen unit. If this property is omitted then
     the `width` and `height` properties will be used for the physical window
     size. Note that this property has no effect on the coordinate system
@@ -101,7 +101,7 @@ table with any of the following fields:
 
 ### window.left {.func-def}
 
-The x coordinate of the left edge of the
+The x coordinate of the left edge of the 
 window in the window's default coordinate system.
 
 Readonly.
@@ -161,7 +161,7 @@ Readonly.
 
 ### window.safe_left {.func-def}
 
-The x coordinate of the left edge of the
+The x coordinate of the left edge of the 
 window's safe area in the window's default coordinate system.
 
 This should be used to position elements that you don't want obscured
@@ -471,7 +471,7 @@ last frame.
 `button` may be `"left"`, `"right"` or `"middle"`.
 
 Note that if `mouse_pressed` returns `true` for a particular button then
-`mouse_down` will also return `true`. Also
+`mouse_down` will also return `true`. Also 
 if `mouse_pressed` returns `true` for a particular button then `mouse_released`
 will return `false`. (If necessary, Amulet will
 postpone button release events to the next frame to ensure this.)
@@ -483,7 +483,7 @@ from down to up since the last frame.
 `button` may be `"left"`, `"right"` or `"middle"`.
 
 Note that if `mouse_released` returns `true` for a particular button then
-`mouse_down` will return `false`. Also
+`mouse_down` will return `false`. Also 
 if `mouse_released` returns `true` for a particular button then `mouse_pressed`
 will return `false`. (If necessary, Amulet will
 postpone button press events to the next frame to ensure this.)

--- a/src/am_backend.h
+++ b/src/am_backend.h
@@ -67,3 +67,4 @@ void am_open_sdl_module(lua_State *L);
 #endif
 
 char *am_open_file_dialog();
+

--- a/src/am_backend.h
+++ b/src/am_backend.h
@@ -33,6 +33,8 @@ bool am_get_native_window_lock_pointer(am_native_window *window);
 void am_set_native_window_lock_pointer(am_native_window *window, bool lock);
 bool am_get_native_window_show_cursor(am_native_window *window);
 void am_set_native_window_show_cursor(am_native_window *window, bool show);
+const char* am_get_native_window_title(am_native_window *window);
+void am_set_native_window_title(am_native_window *window, const char* title);
 void am_destroy_native_window(am_native_window *window);
 
 void am_native_window_bind_framebuffer(am_native_window *win);

--- a/src/am_backend_android.cpp
+++ b/src/am_backend_android.cpp
@@ -93,13 +93,13 @@ static void android_update() {
     pthread_mutex_unlock(&android_audio_mutex);
 
     frame_time = am_get_current_time();
-
+    
     real_delta_time = frame_time - t0;
     if (am_conf_warn_delta_time > 0.0 && real_delta_time > am_conf_warn_delta_time) {
         am_log0("WARNING: FPS dropped to %0.2f (%fs)", 1.0/real_delta_time, real_delta_time);
     }
     // take min in case app paused, or last frame took very long
-    delta_time = am_min(am_conf_max_delta_time, real_delta_time);
+    delta_time = am_min(am_conf_max_delta_time, real_delta_time); 
     t_debt += delta_time;
 
     if (am_conf_fixed_delta_time > 0.0) {
@@ -237,7 +237,7 @@ JNIEXPORT void JNICALL Java_xyz_amulet_AmuletActivity_jniIAPProductsRetrieved(JN
                 env->DeleteLocalRef(jpid);
                 env->DeleteLocalRef(jprice);
                 lua_settable(L, -3);
-            }
+            } 
         } else {
             lua_pushnil(L);
         }
@@ -355,7 +355,7 @@ void am_get_native_window_size(am_native_window *window, int *pw, int *ph, int *
     *sh = android_win_height;
 }
 
-void am_get_native_window_safe_area_margin(am_native_window *window,
+void am_get_native_window_safe_area_margin(am_native_window *window, 
     int *left, int *right, int *bottom, int *top)
 {
     *left = 0;
@@ -382,6 +382,13 @@ bool am_get_native_window_show_cursor(am_native_window *window) {
 void am_set_native_window_show_cursor(am_native_window *window, bool show) {
 }
 
+const char* am_get_native_window_title(am_native_window *window) {
+    return NULL;
+}
+
+void am_set_native_window_title(am_native_window *window, const char* title) {
+}
+
 void am_destroy_native_window(am_native_window *window) {
 }
 
@@ -391,13 +398,6 @@ void am_native_window_bind_framebuffer(am_native_window *win) {
 
 void am_native_window_swap_buffers(am_native_window *window) {
     // handled by Android, I think
-}
-
-const char* am_get_native_window_title(am_native_window *window) {
-    return NULL;
-}
-
-void am_set_native_window_title(am_native_window *window, const char* title) {
 }
 
 double am_get_current_time() {

--- a/src/am_backend_android.cpp
+++ b/src/am_backend_android.cpp
@@ -93,13 +93,13 @@ static void android_update() {
     pthread_mutex_unlock(&android_audio_mutex);
 
     frame_time = am_get_current_time();
-    
+
     real_delta_time = frame_time - t0;
     if (am_conf_warn_delta_time > 0.0 && real_delta_time > am_conf_warn_delta_time) {
         am_log0("WARNING: FPS dropped to %0.2f (%fs)", 1.0/real_delta_time, real_delta_time);
     }
     // take min in case app paused, or last frame took very long
-    delta_time = am_min(am_conf_max_delta_time, real_delta_time); 
+    delta_time = am_min(am_conf_max_delta_time, real_delta_time);
     t_debt += delta_time;
 
     if (am_conf_fixed_delta_time > 0.0) {
@@ -237,7 +237,7 @@ JNIEXPORT void JNICALL Java_xyz_amulet_AmuletActivity_jniIAPProductsRetrieved(JN
                 env->DeleteLocalRef(jpid);
                 env->DeleteLocalRef(jprice);
                 lua_settable(L, -3);
-            } 
+            }
         } else {
             lua_pushnil(L);
         }
@@ -355,7 +355,7 @@ void am_get_native_window_size(am_native_window *window, int *pw, int *ph, int *
     *sh = android_win_height;
 }
 
-void am_get_native_window_safe_area_margin(am_native_window *window, 
+void am_get_native_window_safe_area_margin(am_native_window *window,
     int *left, int *right, int *bottom, int *top)
 {
     *left = 0;
@@ -391,6 +391,13 @@ void am_native_window_bind_framebuffer(am_native_window *win) {
 
 void am_native_window_swap_buffers(am_native_window *window) {
     // handled by Android, I think
+}
+
+const char* am_get_native_window_title(am_native_window *window) {
+    return NULL;
+}
+
+void am_set_native_window_title(am_native_window *window, const char* title) {
 }
 
 double am_get_current_time() {

--- a/src/am_backend_emscripten.cpp
+++ b/src/am_backend_emscripten.cpp
@@ -91,13 +91,20 @@ void am_get_native_window_size(am_native_window *window, int *pw, int *ph, int *
     *sh = *ph;
 }
 
-void am_get_native_window_safe_area_margin(am_native_window *window,
+void am_get_native_window_safe_area_margin(am_native_window *window, 
     int *left, int *right, int *bottom, int *top)
 {
     *left = 0;
     *right = 0;
     *bottom = 0;
     *top = 0;
+}
+
+const char* am_get_native_window_title(am_native_window *window) {
+    return NULL;
+}
+
+void am_set_native_window_title(am_native_window *window, const char* title) {
 }
 
 void am_destroy_native_window(am_native_window* win) {
@@ -430,7 +437,7 @@ static bool handle_events() {
 static void audio_callback(void *ud, Uint8 *stream, int len) {
     if (len != (int)sizeof(float) * am_conf_audio_buffer_size * am_conf_audio_channels) {
         am_log0("audio buffer size mismatch! (%d vs %d)",
-            len,
+            len, 
             (int)sizeof(float) * am_conf_audio_buffer_size * am_conf_audio_channels);
         memset(stream, 0, len);
         return;
@@ -489,13 +496,6 @@ void am_set_native_window_show_cursor(am_native_window *window, bool show) {
 
 bool am_get_native_window_show_cursor(am_native_window *window) {
     return EM_ASM_INT({ return window.amulet.show_cursor ? 1 : 0; }, 0) == 1;
-}
-
-const char* am_get_native_window_title(am_native_window *window) {
-    return NULL;
-}
-
-void am_set_native_window_title(am_native_window *window, const char* title) {
 }
 
 static am_key convert_key(SDL_Keycode key) {
@@ -616,7 +616,7 @@ static void on_load_package_progress(unsigned int x, void *arg, int perc) {
 
 static void load_package(const char *url) {
     emscripten_async_wget2(url, "data.pak", "GET", "", NULL,
-        &on_load_package_complete, &on_load_package_error, &on_load_package_progress);
+        &on_load_package_complete, &on_load_package_error, &on_load_package_progress); 
 }
 
 static void open_package() {

--- a/src/am_backend_emscripten.cpp
+++ b/src/am_backend_emscripten.cpp
@@ -91,7 +91,7 @@ void am_get_native_window_size(am_native_window *window, int *pw, int *ph, int *
     *sh = *ph;
 }
 
-void am_get_native_window_safe_area_margin(am_native_window *window, 
+void am_get_native_window_safe_area_margin(am_native_window *window,
     int *left, int *right, int *bottom, int *top)
 {
     *left = 0;
@@ -430,7 +430,7 @@ static bool handle_events() {
 static void audio_callback(void *ud, Uint8 *stream, int len) {
     if (len != (int)sizeof(float) * am_conf_audio_buffer_size * am_conf_audio_channels) {
         am_log0("audio buffer size mismatch! (%d vs %d)",
-            len, 
+            len,
             (int)sizeof(float) * am_conf_audio_buffer_size * am_conf_audio_channels);
         memset(stream, 0, len);
         return;
@@ -489,6 +489,13 @@ void am_set_native_window_show_cursor(am_native_window *window, bool show) {
 
 bool am_get_native_window_show_cursor(am_native_window *window) {
     return EM_ASM_INT({ return window.amulet.show_cursor ? 1 : 0; }, 0) == 1;
+}
+
+const char* am_get_native_window_title(am_native_window *window) {
+    return NULL;
+}
+
+void am_set_native_window_title(am_native_window *window, const char* title) {
 }
 
 static am_key convert_key(SDL_Keycode key) {
@@ -609,7 +616,7 @@ static void on_load_package_progress(unsigned int x, void *arg, int perc) {
 
 static void load_package(const char *url) {
     emscripten_async_wget2(url, "data.pak", "GET", "", NULL,
-        &on_load_package_complete, &on_load_package_error, &on_load_package_progress); 
+        &on_load_package_complete, &on_load_package_error, &on_load_package_progress);
 }
 
 static void open_package() {

--- a/src/am_backend_ios_gl.cpp
+++ b/src/am_backend_ios_gl.cpp
@@ -311,7 +311,7 @@ static void ios_init_audio() {
     strdesc.mBytesPerPacket =
         strdesc.mBytesPerFrame * strdesc.mFramesPerPacket;
 
-    if (noErr != 
+    if (noErr !=
         AudioUnitSetProperty(instance, kAudioUnitProperty_StreamFormat,
             scope, bus, &strdesc, sizeof(AudioStreamBasicDescription)))
     {
@@ -323,7 +323,7 @@ static void ios_init_audio() {
     memset(&callback, 0, sizeof(AURenderCallbackStruct));
     callback.inputProc = ios_audio_callback;
     callback.inputProcRefCon = NULL;
-    if (noErr != 
+    if (noErr !=
         AudioUnitSetProperty(instance, kAudioUnitProperty_SetRenderCallback,
             scope, bus, &callback, sizeof(AURenderCallbackStruct)))
     {
@@ -411,13 +411,13 @@ static void ios_update() {
     [ios_audio_mutex unlock];
 
     frame_time = am_get_current_time();
-    
+
     real_delta_time = frame_time - t0;
     if (am_conf_warn_delta_time > 0.0 && real_delta_time > am_conf_warn_delta_time) {
         am_log0("WARNING: FPS dropped to %0.2f (%fs)", 1.0/real_delta_time, real_delta_time);
     }
     // take min in case app paused, or last frame took very long
-    delta_time = am_min(am_conf_max_delta_time, real_delta_time); 
+    delta_time = am_min(am_conf_max_delta_time, real_delta_time);
     t_debt += delta_time;
 
     if (am_conf_fixed_delta_time > 0.0) {
@@ -622,7 +622,7 @@ static BOOL handle_orientation(UIInterfaceOrientation orientation) {
 {
     //am_debug("%s", "supportedInterfaceOrientations");
     switch (ios_orientation) {
-        case AM_DISPLAY_ORIENTATION_PORTRAIT: 
+        case AM_DISPLAY_ORIENTATION_PORTRAIT:
             return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
         case AM_DISPLAY_ORIENTATION_LANDSCAPE:
             return UIInterfaceOrientationMaskLandscapeRight | UIInterfaceOrientationMaskLandscapeLeft;
@@ -693,13 +693,13 @@ extern void am_ios_custom_init(UIViewController *view_controller);
 #endif
 
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
- 
+
     EAGLContext * context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
     GLKView *view = [[GLKView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     view.context = context;
     view.delegate = self;
     ios_view = view;
-    [view setMultipleTouchEnabled:YES]; 
+    [view setMultipleTouchEnabled:YES];
 
     if ([ios_view respondsToSelector: NSSelectorFromString(@"traitCollection")] &&
         [[ios_view traitCollection] respondsToSelector: NSSelectorFromString(@"forceTouchCapability")])
@@ -711,7 +711,7 @@ extern void am_ios_custom_init(UIViewController *view_controller);
 
     ios_init_engine();
     ios_init_audio();
- 
+
     GLKViewController * viewController = [[AMViewController alloc] initWithNibName:nil bundle:nil];
     viewController.view = view;
     viewController.delegate = self;
@@ -729,13 +729,13 @@ extern void am_ios_custom_init(UIViewController *view_controller);
 }
 
 - (void)glkView:(GLKView *)view drawInRect:(CGRect)rect {
-    //am_debug("%s", "draw"); 
+    //am_debug("%s", "draw");
     ios_draw();
     ios_done_first_draw = true;
 }
 
 - (void)glkViewControllerUpdate:(GLKViewController *)controller {
-    //am_debug("%s", "update"); 
+    //am_debug("%s", "update");
     if (ios_done_first_draw) {
         // make sure we do a draw before our first update
         ios_update();
@@ -773,14 +773,14 @@ extern void am_ios_custom_init(UIViewController *view_controller);
 }
 
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
-{    
+{
     if (ios_view_controller != nil && ios_view_controller.presentedViewController == nil) {
         ios_touch_moved(touches);
     }
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
-{    
+{
     if (ios_view_controller != nil && ios_view_controller.presentedViewController == nil) {
         ios_touch_ended(touches);
     }
@@ -841,7 +841,7 @@ extern void am_ios_custom_init(UIViewController *view_controller);
     }
 }
 
-- (void)paymentQueue:(SKPaymentQueue *)queue 
+- (void)paymentQueue:(SKPaymentQueue *)queue
 restoreCompletedTransactionsFailedWithError:(NSError *)error
 {
     [self performSelectorOnMainThread:@selector(restoreCompletedTransactionsFailedWithErrorMain) withObject:nil waitUntilDone:YES];
@@ -999,7 +999,7 @@ void am_get_native_window_size(am_native_window *window, int *pw, int *ph, int *
     *ph = *sh * scale;
 }
 
-void am_get_native_window_safe_area_margin(am_native_window *window, 
+void am_get_native_window_safe_area_margin(am_native_window *window,
     int *left, int *right, int *bottom, int *top)
 {
     *left = 0;
@@ -1024,6 +1024,13 @@ void am_set_native_window_show_cursor(am_native_window *window, bool show) {
 
 bool am_get_native_window_show_cursor(am_native_window *window) {
     return false;
+}
+
+const char* am_get_native_window_title(am_native_window *window) {
+    return NULL;
+}
+
+void am_set_native_window_title(am_native_window *window, const char* title) {
 }
 
 void am_destroy_native_window(am_native_window *window) {
@@ -1076,7 +1083,7 @@ int am_next_video_capture_frame() {
 
 static bool gamecenter_available = false;
 
-@interface GameCenterLeaderboardViewController : GKGameCenterViewController 
+@interface GameCenterLeaderboardViewController : GKGameCenterViewController
 @end
 
 @implementation GameCenterLeaderboardViewController
@@ -1168,9 +1175,9 @@ static int init_gamecenter(lua_State *L) {
                 //problem with authentication, probably because the user doesn't use Game Center
                 //am_debug("%s", "gamecenter authentication failed");
             }
-        })]; 
+        })];
     } else {
-        NSLog(@"Already authenticated!");   
+        NSLog(@"Already authenticated!");
     }
     gamecenter_delegate = [[GameCenterDelegate alloc] init];
     [gamecenter_delegate retain];
@@ -1371,7 +1378,7 @@ static void register_iap_product_mt(lua_State *L) {
             lua_pushstring(L, [[product productIdentifier] UTF8String]);
             am_new_userdata(L, am_iap_product)->product = product;
             lua_settable(L, -3);
-        } 
+        }
         am_call_amulet(L, "_iap_retrieve_products_finished", 1, 0);
     }
 }
@@ -1409,7 +1416,7 @@ static int retrieve_iap_products(lua_State *L) {
     }
     SKProductsRequest *productsRequest = [[SKProductsRequest alloc] initWithProductIdentifiers:ids];
     [ids dealloc];
-                     
+
     [productsRequest retain];
     productsRequest.delegate = [[RetrieveIAPProductsDelegate alloc] init];
     [productsRequest start];
@@ -1455,7 +1462,7 @@ static int iap_product_local_price(lua_State *L) {
 static int ios_request_review(lua_State *L) {
     if([SKStoreReviewController class]){
        [SKStoreReviewController requestReview] ;
-    } 
+    }
     return 0;
 }
 

--- a/src/am_backend_ios_gl.cpp
+++ b/src/am_backend_ios_gl.cpp
@@ -311,7 +311,7 @@ static void ios_init_audio() {
     strdesc.mBytesPerPacket =
         strdesc.mBytesPerFrame * strdesc.mFramesPerPacket;
 
-    if (noErr !=
+    if (noErr != 
         AudioUnitSetProperty(instance, kAudioUnitProperty_StreamFormat,
             scope, bus, &strdesc, sizeof(AudioStreamBasicDescription)))
     {
@@ -323,7 +323,7 @@ static void ios_init_audio() {
     memset(&callback, 0, sizeof(AURenderCallbackStruct));
     callback.inputProc = ios_audio_callback;
     callback.inputProcRefCon = NULL;
-    if (noErr !=
+    if (noErr != 
         AudioUnitSetProperty(instance, kAudioUnitProperty_SetRenderCallback,
             scope, bus, &callback, sizeof(AURenderCallbackStruct)))
     {
@@ -411,13 +411,13 @@ static void ios_update() {
     [ios_audio_mutex unlock];
 
     frame_time = am_get_current_time();
-
+    
     real_delta_time = frame_time - t0;
     if (am_conf_warn_delta_time > 0.0 && real_delta_time > am_conf_warn_delta_time) {
         am_log0("WARNING: FPS dropped to %0.2f (%fs)", 1.0/real_delta_time, real_delta_time);
     }
     // take min in case app paused, or last frame took very long
-    delta_time = am_min(am_conf_max_delta_time, real_delta_time);
+    delta_time = am_min(am_conf_max_delta_time, real_delta_time); 
     t_debt += delta_time;
 
     if (am_conf_fixed_delta_time > 0.0) {
@@ -622,7 +622,7 @@ static BOOL handle_orientation(UIInterfaceOrientation orientation) {
 {
     //am_debug("%s", "supportedInterfaceOrientations");
     switch (ios_orientation) {
-        case AM_DISPLAY_ORIENTATION_PORTRAIT:
+        case AM_DISPLAY_ORIENTATION_PORTRAIT: 
             return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
         case AM_DISPLAY_ORIENTATION_LANDSCAPE:
             return UIInterfaceOrientationMaskLandscapeRight | UIInterfaceOrientationMaskLandscapeLeft;
@@ -693,13 +693,13 @@ extern void am_ios_custom_init(UIViewController *view_controller);
 #endif
 
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-
+ 
     EAGLContext * context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
     GLKView *view = [[GLKView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     view.context = context;
     view.delegate = self;
     ios_view = view;
-    [view setMultipleTouchEnabled:YES];
+    [view setMultipleTouchEnabled:YES]; 
 
     if ([ios_view respondsToSelector: NSSelectorFromString(@"traitCollection")] &&
         [[ios_view traitCollection] respondsToSelector: NSSelectorFromString(@"forceTouchCapability")])
@@ -711,7 +711,7 @@ extern void am_ios_custom_init(UIViewController *view_controller);
 
     ios_init_engine();
     ios_init_audio();
-
+ 
     GLKViewController * viewController = [[AMViewController alloc] initWithNibName:nil bundle:nil];
     viewController.view = view;
     viewController.delegate = self;
@@ -729,13 +729,13 @@ extern void am_ios_custom_init(UIViewController *view_controller);
 }
 
 - (void)glkView:(GLKView *)view drawInRect:(CGRect)rect {
-    //am_debug("%s", "draw");
+    //am_debug("%s", "draw"); 
     ios_draw();
     ios_done_first_draw = true;
 }
 
 - (void)glkViewControllerUpdate:(GLKViewController *)controller {
-    //am_debug("%s", "update");
+    //am_debug("%s", "update"); 
     if (ios_done_first_draw) {
         // make sure we do a draw before our first update
         ios_update();
@@ -773,14 +773,14 @@ extern void am_ios_custom_init(UIViewController *view_controller);
 }
 
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
-{
+{    
     if (ios_view_controller != nil && ios_view_controller.presentedViewController == nil) {
         ios_touch_moved(touches);
     }
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
-{
+{    
     if (ios_view_controller != nil && ios_view_controller.presentedViewController == nil) {
         ios_touch_ended(touches);
     }
@@ -841,7 +841,7 @@ extern void am_ios_custom_init(UIViewController *view_controller);
     }
 }
 
-- (void)paymentQueue:(SKPaymentQueue *)queue
+- (void)paymentQueue:(SKPaymentQueue *)queue 
 restoreCompletedTransactionsFailedWithError:(NSError *)error
 {
     [self performSelectorOnMainThread:@selector(restoreCompletedTransactionsFailedWithErrorMain) withObject:nil waitUntilDone:YES];
@@ -999,7 +999,7 @@ void am_get_native_window_size(am_native_window *window, int *pw, int *ph, int *
     *ph = *sh * scale;
 }
 
-void am_get_native_window_safe_area_margin(am_native_window *window,
+void am_get_native_window_safe_area_margin(am_native_window *window, 
     int *left, int *right, int *bottom, int *top)
 {
     *left = 0;
@@ -1083,7 +1083,7 @@ int am_next_video_capture_frame() {
 
 static bool gamecenter_available = false;
 
-@interface GameCenterLeaderboardViewController : GKGameCenterViewController
+@interface GameCenterLeaderboardViewController : GKGameCenterViewController 
 @end
 
 @implementation GameCenterLeaderboardViewController
@@ -1175,9 +1175,9 @@ static int init_gamecenter(lua_State *L) {
                 //problem with authentication, probably because the user doesn't use Game Center
                 //am_debug("%s", "gamecenter authentication failed");
             }
-        })];
+        })]; 
     } else {
-        NSLog(@"Already authenticated!");
+        NSLog(@"Already authenticated!");   
     }
     gamecenter_delegate = [[GameCenterDelegate alloc] init];
     [gamecenter_delegate retain];
@@ -1378,7 +1378,7 @@ static void register_iap_product_mt(lua_State *L) {
             lua_pushstring(L, [[product productIdentifier] UTF8String]);
             am_new_userdata(L, am_iap_product)->product = product;
             lua_settable(L, -3);
-        }
+        } 
         am_call_amulet(L, "_iap_retrieve_products_finished", 1, 0);
     }
 }
@@ -1416,7 +1416,7 @@ static int retrieve_iap_products(lua_State *L) {
     }
     SKProductsRequest *productsRequest = [[SKProductsRequest alloc] initWithProductIdentifiers:ids];
     [ids dealloc];
-
+                     
     [productsRequest retain];
     productsRequest.delegate = [[RetrieveIAPProductsDelegate alloc] init];
     [productsRequest start];
@@ -1462,7 +1462,7 @@ static int iap_product_local_price(lua_State *L) {
 static int ios_request_review(lua_State *L) {
     if([SKStoreReviewController class]){
        [SKStoreReviewController requestReview] ;
-    }
+    } 
     return 0;
 }
 

--- a/src/am_backend_ios_metal.cpp
+++ b/src/am_backend_ios_metal.cpp
@@ -402,7 +402,7 @@ static void ios_init_audio() {
     strdesc.mBytesPerPacket =
         strdesc.mBytesPerFrame * strdesc.mFramesPerPacket;
 
-    if (noErr !=
+    if (noErr != 
         AudioUnitSetProperty(instance, kAudioUnitProperty_StreamFormat,
             scope, bus, &strdesc, sizeof(AudioStreamBasicDescription)))
     {
@@ -414,7 +414,7 @@ static void ios_init_audio() {
     memset(&callback, 0, sizeof(AURenderCallbackStruct));
     callback.inputProc = ios_audio_callback;
     callback.inputProcRefCon = NULL;
-    if (noErr !=
+    if (noErr != 
         AudioUnitSetProperty(instance, kAudioUnitProperty_SetRenderCallback,
             scope, bus, &callback, sizeof(AURenderCallbackStruct)))
     {
@@ -522,10 +522,10 @@ static void ios_update() {
     [ios_audio_mutex unlock];
 
     frame_time = am_get_current_time();
-
+    
     real_delta_time = frame_time - t0;
     // take min in case app paused, or last frame took very long
-    delta_time = am_min(am_conf_max_delta_time, real_delta_time);
+    delta_time = am_min(am_conf_max_delta_time, real_delta_time); 
     t_debt += delta_time;
 
     if (am_conf_fixed_delta_time > 0.0) {
@@ -742,7 +742,7 @@ static BOOL handle_orientation(UIInterfaceOrientation orientation) {
 {
     //am_debug("%s", "supportedInterfaceOrientations");
     switch (ios_orientation) {
-        case AM_DISPLAY_ORIENTATION_PORTRAIT:
+        case AM_DISPLAY_ORIENTATION_PORTRAIT: 
             return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
         case AM_DISPLAY_ORIENTATION_LANDSCAPE:
             return UIInterfaceOrientationMaskLandscapeRight | UIInterfaceOrientationMaskLandscapeLeft;
@@ -834,12 +834,12 @@ extern void am_ios_custom_init(UIViewController *view_controller);
 #endif
 
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-
+ 
     MTKView *view = [[MTKView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     view.device = MTLCreateSystemDefaultDevice();
     view.delegate = self;
     view.preferredFramesPerSecond = 60;
-    [view setMultipleTouchEnabled:YES];
+    [view setMultipleTouchEnabled:YES]; 
     ios_view = view;
     am_metal_ios_view = ios_view;
 
@@ -860,7 +860,7 @@ extern void am_ios_custom_init(UIViewController *view_controller);
 
     ios_init_engine();
     ios_init_audio();
-
+ 
     am_ios_custom_init(viewController);
 
     return YES;
@@ -886,7 +886,7 @@ extern void am_ios_custom_init(UIViewController *view_controller);
     am_metal_window_sheight = (int)((float)am_metal_window_pheight / scale);
 
     @autoreleasepool {
-        //am_debug("%s", "draw");
+        //am_debug("%s", "draw"); 
         if (ios_done_first_draw) {
             // make sure we do a draw before our first update
             ios_update();
@@ -940,14 +940,14 @@ extern void am_ios_custom_init(UIViewController *view_controller);
 }
 
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
-{
+{    
     if (ios_view_controller != nil && ios_view_controller.presentedViewController == nil) {
         ios_touch_moved(touches);
     }
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
-{
+{    
     if (ios_view_controller != nil && ios_view_controller.presentedViewController == nil) {
         ios_touch_ended(touches);
     }
@@ -1008,7 +1008,7 @@ extern void am_ios_custom_init(UIViewController *view_controller);
     }
 }
 
-- (void)paymentQueue:(SKPaymentQueue *)queue
+- (void)paymentQueue:(SKPaymentQueue *)queue 
 restoreCompletedTransactionsFailedWithError:(NSError *)error
 {
     [self performSelectorOnMainThread:@selector(restoreCompletedTransactionsFailedWithErrorMain) withObject:nil waitUntilDone:YES];
@@ -1176,7 +1176,7 @@ void am_get_native_window_size(am_native_window *window, int *pw, int *ph, int *
     *sh = am_metal_window_sheight;
 }
 
-void am_get_native_window_safe_area_margin(am_native_window *window,
+void am_get_native_window_safe_area_margin(am_native_window *window, 
     int *left, int *right, int *bottom, int *top)
 {
     if (ios_view != nil && ios_view.window != nil) {
@@ -1266,7 +1266,7 @@ int am_next_video_capture_frame() {
 
 static bool gamecenter_available = false;
 
-@interface GameCenterLeaderboardViewController : GKGameCenterViewController
+@interface GameCenterLeaderboardViewController : GKGameCenterViewController 
 @end
 
 @implementation GameCenterLeaderboardViewController
@@ -1359,9 +1359,9 @@ static int init_gamecenter(lua_State *L) {
                 //problem with authentication, probably because the user doesn't use Game Center
                 //am_debug("%s", "gamecenter authentication failed");
             }
-        })];
+        })]; 
     } else {
-        NSLog(@"Already authenticated!");
+        NSLog(@"Already authenticated!");   
     }
     gamecenter_delegate = [[GameCenterDelegate alloc] init];
     [gamecenter_delegate retain];
@@ -1566,7 +1566,7 @@ static void register_iap_product_mt(lua_State *L) {
                 am_new_userdata(L, am_iap_product)->product = product;
                 lua_settable(L, -3);
             }
-        }
+        } 
         am_call_amulet(L, "_iap_retrieve_products_finished", 1, 0);
     }
 }
@@ -1604,7 +1604,7 @@ static int retrieve_iap_products(lua_State *L) {
     }
     SKProductsRequest *productsRequest = [[SKProductsRequest alloc] initWithProductIdentifiers:ids];
     [ids dealloc];
-
+                     
     [productsRequest retain];
     productsRequest.delegate = [[RetrieveIAPProductsDelegate alloc] init];
     [productsRequest start];
@@ -1650,7 +1650,7 @@ static int iap_product_local_price(lua_State *L) {
 static int ios_request_review(lua_State *L) {
     if([SKStoreReviewController class]){
        [SKStoreReviewController requestReview] ;
-    }
+    } 
     return 0;
 }
 
@@ -1708,16 +1708,16 @@ static int show_alert(lua_State *L) {
 
 @implementation AMWebViewDelegate
 
-- (void)webView:(WKWebView *)webView
-    didFailNavigation:(WKNavigation *)navigation
+- (void)webView:(WKWebView *)webView 
+    didFailNavigation:(WKNavigation *)navigation 
     withError:(NSError *)error
 {
     //NSLog(@"------------------------ webkit navigation error");
     self.was_error = YES;
 }
 
-- (void)webView:(WKWebView *)webView
-    didFailProvisionalNavigation:(WKNavigation *)navigation
+- (void)webView:(WKWebView *)webView 
+    didFailProvisionalNavigation:(WKNavigation *)navigation 
     withError:(NSError *)error
 {
     //NSLog(@"------------------------ webkit navigation provisional error");

--- a/src/am_backend_ios_metal.cpp
+++ b/src/am_backend_ios_metal.cpp
@@ -402,7 +402,7 @@ static void ios_init_audio() {
     strdesc.mBytesPerPacket =
         strdesc.mBytesPerFrame * strdesc.mFramesPerPacket;
 
-    if (noErr != 
+    if (noErr !=
         AudioUnitSetProperty(instance, kAudioUnitProperty_StreamFormat,
             scope, bus, &strdesc, sizeof(AudioStreamBasicDescription)))
     {
@@ -414,7 +414,7 @@ static void ios_init_audio() {
     memset(&callback, 0, sizeof(AURenderCallbackStruct));
     callback.inputProc = ios_audio_callback;
     callback.inputProcRefCon = NULL;
-    if (noErr != 
+    if (noErr !=
         AudioUnitSetProperty(instance, kAudioUnitProperty_SetRenderCallback,
             scope, bus, &callback, sizeof(AURenderCallbackStruct)))
     {
@@ -522,10 +522,10 @@ static void ios_update() {
     [ios_audio_mutex unlock];
 
     frame_time = am_get_current_time();
-    
+
     real_delta_time = frame_time - t0;
     // take min in case app paused, or last frame took very long
-    delta_time = am_min(am_conf_max_delta_time, real_delta_time); 
+    delta_time = am_min(am_conf_max_delta_time, real_delta_time);
     t_debt += delta_time;
 
     if (am_conf_fixed_delta_time > 0.0) {
@@ -742,7 +742,7 @@ static BOOL handle_orientation(UIInterfaceOrientation orientation) {
 {
     //am_debug("%s", "supportedInterfaceOrientations");
     switch (ios_orientation) {
-        case AM_DISPLAY_ORIENTATION_PORTRAIT: 
+        case AM_DISPLAY_ORIENTATION_PORTRAIT:
             return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
         case AM_DISPLAY_ORIENTATION_LANDSCAPE:
             return UIInterfaceOrientationMaskLandscapeRight | UIInterfaceOrientationMaskLandscapeLeft;
@@ -834,12 +834,12 @@ extern void am_ios_custom_init(UIViewController *view_controller);
 #endif
 
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
- 
+
     MTKView *view = [[MTKView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     view.device = MTLCreateSystemDefaultDevice();
     view.delegate = self;
     view.preferredFramesPerSecond = 60;
-    [view setMultipleTouchEnabled:YES]; 
+    [view setMultipleTouchEnabled:YES];
     ios_view = view;
     am_metal_ios_view = ios_view;
 
@@ -860,7 +860,7 @@ extern void am_ios_custom_init(UIViewController *view_controller);
 
     ios_init_engine();
     ios_init_audio();
- 
+
     am_ios_custom_init(viewController);
 
     return YES;
@@ -886,7 +886,7 @@ extern void am_ios_custom_init(UIViewController *view_controller);
     am_metal_window_sheight = (int)((float)am_metal_window_pheight / scale);
 
     @autoreleasepool {
-        //am_debug("%s", "draw"); 
+        //am_debug("%s", "draw");
         if (ios_done_first_draw) {
             // make sure we do a draw before our first update
             ios_update();
@@ -940,14 +940,14 @@ extern void am_ios_custom_init(UIViewController *view_controller);
 }
 
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
-{    
+{
     if (ios_view_controller != nil && ios_view_controller.presentedViewController == nil) {
         ios_touch_moved(touches);
     }
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
-{    
+{
     if (ios_view_controller != nil && ios_view_controller.presentedViewController == nil) {
         ios_touch_ended(touches);
     }
@@ -1008,7 +1008,7 @@ extern void am_ios_custom_init(UIViewController *view_controller);
     }
 }
 
-- (void)paymentQueue:(SKPaymentQueue *)queue 
+- (void)paymentQueue:(SKPaymentQueue *)queue
 restoreCompletedTransactionsFailedWithError:(NSError *)error
 {
     [self performSelectorOnMainThread:@selector(restoreCompletedTransactionsFailedWithErrorMain) withObject:nil waitUntilDone:YES];
@@ -1176,7 +1176,7 @@ void am_get_native_window_size(am_native_window *window, int *pw, int *ph, int *
     *sh = am_metal_window_sheight;
 }
 
-void am_get_native_window_safe_area_margin(am_native_window *window, 
+void am_get_native_window_safe_area_margin(am_native_window *window,
     int *left, int *right, int *bottom, int *top)
 {
     if (ios_view != nil && ios_view.window != nil) {
@@ -1209,6 +1209,13 @@ void am_set_native_window_show_cursor(am_native_window *window, bool show) {
 
 bool am_get_native_window_show_cursor(am_native_window *window) {
     return false;
+}
+
+const char* am_get_native_window_title(am_native_window *window) {
+    return NULL;
+}
+
+void am_set_native_window_title(am_native_window *window, const char* title) {
 }
 
 void am_destroy_native_window(am_native_window *window) {
@@ -1259,7 +1266,7 @@ int am_next_video_capture_frame() {
 
 static bool gamecenter_available = false;
 
-@interface GameCenterLeaderboardViewController : GKGameCenterViewController 
+@interface GameCenterLeaderboardViewController : GKGameCenterViewController
 @end
 
 @implementation GameCenterLeaderboardViewController
@@ -1352,9 +1359,9 @@ static int init_gamecenter(lua_State *L) {
                 //problem with authentication, probably because the user doesn't use Game Center
                 //am_debug("%s", "gamecenter authentication failed");
             }
-        })]; 
+        })];
     } else {
-        NSLog(@"Already authenticated!");   
+        NSLog(@"Already authenticated!");
     }
     gamecenter_delegate = [[GameCenterDelegate alloc] init];
     [gamecenter_delegate retain];
@@ -1559,7 +1566,7 @@ static void register_iap_product_mt(lua_State *L) {
                 am_new_userdata(L, am_iap_product)->product = product;
                 lua_settable(L, -3);
             }
-        } 
+        }
         am_call_amulet(L, "_iap_retrieve_products_finished", 1, 0);
     }
 }
@@ -1597,7 +1604,7 @@ static int retrieve_iap_products(lua_State *L) {
     }
     SKProductsRequest *productsRequest = [[SKProductsRequest alloc] initWithProductIdentifiers:ids];
     [ids dealloc];
-                     
+
     [productsRequest retain];
     productsRequest.delegate = [[RetrieveIAPProductsDelegate alloc] init];
     [productsRequest start];
@@ -1643,7 +1650,7 @@ static int iap_product_local_price(lua_State *L) {
 static int ios_request_review(lua_State *L) {
     if([SKStoreReviewController class]){
        [SKStoreReviewController requestReview] ;
-    } 
+    }
     return 0;
 }
 
@@ -1701,16 +1708,16 @@ static int show_alert(lua_State *L) {
 
 @implementation AMWebViewDelegate
 
-- (void)webView:(WKWebView *)webView 
-    didFailNavigation:(WKNavigation *)navigation 
+- (void)webView:(WKWebView *)webView
+    didFailNavigation:(WKNavigation *)navigation
     withError:(NSError *)error
 {
     //NSLog(@"------------------------ webkit navigation error");
     self.was_error = YES;
 }
 
-- (void)webView:(WKWebView *)webView 
-    didFailProvisionalNavigation:(WKNavigation *)navigation 
+- (void)webView:(WKWebView *)webView
+    didFailProvisionalNavigation:(WKNavigation *)navigation
     withError:(NSError *)error
 {
     //NSLog(@"------------------------ webkit navigation provisional error");

--- a/src/am_backend_sdl.cpp
+++ b/src/am_backend_sdl.cpp
@@ -237,7 +237,7 @@ void am_get_native_window_size(am_native_window *window, int *pw, int *ph, int *
 #endif
 }
 
-void am_get_native_window_safe_area_margin(am_native_window *window, 
+void am_get_native_window_safe_area_margin(am_native_window *window,
     int *left, int *right, int *bottom, int *top)
 {
     *left = 0;
@@ -334,6 +334,26 @@ void am_set_native_window_show_cursor(am_native_window *window, bool show) {
                 SDL_ShowCursor(show ? SDL_ENABLE : SDL_DISABLE);
             }
             return;
+        }
+    }
+}
+
+const char* am_get_native_window_title(am_native_window *window) {
+    for (unsigned int i = 0; i < windows.size(); i++) {
+        if (windows[i].window == (SDL_Window*)window) {
+            SDL_Window *sdl_win = (SDL_Window*)window;
+            return SDL_GetWindowTitle(sdl_win);
+        }
+    }
+    return NULL;
+}
+
+void am_set_native_window_title(am_native_window *window, const char* title) {
+    for (unsigned int i = 0; i < windows.size(); i++) {
+        if (windows[i].window == (SDL_Window*)window) {
+            SDL_Window *sdl_win = (SDL_Window*)window;
+            SDL_SetWindowTitle(sdl_win, title);
+            break;
         }
     }
 }
@@ -463,7 +483,7 @@ void am_copy_video_frame_to_texture() {
 }
 #endif
 
-#if defined(AM_WINDOWS) && !defined(AM_MINGW) 
+#if defined(AM_WINDOWS) && !defined(AM_MINGW)
 
 static char *from_wstr(const wchar_t *str) {
     int len8 = WideCharToMultiByte(CP_UTF8, 0, str, -1, NULL, 0, NULL, NULL);
@@ -643,7 +663,7 @@ restart:
         if (!handle_events(L)) goto quit;
 
         frame_time = am_get_current_time();
-        
+
         real_delta_time = frame_time - t0;
         if (have_focus && am_conf_warn_delta_time > 0.0 && real_delta_time > am_conf_warn_delta_time) {
             am_log0("WARNING: FPS dropped to %0.2f (%fs)", 1.0/real_delta_time, real_delta_time);

--- a/src/am_backend_sdl.cpp
+++ b/src/am_backend_sdl.cpp
@@ -237,7 +237,7 @@ void am_get_native_window_size(am_native_window *window, int *pw, int *ph, int *
 #endif
 }
 
-void am_get_native_window_safe_area_margin(am_native_window *window,
+void am_get_native_window_safe_area_margin(am_native_window *window, 
     int *left, int *right, int *bottom, int *top)
 {
     *left = 0;
@@ -483,7 +483,7 @@ void am_copy_video_frame_to_texture() {
 }
 #endif
 
-#if defined(AM_WINDOWS) && !defined(AM_MINGW)
+#if defined(AM_WINDOWS) && !defined(AM_MINGW) 
 
 static char *from_wstr(const wchar_t *str) {
     int len8 = WideCharToMultiByte(CP_UTF8, 0, str, -1, NULL, 0, NULL, NULL);
@@ -663,7 +663,7 @@ restart:
         if (!handle_events(L)) goto quit;
 
         frame_time = am_get_current_time();
-
+        
         real_delta_time = frame_time - t0;
         if (have_focus && am_conf_warn_delta_time > 0.0 && real_delta_time > am_conf_warn_delta_time) {
             am_log0("WARNING: FPS dropped to %0.2f (%fs)", 1.0/real_delta_time, real_delta_time);

--- a/src/am_window.cpp
+++ b/src/am_window.cpp
@@ -494,7 +494,7 @@ bool am_execute_actions(lua_State *L, double dt) {
     for (unsigned int i = 0; i < n; i++) {
         am_window *win = windows[i];
         if (!win->needs_closing && win->scene != NULL) {
-            // make sure window size properties are up-to-date before running 
+            // make sure window size properties are up-to-date before running
             // actions.
             update_size(win);
             if (!am_execute_node_actions(L, win->scene)) {
@@ -683,6 +683,19 @@ static void set_show_cursor(lua_State *L, void *obj) {
 
 static am_property show_cursor_property = {get_show_cursor, set_show_cursor};
 
+static void get_window_title(lua_State *L, void* obj) {
+    am_window *window = (am_window*)obj;
+    lua_pushstring(L, am_get_native_window_title(window->native_win));
+}
+
+static void set_window_title(lua_State *L, void* obj) {
+    am_window *window = (am_window*)obj;
+    const char* value = lua_tostring(L, 3);
+    am_set_native_window_title(window->native_win, value);
+}
+
+static am_property title_property = {get_window_title, set_window_title};
+
 static void get_window_mode(lua_State *L, void *obj) {
     am_window *window = (am_window*)obj;
     am_push_enum(L, am_window_mode, window->mode);
@@ -761,6 +774,7 @@ static void register_window_mt(lua_State *L) {
     am_register_property(L, "stencil_clear_value", &stencil_clear_value_property);
     am_register_property(L, "letterbox", &letterbox_property);
     am_register_property(L, "projection", &projection_property);
+    am_register_property(L, "title", &title_property);
 
     lua_pushcclosure(L, close_window, 0);
     lua_setfield(L, -2, "close");

--- a/src/am_window.cpp
+++ b/src/am_window.cpp
@@ -494,7 +494,7 @@ bool am_execute_actions(lua_State *L, double dt) {
     for (unsigned int i = 0; i < n; i++) {
         am_window *win = windows[i];
         if (!win->needs_closing && win->scene != NULL) {
-            // make sure window size properties are up-to-date before running
+            // make sure window size properties are up-to-date before running 
             // actions.
             update_size(win);
             if (!am_execute_node_actions(L, win->scene)) {


### PR DESCRIPTION
It's convenient (for me sometimes at least) to put debug information like fps or other things like currently selected entity in the window title, to avoid having to draw text to the screen.

Made this work in the way you would expect. 

I only tested on Mac Catalina, but I would expect if there aren't bugs in SDL it would be fine on other platforms supported by SDL. 