### PR TITLE
Add user-defined bindings setting to `am.postprocess`

### DIFF
--- a/doc/scene_nodes.md
+++ b/doc/scene_nodes.md
@@ -1194,6 +1194,7 @@ shader program.
 - `clear_color`: The color to clear the texture to before rendering each frame (a `vec4`). The default is black.
 - `auto_clear`: Whether to automatically clear the texture before rendering each frame. The default is true.
 - `program`: The shader program to use to render the texture.
+- `bindings`: An optional table of user bindings to pass into the `program`. The keys/values are added to the `am.bind(...)` node used internally.
 
 The shader program should expect the following uniforms and attributes:
 

--- a/lua/postprocess.lua
+++ b/lua/postprocess.lua
@@ -8,6 +8,7 @@
 --      clear_color
 --      auto_clear
 --      program
+--      bindings
 function am.postprocess(opts)
     local main_window = am._main_window
     local w, h
@@ -35,14 +36,19 @@ function am.postprocess(opts)
         auto_clear = false
     end
     local program = opts.program or am.shaders.texture2d
+    local user_bindings = opts.bindings or {}
+    local pp_bindings = {
+        P = mat4(1),
+        uv = am.rect_verts_2d(0, 0, 1, 1),
+        vert = am.rect_verts_2d(-1, -1, 1, 1),
+        tex = tex,
+    }
+    for k, v in pairs(user_bindings) do
+        pp_bindings[k] = v
+    end
     local node =
         am.use_program(program)
-        ^ am.bind{
-            P = mat4(1),
-            uv = am.rect_verts_2d(0, 0, 1, 1),
-            vert = am.rect_verts_2d(-1, -1, 1, 1),
-            tex = tex,
-        }
+        ^ am.bind(pp_bindings)
         ^ am.draw("triangles", am.rect_indices())
     local wrap = am.wrap(node)
     fb.projection = main_window.projection

--- a/lua/postprocess.lua
+++ b/lua/postprocess.lua
@@ -84,6 +84,13 @@ function am.postprocess(opts)
         program = p
         node"use_program".program = p
     end
+    function wrap:get_bindings()
+        return pp_bindings
+    end
+    function wrap:set_bindings(b)
+        pp_bindings = b
+        node"bind".bindings = b
+    end
     function wrap:clear()
         fb:clear()
     end


### PR DESCRIPTION
Despite using `am.bind` internally to run the user-provided program, `am.postprocess` does not have any way, as far as I can see, to initialize user-defined bindings nor update them later. To remedy this issue, I added a new, optional setting to `am.postprocess` for user-defined bindings, and also exposed an writeable `bindings` field for the postprocess node.